### PR TITLE
Release 0.6.1 with idempotent publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,11 @@ jobs:
               with:
                   bun-version: ${{ env.BUN_VERSION }}
 
+            - name: Check publish status
+              if: steps.version-check.outputs.version_changed == 'true'
+              id: publish-status
+              run: node scripts/check-extension-publish-status.js
+
             - name: Download VSIX artifact
               if: steps.version-check.outputs.version_changed == 'true'
               uses: actions/download-artifact@v4
@@ -125,20 +130,28 @@ jobs:
                   name: extension-vsix
 
             - name: Publish to VS Code Marketplace
-              if: steps.version-check.outputs.version_changed == 'true'
+              if: steps.version-check.outputs.version_changed == 'true' && steps.publish-status.outputs.vsce_published != 'true'
               run: |
                   VSIX_PATH=$(ls *.vsix | head -n 1)
                   bunx vsce publish --packagePath "$VSIX_PATH" -p "$VSCE_PAT"
               env:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+            - name: Skip VS Code Marketplace publish
+              if: steps.version-check.outputs.version_changed == 'true' && steps.publish-status.outputs.vsce_published == 'true'
+              run: echo "Version ${{ steps.version-check.outputs.new_version }} is already published to VS Code Marketplace. Skipping."
+
             - name: Publish to Open VSX
-              if: steps.version-check.outputs.version_changed == 'true'
+              if: steps.version-check.outputs.version_changed == 'true' && steps.publish-status.outputs.ovsx_published != 'true'
               run: |
                   VSIX_PATH=$(ls *.vsix | head -n 1)
                   bunx ovsx publish -p "$OVSX_PAT" "$VSIX_PATH"
               env:
                   OVSX_PAT: ${{ secrets.OVSX_PAT }}
+
+            - name: Skip Open VSX publish
+              if: steps.version-check.outputs.version_changed == 'true' && steps.publish-status.outputs.ovsx_published == 'true'
+              run: echo "Version ${{ steps.version-check.outputs.new_version }} is already published to Open VSX. Skipping."
 
             - name: Create git tag
               if: steps.version-check.outputs.version_changed == 'true'
@@ -155,12 +168,30 @@ jobs:
               env:
                   NEW_VERSION: ${{ steps.version-check.outputs.new_version }}
 
-            - name: Create GitHub Release and upload VSIX
+            - name: Check if GitHub release exists
               if: steps.version-check.outputs.version_changed == 'true'
-              uses: softprops/action-gh-release@v2
-              with:
-                  generate_release_notes: true
-                  tag_name: v${{ steps.version-check.outputs.new_version }}
-                  files: "*.vsix"
+              id: github-release-check
+              run: |
+                  VERSION="v$NEW_VERSION"
+                  if gh release view "$VERSION" >/dev/null 2>&1; then
+                    echo "release_exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "release_exists=false" >> "$GITHUB_OUTPUT"
+                  fi
               env:
+                  NEW_VERSION: ${{ steps.version-check.outputs.new_version }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create GitHub Release and upload VSIX
+              if: steps.version-check.outputs.version_changed == 'true' && steps.github-release-check.outputs.release_exists != 'true'
+              run: gh release create "v$NEW_VERSION" *.vsix --generate-notes
+              env:
+                  NEW_VERSION: ${{ steps.version-check.outputs.new_version }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Update GitHub Release asset
+              if: steps.version-check.outputs.version_changed == 'true' && steps.github-release-check.outputs.release_exists == 'true'
+              run: gh release upload "v$NEW_VERSION" *.vsix --clobber
+              env:
+                  NEW_VERSION: ${{ steps.version-check.outputs.new_version }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,10 @@ jobs:
               with:
                   bun-version: ${{ env.BUN_VERSION }}
 
+            - name: Install release dependencies
+              if: steps.version-check.outputs.version_changed == 'true'
+              run: bun install --frozen-lockfile
+
             - name: Check publish status
               if: steps.version-check.outputs.version_changed == 'true'
               id: publish-status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-03-12
+
+### Fixed
+
+- Release workflow reruns now check whether the current extension version is already published to the VS Code Marketplace or Open VSX and skip that target instead of failing on duplicate publish attempts.
+- GitHub release publishing is now idempotent for reruns: existing releases are reused and the VSIX asset is uploaded with overwrite support so partially failed release runs can be resumed safely.
+
 ## [0.6.0] - 2026-03-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/scripts/check-extension-publish-status.js
+++ b/scripts/check-extension-publish-status.js
@@ -1,0 +1,134 @@
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+function getExtensionId(packageJson) {
+    return `${packageJson.publisher}.${packageJson.name}`;
+}
+
+function parseJsonOutput(output, source) {
+    try {
+        return JSON.parse(output);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to parse ${source} JSON output: ${message}`);
+    }
+}
+
+function isVsceVersionPublished(metadata, version) {
+    const versions = Array.isArray(metadata?.versions) ? metadata.versions : [];
+    return versions.some((entry) => entry?.version === version);
+}
+
+function isOvsxVersionPublished(metadata, version) {
+    if (!metadata || typeof metadata !== "object") return false;
+    if (metadata.version === version) return true;
+    const allVersions = metadata.allVersions;
+    return Boolean(
+        allVersions &&
+            typeof allVersions === "object" &&
+            Object.prototype.hasOwnProperty.call(allVersions, version),
+    );
+}
+
+function isMissingMarketplaceExtensionError(message) {
+    return /extension .*not found|no extension found/i.test(message);
+}
+
+function isMissingOpenVsxVersionError(message) {
+    return /has no published version matching|extension .*not found|no extension found/i.test(
+        message,
+    );
+}
+
+function defaultRunCommand(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        encoding: "utf8",
+        ...options,
+    });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    if (result.status !== 0) {
+        const stderr = result.stderr?.trim();
+        const stdout = result.stdout?.trim();
+        throw new Error(stderr || stdout || `${command} exited with status ${result.status}`);
+    }
+
+    return result.stdout;
+}
+
+function lookupPublishStatus({ packageJson, runCommand = defaultRunCommand, cwd = process.cwd() }) {
+    const extensionId = getExtensionId(packageJson);
+    const version = packageJson.version;
+
+    let vscePublished = false;
+    try {
+        const vsceOutput = runCommand(
+            "bunx",
+            ["vsce", "show", extensionId, "--json"],
+            { cwd },
+        );
+        vscePublished = isVsceVersionPublished(parseJsonOutput(vsceOutput, "vsce"), version);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isMissingMarketplaceExtensionError(message)) {
+            throw new Error(`VS Code Marketplace lookup failed: ${message}`);
+        }
+    }
+
+    let ovsxPublished = false;
+    try {
+        const ovsxOutput = runCommand(
+            "bunx",
+            ["ovsx", "get", extensionId, "--metadata", "--versionRange", version],
+            { cwd },
+        );
+        ovsxPublished = isOvsxVersionPublished(parseJsonOutput(ovsxOutput, "ovsx"), version);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isMissingOpenVsxVersionError(message)) {
+            throw new Error(`Open VSX lookup failed: ${message}`);
+        }
+    }
+
+    return {
+        extensionId,
+        version,
+        vscePublished,
+        ovsxPublished,
+    };
+}
+
+function writeGitHubOutput(key, value, outputPath) {
+    fs.appendFileSync(outputPath, `${key}=${value}\n`, "utf8");
+}
+
+function main() {
+    const packageJsonPath = path.join(process.cwd(), "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    const status = lookupPublishStatus({ packageJson });
+
+    console.log(`Extension: ${status.extensionId}`);
+    console.log(`Version: ${status.version}`);
+    console.log(`VS Code Marketplace published: ${status.vscePublished}`);
+    console.log(`Open VSX published: ${status.ovsxPublished}`);
+
+    if (process.env.GITHUB_OUTPUT) {
+        writeGitHubOutput("vsce_published", String(status.vscePublished), process.env.GITHUB_OUTPUT);
+        writeGitHubOutput("ovsx_published", String(status.ovsxPublished), process.env.GITHUB_OUTPUT);
+    }
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    getExtensionId,
+    isVsceVersionPublished,
+    isOvsxVersionPublished,
+    lookupPublishStatus,
+};

--- a/scripts/check-extension-publish-status.js
+++ b/scripts/check-extension-publish-status.js
@@ -11,7 +11,7 @@ function parseJsonOutput(output, source) {
         return JSON.parse(output);
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to parse ${source} JSON output: ${message}`);
+        throw new Error(`Failed to parse ${source} JSON output: ${message}`, { cause: error });
     }
 }
 
@@ -75,7 +75,7 @@ function lookupPublishStatus({ packageJson, runCommand = defaultRunCommand, cwd 
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!isMissingMarketplaceExtensionError(message)) {
-            throw new Error(`VS Code Marketplace lookup failed: ${message}`);
+            throw new Error(`VS Code Marketplace lookup failed: ${message}`, { cause: error });
         }
     }
 
@@ -90,7 +90,7 @@ function lookupPublishStatus({ packageJson, runCommand = defaultRunCommand, cwd 
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         if (!isMissingOpenVsxVersionError(message)) {
-            throw new Error(`Open VSX lookup failed: ${message}`);
+            throw new Error(`Open VSX lookup failed: ${message}`, { cause: error });
         }
     }
 

--- a/tests/unit/check-extension-publish-status.test.ts
+++ b/tests/unit/check-extension-publish-status.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    getExtensionId,
+    isVsceVersionPublished,
+    isOvsxVersionPublished,
+    lookupPublishStatus,
+} from "../../scripts/check-extension-publish-status";
+
+describe("getExtensionId", () => {
+    it("builds the extension id from publisher and name", () => {
+        expect(getExtensionId({ publisher: "MaheshKok", name: "intelligit" })).toBe(
+            "MaheshKok.intelligit",
+        );
+    });
+});
+
+describe("isVsceVersionPublished", () => {
+    it("returns true when the version exists in marketplace metadata", () => {
+        expect(
+            isVsceVersionPublished(
+                {
+                    versions: [{ version: "0.5.5" }, { version: "0.6.0" }],
+                },
+                "0.6.0",
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when the version is absent", () => {
+        expect(
+            isVsceVersionPublished(
+                {
+                    versions: [{ version: "0.5.5" }],
+                },
+                "0.6.0",
+            ),
+        ).toBe(false);
+    });
+});
+
+describe("isOvsxVersionPublished", () => {
+    it("returns true when the exact version is present in metadata", () => {
+        expect(
+            isOvsxVersionPublished(
+                {
+                    version: "0.6.0",
+                    allVersions: {
+                        latest: "https://open-vsx.org/api/MaheshKok/intelligit/universal/latest",
+                        "0.6.0":
+                            "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.6.0",
+                    },
+                },
+                "0.6.0",
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when the exact version is absent", () => {
+        expect(
+            isOvsxVersionPublished(
+                {
+                    version: "0.5.5",
+                    allVersions: {
+                        latest: "https://open-vsx.org/api/MaheshKok/intelligit/universal/latest",
+                        "0.5.5":
+                            "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.5.5",
+                    },
+                },
+                "0.6.0",
+            ),
+        ).toBe(false);
+    });
+});
+
+describe("lookupPublishStatus", () => {
+    it("treats missing Open VSX versions as unpublished but preserves marketplace status", () => {
+        const result = lookupPublishStatus({
+            packageJson: {
+                publisher: "MaheshKok",
+                name: "intelligit",
+                version: "0.6.0",
+            },
+            runCommand: (_command, args) => {
+                if (args[0] === "vsce") {
+                    return JSON.stringify({
+                        versions: [{ version: "0.6.0" }],
+                    });
+                }
+                throw new Error(
+                    "Extension MaheshKok.intelligit has no published version matching '0.6.0'",
+                );
+            },
+        });
+
+        expect(result).toEqual({
+            extensionId: "MaheshKok.intelligit",
+            version: "0.6.0",
+            vscePublished: true,
+            ovsxPublished: false,
+        });
+    });
+});

--- a/tests/unit/check-extension-publish-status.test.ts
+++ b/tests/unit/check-extension-publish-status.test.ts
@@ -100,4 +100,62 @@ describe("lookupPublishStatus", () => {
             ovsxPublished: false,
         });
     });
+
+    it("preserves the parse failure as the cause for marketplace lookup errors", () => {
+        let thrownError;
+
+        try {
+            lookupPublishStatus({
+                packageJson: {
+                    publisher: "MaheshKok",
+                    name: "intelligit",
+                    version: "0.6.0",
+                },
+                runCommand: (_command, args) => {
+                    if (args[0] === "vsce") {
+                        return "{";
+                    }
+                    return "{}";
+                },
+            });
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toContain("VS Code Marketplace lookup failed");
+        expect(thrownError.cause).toBeInstanceOf(Error);
+        expect(thrownError.cause.message).toContain("Failed to parse vsce JSON output");
+        expect(thrownError.cause.cause).toBeInstanceOf(SyntaxError);
+    });
+
+    it("preserves the original lookup failure as the cause for Open VSX errors", () => {
+        const rootCause = new Error("bunx ovsx not found");
+        let thrownError;
+
+        try {
+            lookupPublishStatus({
+                packageJson: {
+                    publisher: "MaheshKok",
+                    name: "intelligit",
+                    version: "0.6.0",
+                },
+                runCommand: (_command, args) => {
+                    if (args[0] === "vsce") {
+                        return JSON.stringify({
+                            versions: [{ version: "0.6.0" }],
+                        });
+                    }
+
+                    throw rootCause;
+                },
+            });
+        } catch (error) {
+            thrownError = error;
+        }
+
+        expect(thrownError).toBeInstanceOf(Error);
+        expect(thrownError.message).toContain("Open VSX lookup failed");
+        expect(thrownError.cause).toBe(rootCause);
+    });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release workflow now checks if the current version is already published to VS Code Marketplace or Open VSX and skips those targets to prevent duplicate publishes.
  * GitHub release publishing is idempotent: existing releases are detected and assets are overwritten to allow safe resumption of partial releases.

* **Chores**
  * Bumps package version and adds a changelog entry for 0.6.1.

* **Tests**
  * Adds unit tests covering the publish-status checks used by the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->