### PR TITLE
Fix/stale branch filter after delete

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -58,5 +58,8 @@ CLAUDE.md
 *.db-shm
 *.db-wal
 
+# vexp index data
+.vexp/**
+
 # Build scripts
 scripts/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-03-04
+
+### Fixed
+
+- Fixed "ambiguous argument" error in commit graph when a branch used as filter is deleted. The stale branch reference is now cleared and the graph falls back to showing all branches.
+
+## [0.5.2] - 2026-03-04
+
+### Fixed
+
+- Fixed `groupByDir` setting not persisting across webview reloads. The toggle state is now saved to and restored from `vscode.getState()`. (PR #13 by sivertillia)
+- Fixed `useCheckedFiles` overwriting all webview state keys on every update. State writes now merge with existing keys instead of replacing them.
+- Excluded `.vexp/` from VSIX packaging to prevent build failures caused by non-file entries (Unix sockets).
+
 ## [0.5.1] - 2026-03-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",
@@ -374,8 +374,7 @@
                     "command": "intelligit.fileRefresh",
                     "when": "webviewId == 'intelligit.commitPanel' && !intelligit.commitPanel.refreshing",
                     "group": "3_info@2"
-                }
-                ,
+                },
                 {
                     "command": "intelligit.commitFileCompareWithLocal",
                     "when": "(webviewId == 'intelligit.commitGraph' || webviewId == 'intelligit.commitFiles') && webviewSection == 'commitInfoFile'",

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -186,6 +186,12 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         const requestId = ++this.requestSeq;
         this.offset = 0;
         this.loadingMore = false;
+
+        if (this.currentBranch && !this.branches.some((b) => b.name === this.currentBranch)) {
+            this.currentBranch = null;
+            this.postToWebview({ type: "setSelectedBranch", branch: null });
+        }
+
         try {
             const commits = await this.gitOps.getLog(
                 this.PAGE_SIZE,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an error in the commit graph when a branch used as a filter is deleted: the stale branch reference is cleared and the graph falls back to showing all branches.

* **Chores**
  * Added a changelog entry for version 0.5.3 and updated project metadata (version bump).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->