### PR TITLE
Feature/double click on changed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2026-03-04
+
+### Fixed
+
+- Fixed commit graph Changed Files double-click behavior so file rows now open a commit-to-parent diff (`<parent> ↔ <commit>`) as expected.
+- Wired commit graph webview `openCommitFileDiff` events through the provider and extension host to reuse the same diff-opening path as the Commit Files view.
+
+### Tests
+
+- Added integration coverage for commit graph Changed Files double-click to assert `openCommitFileDiff` messaging and provider event forwarding.
+
 ## [0.5.3] - 2026-03-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -605,7 +605,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
         }),
         commitInfo.onOpenCommitFileDiff(async ({ commitHash, filePath }) => {
-            console.log("[IntelliGit] openCommitFileDiff event:", commitHash, filePath);
             try {
                 await openCommitFileDiff(commitHash, filePath);
             } catch (error) {
@@ -884,7 +883,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     const openCommitFileDiff = async (commitHash: string, filePath: string): Promise<void> => {
         const parents = await getCommitParentHashes(commitHash);
-        const parentRef = parents.length === 0 ? EMPTY_TREE_HASH : parents[0];
+
+        let parentRef: string;
+        let parentDisplayHash: string;
+        if (parents.length > 1) {
+            const result = await pickMainlineParent(commitHash, "Open Commit File Diff", parents);
+            if (result.kind === "cancelled") return;
+            if (result.kind === "notMerge") return;
+            parentRef = `${commitHash}^${result.parentNumber}`;
+            parentDisplayHash = parents[result.parentNumber - 1] ?? parentRef;
+        } else {
+            parentRef = parents.length === 0 ? EMPTY_TREE_HASH : parents[0];
+            parentDisplayHash = parentRef;
+        }
 
         let leftContent: string;
         try {
@@ -915,7 +926,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             content: rightContent,
             language,
         });
-        const shortParent = parentRef.slice(0, 8);
+        const shortParent = parentDisplayHash.slice(0, 8);
         const shortCommit = commitHash.slice(0, 8);
         const title = `${filePath} (${shortParent} ↔ ${shortCommit})`;
         await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, rightDoc.uri, title);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1141,6 +1141,87 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 await refreshAll();
                 return;
             }
+            case "pushAllUpToHere": {
+                if (!(await isCommitUnpushed(validatedHash))) {
+                    vscode.window.showErrorMessage(
+                        "Push All up to Here is available only for unpushed commits.",
+                    );
+                    return;
+                }
+
+                const checkedOutBranchName = await getCheckedOutBranchName();
+                if (!checkedOutBranchName) {
+                    vscode.window.showErrorMessage(
+                        "Push All up to Here is only available when a local branch is checked out.",
+                    );
+                    return;
+                }
+
+                try {
+                    await executor.run(["merge-base", "--is-ancestor", validatedHash, "HEAD"]);
+                } catch {
+                    vscode.window.showErrorMessage(
+                        `Commit ${short} is not in the current branch history.`,
+                    );
+                    return;
+                }
+
+                const currentBranch =
+                    currentBranches.find(
+                        (branch) => !branch.isRemote && branch.name === checkedOutBranchName,
+                    ) ?? {
+                        name: checkedOutBranchName,
+                        hash: "",
+                        isRemote: false,
+                        isCurrent: true,
+                        ahead: 0,
+                        behind: 0,
+                    };
+
+                let target = resolveTrackedRemoteBranch(currentBranch);
+                let setUpstream = false;
+                if (!target) {
+                    const remote = await resolveRemoteName(currentBranch);
+                    if (!remote) {
+                        vscode.window.showErrorMessage(
+                            `No remote configured for branch ${currentBranch.name}.`,
+                        );
+                        return;
+                    }
+
+                    const setUpstreamConfirm = await vscode.window.showWarningMessage(
+                        `Branch '${currentBranch.name}' has no upstream. Set upstream to '${remote}/${currentBranch.name}' and push commits up to ${short}?`,
+                        { modal: true },
+                        "Set Upstream and Push",
+                    );
+                    if (setUpstreamConfirm !== "Set Upstream and Push") return;
+
+                    target = { remote, remoteBranch: currentBranch.name };
+                    setUpstream = true;
+                }
+
+                const confirm = await vscode.window.showWarningMessage(
+                    `Push all commits up to ${short} to ${target.remote}/${target.remoteBranch}?`,
+                    { modal: true },
+                    "Push",
+                );
+                if (confirm !== "Push") return;
+
+                await runWithNotificationProgress(`Pushing commits up to ${short}...`, async () => {
+                    const destinationRef = `refs/heads/${target.remoteBranch}`;
+                    const refspec = `${validatedHash}:${destinationRef}`;
+                    await executor.run([
+                        "push",
+                        ...(setUpstream ? ["-u"] : []),
+                        target.remote,
+                        refspec,
+                    ]);
+                });
+
+                vscode.window.showInformationMessage(`Pushed commits up to ${short}.`);
+                await refreshAll();
+                return;
+            }
             case "newBranch": {
                 const branchName = await vscode.window.showInputBox({
                     prompt: `New branch from ${short}`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
         const config = getIntelliGitConfig();
         if (config && typeof config.update === "function") {
-            await config.update("jetbrainsMergeTool.path", trimmed, vscode.ConfigurationTarget.Global);
+            await config.update(
+                "jetbrainsMergeTool.path",
+                trimmed,
+                vscode.ConfigurationTarget.Global,
+            );
         }
 
         const resolutionText =
@@ -246,9 +250,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
         }
 
-        throw (lastReadError instanceof Error
+        throw lastReadError instanceof Error
             ? lastReadError
-            : new Error("Failed to read merged file after external merge tool closed."));
+            : new Error("Failed to read merged file after external merge tool closed.");
     };
 
     const openJetBrainsMergeToolForFile = async (filePath: string): Promise<boolean> => {
@@ -272,7 +276,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         try {
             const versions = await gitOps.getConflictFileVersions(filePath);
             const outputFileFsPath = path.join(repoRoot, filePath);
-            const beforeMergeText = await fs.promises.readFile(outputFileFsPath, "utf8").catch(() => null);
+            const beforeMergeText = await fs.promises
+                .readFile(outputFileFsPath, "utf8")
+                .catch(() => null);
 
             await runWithNotificationProgress(
                 `Opening JetBrains merge tool for ${filePath}...`,
@@ -382,7 +388,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             .flatMap((group) => group.tabs)
             .find((tab) => {
                 const input = tab.input;
-                return input instanceof vscode.TabInputText && input.uri.toString() === uri.toString();
+                return (
+                    input instanceof vscode.TabInputText && input.uri.toString() === uri.toString()
+                );
             });
         if (!matchingTab) return;
         try {
@@ -583,6 +591,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 const message = getErrorMessage(error);
                 console.error(`Commit action '${action}' failed:`, error);
                 vscode.window.showErrorMessage(`Commit action failed: ${message}`);
+            }
+        }),
+    );
+
+    context.subscriptions.push(
+        commitGraph.onOpenCommitFileDiff(async ({ commitHash, filePath }) => {
+            try {
+                await openCommitFileDiff(commitHash, filePath);
+            } catch (error) {
+                const message = getErrorMessage(error);
+                vscode.window.showErrorMessage(`Failed to open commit diff: ${message}`);
+            }
+        }),
+        commitInfo.onOpenCommitFileDiff(async ({ commitHash, filePath }) => {
+            console.log("[IntelliGit] openCommitFileDiff event:", commitHash, filePath);
+            try {
+                await openCommitFileDiff(commitHash, filePath);
+            } catch (error) {
+                const message = getErrorMessage(error);
+                vscode.window.showErrorMessage(`Failed to open commit diff: ${message}`);
             }
         }),
     );
@@ -793,7 +821,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         actionLabel: string,
         knownParents?: string[],
     ): Promise<MainlineParentPickResult> => {
-        const parents = knownParents ?? await getCommitParentHashes(hash);
+        const parents = knownParents ?? (await getCommitParentHashes(hash));
         if (parents.length <= 1) return { kind: "notMerge" };
 
         const pick = await vscode.window.showQuickPick(
@@ -852,6 +880,46 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             "--",
             filePath,
         ]);
+    };
+
+    const openCommitFileDiff = async (commitHash: string, filePath: string): Promise<void> => {
+        const parents = await getCommitParentHashes(commitHash);
+        const parentRef = parents.length === 0 ? EMPTY_TREE_HASH : parents[0];
+
+        let leftContent: string;
+        try {
+            leftContent = await gitOps.getFileContentAtRef(filePath, parentRef);
+        } catch {
+            leftContent = "";
+        }
+
+        let rightContent: string;
+        try {
+            rightContent = await gitOps.getFileContentAtRef(filePath, commitHash);
+        } catch {
+            rightContent = "";
+        }
+
+        // Detect language from the working tree file if it exists on disk.
+        let language: string | undefined;
+        const diskPath = path.join(repoRoot, filePath);
+        try {
+            const diskDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(diskPath));
+            language = diskDoc.languageId;
+        } catch {
+            // File may not exist on disk (deleted or only in history).
+        }
+
+        const leftDoc = await vscode.workspace.openTextDocument({ content: leftContent, language });
+        const rightDoc = await vscode.workspace.openTextDocument({
+            content: rightContent,
+            language,
+        });
+        const shortParent = parentRef.slice(0, 8);
+        const shortCommit = commitHash.slice(0, 8);
+        const title = `${filePath} (${shortParent} ↔ ${shortCommit})`;
+        await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, rightDoc.uri, title);
+        await closeTemporaryDiffSourceTab(leftDoc.uri);
     };
 
     const applyPatchTextToRepo = async (patchText: string, reverse: boolean): Promise<void> => {
@@ -1251,7 +1319,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
 
     const isFilePathContext = (value: unknown): value is { filePath: string } => {
-        return !!value && typeof value === "object" && "filePath" in value && typeof value.filePath === "string";
+        return (
+            !!value &&
+            typeof value === "object" &&
+            "filePath" in value &&
+            typeof value.filePath === "string"
+        );
     };
 
     const resolveConflictPath = (ctx: unknown): string | null =>
@@ -1655,15 +1728,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // --- Commit panel file context menu commands ---
 
     context.subscriptions.push(
-        vscode.commands.registerCommand("intelligit.commitFileCompareWithLocal", async (ctx: unknown) => {
-            await compareCommitInfoFileWithLocal(ctx);
-        }),
-        vscode.commands.registerCommand("intelligit.commitFileCherryPickChange", async (ctx: unknown) => {
-            await applySelectedCommitFileChange(ctx, "cherry-pick");
-        }),
-        vscode.commands.registerCommand("intelligit.commitFileRevertChange", async (ctx: unknown) => {
-            await applySelectedCommitFileChange(ctx, "revert");
-        }),
+        vscode.commands.registerCommand(
+            "intelligit.commitFileCompareWithLocal",
+            async (ctx: unknown) => {
+                await compareCommitInfoFileWithLocal(ctx);
+            },
+        ),
+        vscode.commands.registerCommand(
+            "intelligit.commitFileCherryPickChange",
+            async (ctx: unknown) => {
+                await applySelectedCommitFileChange(ctx, "cherry-pick");
+            },
+        ),
+        vscode.commands.registerCommand(
+            "intelligit.commitFileRevertChange",
+            async (ctx: unknown) => {
+                await applySelectedCommitFileChange(ctx, "revert");
+            },
+        ),
         vscode.commands.registerCommand(
             "intelligit.fileRollback",
             async (ctx: { filePath?: string }) => {

--- a/src/mergeEditor/conflictParser.ts
+++ b/src/mergeEditor/conflictParser.ts
@@ -323,7 +323,7 @@ function collectOverlappingEdits(
             edits.push(edit);
         }
     }
-    edits.sort((a, b) => (a.baseStart - b.baseStart) || (a.modStart - b.modStart));
+    edits.sort((a, b) => a.baseStart - b.baseStart || a.modStart - b.modStart);
     return edits;
 }
 

--- a/src/utils/jetbrainsMergeTool.ts
+++ b/src/utils/jetbrainsMergeTool.ts
@@ -357,7 +357,11 @@ async function detectWindowsJetBrainsExecutableCandidates(): Promise<DetectedJet
     if (localAppData) addRoot(path.join(localAppData, "JetBrains", "Toolbox", "apps"), 6, 5000);
     if (appData) addRoot(path.join(appData, "JetBrains", "Toolbox", "apps"), 6, 5000);
     if (userProfile) {
-        addRoot(path.join(userProfile, "AppData", "Local", "JetBrains", "Toolbox", "apps"), 6, 5000);
+        addRoot(
+            path.join(userProfile, "AppData", "Local", "JetBrains", "Toolbox", "apps"),
+            6,
+            5000,
+        );
     }
 
     const all = (

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -8,6 +8,7 @@ import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
 import type {
     BranchAction,
     CommitAction,
+    CommitGraphOutbound,
     CommitGraphInbound,
 } from "../webviews/react/commitGraphTypes";
 import { IconThemeService } from "./shared";
@@ -89,7 +90,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
 
         webviewView.webview.html = this.getHtml(webviewView.webview);
 
-        webviewView.webview.onDidReceiveMessage(async (msg) => {
+        webviewView.webview.onDidReceiveMessage(async (msg: CommitGraphOutbound) => {
             try {
                 switch (msg.type) {
                     case "ready":

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -50,6 +50,12 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     }>();
     readonly onCommitAction = this._onCommitAction.event;
 
+    private readonly _onOpenCommitFileDiff = new vscode.EventEmitter<{
+        commitHash: string;
+        filePath: string;
+    }>();
+    readonly onOpenCommitFileDiff = this._onOpenCommitFileDiff.event;
+
     constructor(
         private readonly extensionUri: vscode.Uri,
         private readonly gitOps: GitOps,
@@ -118,6 +124,12 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
                         this._onCommitAction.fire({
                             action: msg.action,
                             hash: msg.hash,
+                        });
+                        break;
+                    case "openCommitFileDiff":
+                        this._onOpenCommitFileDiff.fire({
+                            commitHash: msg.commitHash,
+                            filePath: msg.filePath,
                         });
                         break;
                 }
@@ -296,6 +308,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this._onBranchFilterChanged.dispose();
         this._onBranchAction.dispose();
         this._onCommitAction.dispose();
+        this._onOpenCommitFileDiff.dispose();
     }
 
     private refreshThemeDataWithErrorHandling(): void {

--- a/src/views/CommitInfoViewProvider.ts
+++ b/src/views/CommitInfoViewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import type { CommitDetail, ThemeFolderIconMap } from "../types";
-import type { CommitInfoInbound } from "../webviews/react/commitInfoTypes";
+import type { CommitInfoInbound, CommitInfoOutbound } from "../webviews/react/commitInfoTypes";
 import { IconThemeService } from "./shared";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
@@ -14,6 +14,11 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
     private folderIconsByName: ThemeFolderIconMap = {};
     private requestSeq = 0;
     private readonly iconTheme: IconThemeService;
+    private readonly _onOpenCommitFileDiff = new vscode.EventEmitter<{
+        commitHash: string;
+        filePath: string;
+    }>();
+    readonly onOpenCommitFileDiff = this._onOpenCommitFileDiff.event;
 
     constructor(private readonly extensionUri: vscode.Uri) {
         this.iconTheme = new IconThemeService(this.extensionUri);
@@ -34,15 +39,28 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         };
         this.iconTheme.attachWebview(webviewView.webview);
 
-        webviewView.webview.onDidReceiveMessage(async (msg) => {
-            if (msg?.type === "ready") {
-                try {
-                    await this.iconTheme.initIconThemeData();
-                } catch (err) {
-                    console.error("[IntelliGit] Failed to initialize icon theme data:", err);
-                }
-                this.ready = true;
-                this.postCurrentState();
+        webviewView.webview.onDidReceiveMessage(async (msg: CommitInfoOutbound) => {
+            switch (msg.type) {
+                case "ready":
+                    try {
+                        await this.iconTheme.initIconThemeData();
+                    } catch (err) {
+                        console.error("[IntelliGit] Failed to initialize icon theme data:", err);
+                    }
+                    this.ready = true;
+                    this.postCurrentState();
+                    break;
+                case "openCommitFileDiff":
+                    console.log(
+                        "[IntelliGit] Received openCommitFileDiff:",
+                        msg.commitHash,
+                        msg.filePath,
+                    );
+                    this._onOpenCommitFileDiff.fire({
+                        commitHash: msg.commitHash,
+                        filePath: msg.filePath,
+                    });
+                    break;
             }
         });
 
@@ -111,5 +129,6 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
 
     dispose(): void {
         this.iconTheme.dispose();
+        this._onOpenCommitFileDiff.dispose();
     }
 }

--- a/src/views/CommitInfoViewProvider.ts
+++ b/src/views/CommitInfoViewProvider.ts
@@ -51,11 +51,6 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
                     this.postCurrentState();
                     break;
                 case "openCommitFileDiff":
-                    console.log(
-                        "[IntelliGit] Received openCommitFileDiff:",
-                        msg.commitHash,
-                        msg.filePath,
-                    );
                     this._onOpenCommitFileDiff.fire({
                         commitHash: msg.commitHash,
                         filePath: msg.filePath,

--- a/src/views/MergeEditorPanel.ts
+++ b/src/views/MergeEditorPanel.ts
@@ -190,7 +190,10 @@ export class MergeEditorPanel {
         });
     }
 
-    private async detectTextFormatForOutput(): Promise<{ eol: "\n" | "\r\n"; hasTrailingNewline: boolean }> {
+    private async detectTextFormatForOutput(): Promise<{
+        eol: "\n" | "\r\n";
+        hasTrailingNewline: boolean;
+    }> {
         const fileUri = vscode.Uri.joinPath(this.workspaceRoot, this.filePath);
         const bytes = await vscode.workspace.fs.readFile(fileUri);
         const text = Buffer.from(bytes).toString("utf8");
@@ -198,7 +201,10 @@ export class MergeEditorPanel {
     }
 }
 
-function detectTextFormatFromText(text: string): { eol: "\n" | "\r\n"; hasTrailingNewline: boolean } {
+function detectTextFormatFromText(text: string): {
+    eol: "\n" | "\r\n";
+    hasTrailingNewline: boolean;
+} {
     const newlineIdx = text.indexOf("\n");
     const eol: "\n" | "\r\n" =
         newlineIdx > 0 && text.charAt(newlineIdx - 1) === "\r" ? "\r\n" : "\n";

--- a/src/webviews/react/CommitGraphApp.tsx
+++ b/src/webviews/react/CommitGraphApp.tsx
@@ -247,6 +247,10 @@ function App(): React.ReactElement {
         vscode.postMessage({ type: "commitAction", action, hash });
     }, []);
 
+    const handleOpenDiff = useCallback((commitHash: string, filePath: string) => {
+        vscode.postMessage({ type: "openCommitFileDiff", commitHash, filePath });
+    }, []);
+
     return (
         <>
             <ThemeIconFontFaces fonts={iconFonts} />
@@ -314,6 +318,7 @@ function App(): React.ReactElement {
                             folderIcon={commitFolderIcon}
                             folderExpandedIcon={commitFolderExpandedIcon}
                             folderIconsByName={commitFolderIconsByName}
+                            onOpenDiff={handleOpenDiff}
                         />
                     </div>
                 </div>

--- a/src/webviews/react/CommitInfoApp.tsx
+++ b/src/webviews/react/CommitInfoApp.tsx
@@ -53,7 +53,6 @@ function App(): React.ReactElement {
     }, []);
 
     const handleOpenDiff = useCallback((commitHash: string, filePath: string) => {
-        console.log("[CommitInfo] postMessage openCommitFileDiff", commitHash, filePath);
         vscode.postMessage({ type: "openCommitFileDiff", commitHash, filePath });
     }, []);
 

--- a/src/webviews/react/CommitInfoApp.tsx
+++ b/src/webviews/react/CommitInfoApp.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 import type { CommitDetail, ThemeFolderIconMap, ThemeIconFont, ThemeTreeIcon } from "../../types";
@@ -52,6 +52,11 @@ function App(): React.ReactElement {
         return () => window.removeEventListener("message", handler);
     }, []);
 
+    const handleOpenDiff = useCallback((commitHash: string, filePath: string) => {
+        console.log("[CommitInfo] postMessage openCommitFileDiff", commitHash, filePath);
+        vscode.postMessage({ type: "openCommitFileDiff", commitHash, filePath });
+    }, []);
+
     return (
         <>
             <ThemeIconFontFaces fonts={iconFonts} />
@@ -60,6 +65,7 @@ function App(): React.ReactElement {
                 folderIcon={folderIcon}
                 folderExpandedIcon={folderExpandedIcon}
                 folderIconsByName={folderIconsByName}
+                onOpenDiff={handleOpenDiff}
             />
         </>
     );

--- a/src/webviews/react/commit-info/CommitInfoPane.tsx
+++ b/src/webviews/react/commit-info/CommitInfoPane.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SYSTEM_FONT_STACK } from "../../../utils/constants";
 import { Box, Flex } from "@chakra-ui/react";
 import type { CommitDetail, CommitFile, ThemeFolderIconMap, ThemeTreeIcon } from "../../../types";
@@ -61,11 +61,13 @@ export function CommitInfoPane({
     folderIcon,
     folderExpandedIcon,
     folderIconsByName,
+    onOpenDiff,
 }: {
     detail: CommitDetail | null;
     folderIcon?: ThemeTreeIcon;
     folderExpandedIcon?: ThemeTreeIcon;
     folderIconsByName?: ThemeFolderIconMap;
+    onOpenDiff?: (commitHash: string, filePath: string) => void;
 }): React.ReactElement {
     const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
     const [filesCollapsed, setFilesCollapsed] = useState(false);
@@ -152,6 +154,7 @@ export function CommitInfoPane({
                                 return next;
                             })
                         }
+                        onOpenDiff={onOpenDiff}
                     />
                 </Box>
             )}
@@ -310,6 +313,7 @@ function TreeRows({
     folderExpandedIcon,
     folderIconsByName,
     onToggleDir,
+    onOpenDiff,
 }: {
     entries: TreeEntry[];
     depth: number;
@@ -320,6 +324,7 @@ function TreeRows({
     folderExpandedIcon?: ThemeTreeIcon;
     folderIconsByName?: ThemeFolderIconMap;
     onToggleDir: (path: string) => void;
+    onOpenDiff?: (commitHash: string, filePath: string) => void;
 }): React.ReactElement {
     return (
         <>
@@ -332,6 +337,7 @@ function TreeRows({
                             depth={depth}
                             commitHash={commitHash}
                             commitShortHash={commitShortHash}
+                            onOpenDiff={onOpenDiff}
                         />
                     );
                 }
@@ -360,6 +366,7 @@ function TreeRows({
                                 folderExpandedIcon={folderExpandedIcon}
                                 folderIconsByName={folderIconsByName}
                                 onToggleDir={onToggleDir}
+                                onOpenDiff={onOpenDiff}
                             />
                         )}
                     </React.Fragment>
@@ -441,14 +448,39 @@ const CommitFileRow = React.memo(function CommitFileRow({
     depth,
     commitHash,
     commitShortHash,
+    onOpenDiff,
 }: {
     file: CommitFile;
     depth: number;
     commitHash: string;
     commitShortHash: string;
+    onOpenDiff?: (commitHash: string, filePath: string) => void;
 }): React.ReactElement {
     const padLeft = INFO_INDENT_BASE + depth * INFO_INDENT_STEP;
     const fileName = getLeafName(file.path);
+    const rowRef = useRef<HTMLDivElement>(null);
+
+    const openDiff = useCallback(() => {
+        onOpenDiff?.(commitHash, file.path);
+    }, [onOpenDiff, commitHash, file.path]);
+
+    useEffect(() => {
+        const el = rowRef.current;
+        if (!el) return;
+        const handleDblClick = () => openDiff();
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Enter") {
+                e.preventDefault();
+                openDiff();
+            }
+        };
+        el.addEventListener("dblclick", handleDblClick);
+        el.addEventListener("keydown", handleKeyDown);
+        return () => {
+            el.removeEventListener("dblclick", handleDblClick);
+            el.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [openDiff]);
 
     const vscodeContext = useMemo(
         () =>
@@ -464,6 +496,7 @@ const CommitFileRow = React.memo(function CommitFileRow({
 
     return (
         <Flex
+            ref={rowRef}
             align="center"
             gap="4px"
             pl={`${padLeft}px`}
@@ -471,8 +504,9 @@ const CommitFileRow = React.memo(function CommitFileRow({
             lineHeight="22px"
             fontSize="13px"
             fontFamily={SYSTEM_FONT_STACK}
-            cursor="default"
+            cursor="pointer"
             position="relative"
+            tabIndex={0}
             _hover={{ bg: "var(--vscode-list-hoverBackground)" }}
             data-vscode-context={vscodeContext}
             title={file.path}

--- a/src/webviews/react/commit-list/commitMenu.tsx
+++ b/src/webviews/react/commit-list/commitMenu.tsx
@@ -27,6 +27,12 @@ export function getCommitMenuItems(commit: Commit, isUnpushed: boolean): CommitM
     });
     items.push({ label: "Revert Commit", action: "revertCommit" });
     items.push({
+        label: "Push All up to Here...",
+        action: "pushAllUpToHere",
+        disabled: isPushed,
+        icon: iconPush(),
+    });
+    items.push({
         label: "Undo Commit...",
         action: "undoCommit",
         disabled: isPushed || isMergeCommit,
@@ -95,6 +101,17 @@ function iconReset(): React.ReactElement {
             <path
                 fill="currentColor"
                 d="M8 2a6 6 0 1 1-4.8 2.4L1 6.6V2h4.6L4 3.6A5 5 0 1 0 8 3v-1z"
+            />
+        </svg>
+    );
+}
+
+function iconPush(): React.ReactElement {
+    return (
+        <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden>
+            <path
+                fill="currentColor"
+                d="M8 1l3 3H9v5H7V4H5l3-3zm-4 9h8a2 2 0 0 1 2 2v3h-1v-3a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v3H2v-3a2 2 0 0 1 2-2z"
             />
         </svg>
     );

--- a/src/webviews/react/commitGraphTypes.ts
+++ b/src/webviews/react/commitGraphTypes.ts
@@ -56,7 +56,8 @@ export type CommitGraphOutbound =
     | { type: "loadMore" }
     | { type: "filterBranch"; branch: string | null }
     | { type: "branchAction"; action: BranchAction; branchName: string }
-    | { type: "commitAction"; action: CommitAction; hash: string };
+    | { type: "commitAction"; action: CommitAction; hash: string }
+    | { type: "openCommitFileDiff"; commitHash: string; filePath: string };
 
 /** Messages sent FROM the extension host TO the webview. */
 export type CommitGraphInbound =

--- a/src/webviews/react/commitGraphTypes.ts
+++ b/src/webviews/react/commitGraphTypes.ts
@@ -29,6 +29,7 @@ export const COMMIT_ACTION_VALUES = [
     "checkoutRevision",
     "resetCurrentToHere",
     "revertCommit",
+    "pushAllUpToHere",
     "undoCommit",
     "editCommitMessage",
     "dropCommit",

--- a/src/webviews/react/commitInfoTypes.ts
+++ b/src/webviews/react/commitInfoTypes.ts
@@ -4,7 +4,9 @@
 import type { CommitDetail, ThemeFolderIconMap, ThemeIconFont, ThemeTreeIcon } from "../../types";
 
 /** Messages sent FROM the webview TO the extension host. */
-export type CommitInfoOutbound = { type: "ready" };
+export type CommitInfoOutbound =
+    | { type: "ready" }
+    | { type: "openCommitFileDiff"; commitHash: string; filePath: string };
 
 /** Messages sent FROM the extension host TO the webview. */
 export type CommitInfoInbound =

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -76,7 +76,10 @@ function getResultLines(
     }
 }
 
-function buildResultContent(data: MergeEditorData, resolutions: Record<number, HunkResolution>): string {
+function buildResultContent(
+    data: MergeEditorData,
+    resolutions: Record<number, HunkResolution>,
+): string {
     const { segments } = data;
     const lines: string[] = [];
     for (const seg of segments) {

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -851,6 +851,60 @@ describe("extension integration", () => {
         );
     });
 
+    it("prompts merge parent selection before opening commit file diff", async () => {
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        showQuickPick.mockResolvedValueOnce({ parentNumber: 2 });
+        openTextDocument.mockImplementation(async (arg: unknown) => {
+            if (arg && typeof arg === "object" && "content" in (arg as Record<string, unknown>)) {
+                const contentDoc = arg as { content: string };
+                return {
+                    uri: {
+                        toString: () => `untitled:${contentDoc.content}`,
+                    },
+                    languageId: "typescript",
+                };
+            }
+            return {
+                uri: {
+                    toString: () => JSON.stringify(arg),
+                },
+                languageId: "typescript",
+            };
+        });
+
+        await activate(context);
+
+        executeCommandFallback.mockClear();
+        latestCommitGraphProvider!.emitOpenCommitFileDiff({
+            commitHash: "deadbee",
+            filePath: "src/feature.ts",
+        });
+        await waitForAsync();
+
+        expect(showQuickPick).toHaveBeenCalled();
+        expect(gitOpsState.getFileContentAtRef).toHaveBeenNthCalledWith(
+            1,
+            "src/feature.ts",
+            "deadbee^2",
+        );
+        expect(gitOpsState.getFileContentAtRef).toHaveBeenNthCalledWith(
+            2,
+            "src/feature.ts",
+            "deadbee",
+        );
+        expect(executeCommandFallback).toHaveBeenCalledWith(
+            "vscode.diff",
+            expect.anything(),
+            expect.anything(),
+            "src/feature.ts (parent2 ↔ deadbee)",
+        );
+    });
+
     it("covers activation guards and debounced refresh sources", async () => {
         const { activate, deactivate } = await import("../../src/extension");
         const context = {

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -128,6 +128,7 @@ const gitOpsState = {
         files: [],
     })),
     getUnpushedCommitHashes: vi.fn(async () => ["a1b2c3d4", "feed1234", "deadbee"]),
+    getFileContentAtRef: vi.fn(async (_filePath: string, ref: string) => `content:${ref}`),
     rollbackFiles: vi.fn(async () => undefined),
     shelveSave: vi.fn(async () => "saved"),
     getFileHistory: vi.fn(async () => "history"),
@@ -159,6 +160,10 @@ class MockCommitGraphViewProvider {
         action: string;
         hash: string;
     }>();
+    private openCommitFileDiffEmitter = new MockEventEmitter<{
+        commitHash: string;
+        filePath: string;
+    }>();
 
     constructor(_uri: unknown, _gitOps: unknown) {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -168,6 +173,7 @@ class MockCommitGraphViewProvider {
     onBranchFilterChanged = this.branchFilterEmitter.event;
     onBranchAction = this.branchActionEmitter.event;
     onCommitAction = this.commitActionEmitter.event;
+    onOpenCommitFileDiff = this.openCommitFileDiffEmitter.event;
     setBranches = vi.fn();
     refresh = vi.fn(async () => undefined);
     filterByBranch = vi.fn(async () => undefined);
@@ -187,12 +193,20 @@ class MockCommitGraphViewProvider {
     emitCommitAction(payload: { action: string; hash: string }): void {
         this.commitActionEmitter.fire(payload);
     }
+    emitOpenCommitFileDiff(payload: { commitHash: string; filePath: string }): void {
+        this.openCommitFileDiffEmitter.fire(payload);
+    }
 }
 
 class MockCommitInfoViewProvider {
     static readonly viewType = "intelligit.commitFiles";
+    private openCommitFileDiffEmitter = new MockEventEmitter<{
+        commitHash: string;
+        filePath: string;
+    }>();
     setCommitDetail = vi.fn();
     clear = vi.fn();
+    onOpenCommitFileDiff = this.openCommitFileDiffEmitter.event;
     dispose = vi.fn();
 }
 
@@ -342,6 +356,7 @@ vi.mock("../../src/git/operations", async (importOriginal) => {
             getBranches = gitOpsState.getBranches;
             getCommitDetail = gitOpsState.getCommitDetail;
             getUnpushedCommitHashes = gitOpsState.getUnpushedCommitHashes;
+            getFileContentAtRef = gitOpsState.getFileContentAtRef;
             rollbackFiles = gitOpsState.rollbackFiles;
             shelveSave = gitOpsState.shelveSave;
             getFileHistory = gitOpsState.getFileHistory;
@@ -441,6 +456,9 @@ describe("extension integration", () => {
             files: [],
         }));
         gitOpsState.getUnpushedCommitHashes.mockResolvedValue(["a1b2c3d4", "feed1234", "deadbee"]);
+        gitOpsState.getFileContentAtRef.mockImplementation(
+            async (_filePath: string, ref: string) => `content:${ref}`,
+        );
         gitOpsState.rollbackFiles.mockResolvedValue(undefined);
         gitOpsState.shelveSave.mockResolvedValue("saved");
         gitOpsState.getFileHistory.mockResolvedValue("history");
@@ -778,6 +796,58 @@ describe("extension integration", () => {
         );
         expect(showErrorMessage).not.toHaveBeenCalledWith(
             "Invalid commit hash received for commit action.",
+        );
+    });
+
+    it("opens commit diff when commit graph requests file diff", async () => {
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        openTextDocument.mockImplementation(async (arg: unknown) => {
+            if (arg && typeof arg === "object" && "content" in (arg as Record<string, unknown>)) {
+                const contentDoc = arg as { content: string };
+                return {
+                    uri: {
+                        toString: () => `untitled:${contentDoc.content}`,
+                    },
+                    languageId: "typescript",
+                };
+            }
+            return {
+                uri: {
+                    toString: () => JSON.stringify(arg),
+                },
+                languageId: "typescript",
+            };
+        });
+
+        await activate(context);
+
+        executeCommandFallback.mockClear();
+        latestCommitGraphProvider!.emitOpenCommitFileDiff({
+            commitHash: "a1b2c3d4",
+            filePath: "src/feature.ts",
+        });
+        await waitForAsync();
+
+        expect(gitOpsState.getFileContentAtRef).toHaveBeenNthCalledWith(
+            1,
+            "src/feature.ts",
+            "parent1",
+        );
+        expect(gitOpsState.getFileContentAtRef).toHaveBeenNthCalledWith(
+            2,
+            "src/feature.ts",
+            "a1b2c3d4",
+        );
+        expect(executeCommandFallback).toHaveBeenCalledWith(
+            "vscode.diff",
+            expect.anything(),
+            expect.anything(),
+            "src/feature.ts (parent1 ↔ a1b2c3d4)",
         );
     });
 

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -799,6 +799,63 @@ describe("extension integration", () => {
         );
     });
 
+    it("pushes commits up to selected revision from commit context action", async () => {
+        const { activate } = await import("../../src/extension");
+        gitOpsState.getBranches.mockResolvedValueOnce([
+            {
+                name: "main",
+                hash: "feed1234",
+                isRemote: false,
+                isCurrent: true,
+                upstream: "origin/main",
+                remote: "origin",
+                ahead: 2,
+                behind: 0,
+            },
+            {
+                name: "origin/main",
+                hash: "feed1234",
+                isRemote: true,
+                isCurrent: false,
+                remote: "origin",
+                ahead: 0,
+                behind: 0,
+            },
+        ]);
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        await activate(context);
+
+        latestCommitGraphProvider!.emitCommitAction({
+            action: "pushAllUpToHere",
+            hash: "a1b2c3d4",
+        });
+        await waitForAsync();
+
+        expect(executorRun).toHaveBeenCalledWith([
+            "merge-base",
+            "--is-ancestor",
+            "a1b2c3d4",
+            "HEAD",
+        ]);
+        expect(executorRun).toHaveBeenCalledWith([
+            "push",
+            "origin",
+            "a1b2c3d4:refs/heads/main",
+        ]);
+        expect(withProgress).toHaveBeenCalledWith(
+            expect.objectContaining({
+                location: 15,
+                title: expect.stringContaining("Pushing commits up to a1b2c3d4"),
+            }),
+            expect.any(Function),
+        );
+        expect(showInformationMessage).toHaveBeenCalledWith("Pushed commits up to a1b2c3d4.");
+    });
+
     it("opens commit diff when commit graph requests file diff", async () => {
         const { activate } = await import("../../src/extension");
         const context = {
@@ -1016,6 +1073,9 @@ describe("extension integration", () => {
         await emitCommitAction({ action: "newTag", hash: "a1b2c3d4" });
 
         gitOpsState.getUnpushedCommitHashes.mockResolvedValueOnce([]);
+        await emitCommitAction({ action: "pushAllUpToHere", hash: "a1b2c3d4" });
+
+        gitOpsState.getUnpushedCommitHashes.mockResolvedValueOnce([]);
         await emitCommitAction({ action: "undoCommit", hash: "a1b2c3d4" });
         gitOpsState.getUnpushedCommitHashes.mockResolvedValueOnce(["deadbee"]);
         await emitCommitAction({ action: "undoCommit", hash: "deadbee" });
@@ -1045,6 +1105,9 @@ describe("extension integration", () => {
         );
         expect(showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining("Invalid tag name '-bad-tag-name'"),
+        );
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            "Push All up to Here is available only for unpushed commits.",
         );
         expect(showErrorMessage).toHaveBeenCalledWith(
             "Undo Commit is available only for unpushed commits.",

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -275,11 +275,13 @@ describe("view providers integration", () => {
         const branchFilter = vi.fn();
         const branchAction = vi.fn();
         const commitAction = vi.fn();
+        const openCommitFileDiff = vi.fn();
 
         provider.onCommitSelected(selected);
         provider.onBranchFilterChanged(branchFilter);
         provider.onBranchAction(branchAction);
         provider.onCommitAction(commitAction);
+        provider.onOpenCommitFileDiff(openCommitFileDiff);
 
         provider.resolveWebviewView(
             webview.view as unknown as object,
@@ -316,6 +318,16 @@ describe("view providers integration", () => {
         expect(commitAction).toHaveBeenCalledWith({
             action: "copyRevision",
             hash: "abc1234",
+        });
+
+        await webview.send({
+            type: "openCommitFileDiff",
+            commitHash: "abc1234",
+            filePath: "src/file.ts",
+        });
+        expect(openCommitFileDiff).toHaveBeenCalledWith({
+            commitHash: "abc1234",
+            filePath: "src/file.ts",
         });
 
         const logCallsBeforePagedFetch = gitOps.getLog.mock.calls.length;

--- a/tests/unit/webview-apps.integration.test.tsx
+++ b/tests/unit/webview-apps.integration.test.tsx
@@ -313,9 +313,43 @@ describe("CommitGraphApp integration", () => {
                     },
                 }),
             );
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        type: "setCommitDetail",
+                        detail: {
+                            hash: "aa11",
+                            shortHash: "aa11",
+                            message: "feat: first commit",
+                            body: "",
+                            author: "Mahesh",
+                            email: "m@example.com",
+                            date: "2026-02-19T00:00:00Z",
+                            parentHashes: ["p1"],
+                            refs: ["HEAD -> main"],
+                            files: [
+                                {
+                                    path: "src/feature.ts",
+                                    status: "M",
+                                    additions: 3,
+                                    deletions: 1,
+                                },
+                            ],
+                        },
+                    },
+                }),
+            );
         });
         await flush();
         expect(document.body.textContent).toContain("Branch: features/right-click-context");
+
+        const changedFileRow = document.querySelector(
+            '[title="src/feature.ts"]',
+        ) as HTMLElement | null;
+        expect(changedFileRow).toBeTruthy();
+        act(() => {
+            changedFileRow?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+        });
 
         const branchRow = Array.from(document.querySelectorAll(".branch-row")).find((row) =>
             row.textContent?.includes("HEAD (main)"),
@@ -367,6 +401,13 @@ describe("CommitGraphApp integration", () => {
         );
         expect(vscode.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({ type: "selectCommit", hash: "aa11" }),
+        );
+        expect(vscode.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "openCommitFileDiff",
+                commitHash: "aa11",
+                filePath: "src/feature.ts",
+            }),
         );
     });
 });

--- a/tests/unit/webview-utils.test.ts
+++ b/tests/unit/webview-utils.test.ts
@@ -128,10 +128,12 @@ describe("commit menu", () => {
     it("disables history-rewrite actions for pushed merge commits", () => {
         const mergeCommit = makeCommit({ parentHashes: ["a", "b"] });
         const items = getCommitMenuItems(mergeCommit, false);
+        const pushUpToHere = items.find((item) => item.action === "pushAllUpToHere");
         const undo = items.find((item) => item.action === "undoCommit");
         const edit = items.find((item) => item.action === "editCommitMessage");
         const drop = items.find((item) => item.action === "dropCommit");
         const rebase = items.find((item) => item.action === "interactiveRebaseFromHere");
+        expect(pushUpToHere?.disabled).toBe(true);
         expect(undo?.disabled).toBe(true);
         expect(edit?.disabled).toBe(true);
         expect(drop?.disabled).toBe(true);
@@ -149,7 +151,9 @@ describe("commit menu", () => {
     it("keeps checkout revision action in commit menu", () => {
         const items = getCommitMenuItems(makeCommit(), true);
         const checkoutRevision = items.find((item) => item.action === "checkoutRevision");
+        const pushUpToHere = items.find((item) => item.action === "pushAllUpToHere");
         expect(checkoutRevision).toBeDefined();
+        expect(pushUpToHere).toBeDefined();
         expect(items.some((item) => item.action === "checkoutMain")).toBe(false);
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click file entries in a commit to open a diff against the parent version.
  * New "Push All up to Here..." action in commit menu to push commits up to a selected revision.

* **Tests**
  * Added integration tests covering double-click diff behavior, messaging/event forwarding, and push-up-to-here flows.

* **Chores**
  * Changelog updated for v0.5.4 (2026-03-04).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->