### PR TITLE
Add inline blame with graph reveal and fix diff/push behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ If no JetBrains IDE path is configured, IntelliGit falls back to the VS Code int
 
 - VS Code `1.96.0` or later
 - Git installed and available on `PATH`
+- Node.js `20+` recommended for packaging with `vsce`
 
 ## Installation
 
@@ -162,10 +163,37 @@ bun run format
 ### Manually test the changes 
 
 ```bash
-bun install
-bun run build
-bun run package
+# Use Node 20+ (Node 22 recommended)
+nvm use 22
+
+# Install dependencies
+pnpm install
+
+# Build production bundles
+node scripts/build.js --production
+
+# Package VSIX
+pnpm exec vsce package --no-dependencies
+
+# Install locally
 code --install-extension intelligit-*.vsix
+```
+
+### Packaging
+
+```bash
+# Use Node 20+ (Node 22 recommended)
+nvm use 22
+
+pnpm install
+node scripts/build.js --production
+pnpm exec vsce package --no-dependencies
+```
+
+The packaged VSIX is written to the repository root, for example:
+
+```bash
+/Users/wnz/goProject/IntelliGit/intelligit-0.6.2.vsix
 ```
 
 ### Running the Test Suite
@@ -212,7 +240,7 @@ Data flow highlights:
 | Webviews | React 18 |
 | Graph rendering | HTML5 Canvas |
 | Bundler | esbuild |
-| Package manager | Bun |
+| Package manager | pnpm / Bun |
 | Testing | Vitest |
 | Linting | ESLint |
 | Formatting | Prettier |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ If no JetBrains IDE path is configured, IntelliGit falls back to the VS Code int
 
 - VS Code `1.96.0` or later
 - Git installed and available on `PATH`
-- Node.js `20+` recommended for packaging with `vsce`
 
 ## Installation
 
@@ -163,37 +162,10 @@ bun run format
 ### Manually test the changes 
 
 ```bash
-# Use Node 20+ (Node 22 recommended)
-nvm use 22
-
-# Install dependencies
-pnpm install
-
-# Build production bundles
-node scripts/build.js --production
-
-# Package VSIX
-pnpm exec vsce package --no-dependencies
-
-# Install locally
+bun install
+bun run build
+bun run package
 code --install-extension intelligit-*.vsix
-```
-
-### Packaging
-
-```bash
-# Use Node 20+ (Node 22 recommended)
-nvm use 22
-
-pnpm install
-node scripts/build.js --production
-pnpm exec vsce package --no-dependencies
-```
-
-The packaged VSIX is written to the repository root, for example:
-
-```bash
-/Users/wnz/goProject/IntelliGit/intelligit-0.6.2.vsix
 ```
 
 ### Running the Test Suite
@@ -240,7 +212,7 @@ Data flow highlights:
 | Webviews | React 18 |
 | Graph rendering | HTML5 Canvas |
 | Bundler | esbuild |
-| Package manager | pnpm / Bun |
+| Package manager | Bun |
 | Testing | Vitest |
 | Linting | ESLint |
 | Formatting | Prettier |

--- a/package.json
+++ b/package.json
@@ -448,10 +448,10 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "node scripts/build.js --production",
-        "build": "node scripts/build.js",
-        "build:prod": "node scripts/build.js --production",
-        "watch": "node scripts/watch.js",
+        "vscode:prepublish": "bun scripts/build.js --production",
+        "build": "bun scripts/build.js",
+        "build:prod": "bun scripts/build.js --production",
+        "watch": "bun scripts/watch.js",
         "format": "prettier --write \"src/**/*.{ts,tsx}\" \"scripts/**/*.js\"",
         "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.js\"",
         "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -416,10 +416,10 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "bun scripts/build.js --production",
-        "build": "bun scripts/build.js",
-        "build:prod": "bun scripts/build.js --production",
-        "watch": "bun scripts/watch.js",
+        "vscode:prepublish": "node scripts/build.js --production",
+        "build": "node scripts/build.js",
+        "build:prod": "node scripts/build.js --production",
+        "watch": "node scripts/watch.js",
         "format": "prettier --write \"src/**/*.{ts,tsx}\" \"scripts/**/*.js\"",
         "format:check": "prettier --check \"src/**/*.{ts,tsx}\" \"scripts/**/*.js\"",
         "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,16 @@
                 "icon": "$(git-branch)"
             },
             {
+                "command": "intelligit.annotateWithGitBlame",
+                "title": "Annotate with Git Blame",
+                "category": "IntelliGit"
+            },
+            {
+                "command": "intelligit.clearGitBlame",
+                "title": "Close Git Blame",
+                "category": "IntelliGit"
+            },
+            {
                 "command": "intelligit.commitFileCompareWithLocal",
                 "title": "Compare with Local",
                 "category": "IntelliGit",
@@ -273,7 +283,29 @@
                     "group": "navigation@9"
                 }
             ],
+            "editor/lineNumber/context": [
+                {
+                    "command": "intelligit.annotateWithGitBlame",
+                    "when": "resourceScheme == file && intelligit.blameSupportedFile && !intelligit.blameActive",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "intelligit.clearGitBlame",
+                    "when": "resourceScheme == file && intelligit.blameSupportedFile && intelligit.blameActive",
+                    "group": "navigation@1"
+                }
+            ],
             "intelligit.editorContext": [
+                {
+                    "command": "intelligit.annotateWithGitBlame",
+                    "when": "resourceScheme == file && intelligit.blameSupportedFile && !intelligit.blameActive",
+                    "group": "1_compare@0"
+                },
+                {
+                    "command": "intelligit.clearGitBlame",
+                    "when": "resourceScheme == file && intelligit.blameSupportedFile && intelligit.blameActive",
+                    "group": "1_compare@0"
+                },
                 {
                     "command": "intelligit.compareWithRevision",
                     "when": "resourceScheme == file",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
     compareCommitInfoFileWithLocal,
     applySelectedCommitFileChange,
     openCommitFileDiff,
+    registerDiffContentProvider,
 } from "./services/diffService";
 import { EditorBlameController } from "./services/EditorBlameController";
 import { runWithNotificationProgress } from "./utils/notifications";
@@ -40,6 +41,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const repoRoot = workspaceFolder.uri.fsPath;
     const executor = new GitExecutor(repoRoot);
     const gitOps = new GitOps(executor);
+    registerDiffContentProvider(context.subscriptions);
 
     try {
         const isRepo = await gitOps.isRepository();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import {
     applySelectedCommitFileChange,
     openCommitFileDiff,
 } from "./services/diffService";
+import { EditorBlameController } from "./services/EditorBlameController";
 import { runWithNotificationProgress } from "./utils/notifications";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -57,6 +58,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const commitInfo = new CommitInfoViewProvider(context.extensionUri);
     const commitPanel = new CommitPanelViewProvider(context.extensionUri, gitOps);
     const mergeConflicts = new MergeConflictsTreeProvider(gitOps, workspaceFolder.uri);
+    const blameController = new EditorBlameController(repoRoot, gitOps, async (hash) => {
+        await vscode.commands.executeCommand("intelligit.revealCommitInGraph", hash);
+    });
 
     // --- Register views ---
 
@@ -258,6 +262,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
         vscode.commands.registerCommand("intelligit.showGitLog", async () => {
             await vscode.commands.executeCommand("intelligit.commitGraph.focus");
+        }),
+
+        vscode.commands.registerCommand("intelligit.revealCommitInGraph", async (hash: unknown) => {
+            if (typeof hash !== "string" || !hash.trim()) return;
+            await vscode.commands.executeCommand("intelligit.commitGraph.focus");
+            await commitGraph.revealCommit(hash.trim());
+        }),
+
+        vscode.commands.registerCommand("intelligit.annotateWithGitBlame", async () => {
+            await blameController.annotateActiveEditor();
+        }),
+
+        vscode.commands.registerCommand("intelligit.clearGitBlame", async () => {
+            await blameController.clear();
         }),
 
         vscode.commands.registerCommand("intelligit.mergeConflictsRefresh", async () => {
@@ -496,6 +514,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     currentBranches = await gitOps.getBranches();
     commitGraph.setBranches(currentBranches);
+    await blameController.initialize();
 
     // Eagerly fetch file count so the activity bar badge shows immediately.
     commitPanel.refresh().catch((err) => {
@@ -513,6 +532,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     context.subscriptions.push(
         refreshService,
+        blameController,
         commitGraph,
         commitInfo,
         commitPanel,

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -4,6 +4,7 @@ import type {
     Commit,
     CommitDetail,
     CommitFile,
+    GitBlameLine,
     WorkingFile,
     StashEntry,
     MergeConflictFile,
@@ -428,6 +429,71 @@ export class GitOps {
         return files;
     }
 
+    async getBlame(filePath: string): Promise<GitBlameLine[]> {
+        const output = await this.executor.run([
+            "blame",
+            "--line-porcelain",
+            "--date=short",
+            "--",
+            filePath,
+        ]);
+        const blameLines: GitBlameLine[] = [];
+        const lines = output.split("\n");
+
+        for (let i = 0; i < lines.length; ) {
+            const header = lines[i]?.trim();
+            if (!header) {
+                i += 1;
+                continue;
+            }
+
+            const headerMatch = header.match(/^([0-9a-f]{40}|0{40})\s+\d+\s+(\d+)(?:\s+\d+)?$/i);
+            if (!headerMatch) {
+                i += 1;
+                continue;
+            }
+
+            const commitHash = headerMatch[1];
+            const finalLine = Number.parseInt(headerMatch[2] ?? "0", 10);
+            let author = "";
+            let authorTime = 0;
+            let authorTz = "+0000";
+            let summary = "";
+            i += 1;
+
+            while (i < lines.length && !lines[i].startsWith("\t")) {
+                const line = lines[i];
+                if (line.startsWith("author ")) {
+                    author = line.slice("author ".length).trim();
+                } else if (line.startsWith("author-time ")) {
+                    authorTime = Number.parseInt(line.slice("author-time ".length).trim(), 10) || 0;
+                } else if (line.startsWith("author-tz ")) {
+                    authorTz = line.slice("author-tz ".length).trim() || "+0000";
+                } else if (line.startsWith("summary ")) {
+                    summary = line.slice("summary ".length).trim();
+                }
+                i += 1;
+            }
+
+            if (i < lines.length && lines[i].startsWith("\t")) {
+                i += 1;
+            }
+
+            const isUncommitted = /^0+$/.test(commitHash);
+            blameLines.push({
+                line: Math.max(0, finalLine - 1),
+                commitHash,
+                shortHash: commitHash.slice(0, 8),
+                author: author || (isUncommitted ? "Not Committed Yet" : "Unknown"),
+                date: formatBlameDate(authorTime, authorTz),
+                summary,
+                isUncommitted,
+            });
+        }
+
+        return blameLines.sort((a, b) => a.line - b.line);
+    }
+
     async stageFiles(paths: string[]): Promise<void> {
         if (paths.length === 0) return;
         await this.executor.run(["add", "--", ...paths]);
@@ -844,4 +910,14 @@ function parseSetUpstreamPushSuggestion(err: unknown): { remote: string; branch:
     const branch = match[2]?.trim();
     if (!remote || !branch) return null;
     return { remote, branch };
+}
+
+function formatBlameDate(authorTime: number, authorTz: string): string {
+    if (!Number.isFinite(authorTime) || authorTime <= 0) return "";
+    const sign = authorTz.startsWith("-") ? -1 : 1;
+    const hours = Number.parseInt(authorTz.slice(1, 3), 10) || 0;
+    const minutes = Number.parseInt(authorTz.slice(3, 5), 10) || 0;
+    const offsetSeconds = sign * (hours * 60 + minutes) * 60;
+    const date = new Date((authorTime + offsetSeconds) * 1000);
+    return `${date.getUTCFullYear()}/${date.getUTCMonth() + 1}/${date.getUTCDate()}`;
 }

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -438,9 +438,12 @@ export class GitOps {
         await this.executor.run(["reset", "HEAD", "--", ...paths]);
     }
 
-    async commit(message: string, amend: boolean = false): Promise<string> {
+    async commit(message: string, amend: boolean = false, paths?: string[]): Promise<string> {
         const args = ["commit", "-m", message];
         if (amend) args.push("--amend");
+        if (paths && paths.length > 0) {
+            args.push("--only", "--", ...paths);
+        }
         return this.executor.run(args);
     }
 
@@ -464,8 +467,8 @@ export class GitOps {
         }
     }
 
-    async commitAndPush(message: string, amend: boolean = false): Promise<string> {
-        await this.commit(message, amend);
+    async commitAndPush(message: string, amend: boolean = false, paths?: string[]): Promise<string> {
+        await this.commit(message, amend, paths);
         return this.push();
     }
 

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -898,8 +898,9 @@ function mapConflictSideState(code: string): MergeConflictFile["ours"] {
 }
 
 function isNoUpstreamPushError(err: unknown): boolean {
-    const message = getErrorMessage(err).toLowerCase();
-    return message.includes("has no upstream branch");
+    const message = getErrorMessage(err);
+    const lower = message.toLowerCase();
+    return lower.includes("has no upstream branch") || parseSetUpstreamPushSuggestion(err) !== null;
 }
 
 function parseSetUpstreamPushSuggestion(err: unknown): { remote: string; branch: string } | null {

--- a/src/services/EditorBlameController.ts
+++ b/src/services/EditorBlameController.ts
@@ -8,6 +8,7 @@ const BLAME_ACTIVE_CONTEXT = "intelligit.blameActive";
 const BLAME_SUPPORTED_CONTEXT = "intelligit.blameSupportedFile";
 
 type BlameStyle = {
+    color: vscode.ThemeColor;
     borderColor: string;
     backgroundColor: string;
 };
@@ -15,15 +16,13 @@ type BlameStyle = {
 type BlameSession = {
     uri: string;
     filePath: string;
+    blameLines: GitBlameLine[];
     decorationType: vscode.TextEditorDecorationType;
     decorations: vscode.DecorationOptions[];
     linesByNumber: Map<number, GitBlameLine>;
 };
 
-const UNCOMMITTED_STYLE: BlameStyle = {
-    borderColor: "rgba(126, 132, 146, 0.9)",
-    backgroundColor: "rgba(126, 132, 146, 0.16)",
-};
+const BLAME_TEXT_COLOR = new vscode.ThemeColor("editor.foreground");
 
 export class EditorBlameController implements vscode.Disposable {
     private readonly disposables: vscode.Disposable[] = [];
@@ -40,6 +39,9 @@ export class EditorBlameController implements vscode.Disposable {
             }),
             vscode.window.onDidChangeTextEditorSelection((event) => {
                 void this.handleSelectionChanged(event);
+            }),
+            vscode.window.onDidChangeActiveColorTheme(() => {
+                this.handleThemeChanged();
             }),
         );
     }
@@ -74,6 +76,7 @@ export class EditorBlameController implements vscode.Disposable {
             this.session = {
                 uri: editor.document.uri.toString(),
                 filePath,
+                blameLines,
                 decorationType,
                 decorations,
                 linesByNumber: new Map(blameLines.map((line) => [line.line, line])),
@@ -141,6 +144,15 @@ export class EditorBlameController implements vscode.Disposable {
         this.session = null;
     }
 
+    private handleThemeChanged(): void {
+        if (!this.session) return;
+        this.session.decorations = buildBlameDecorations(this.session.blameLines);
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.uri.toString() === this.session.uri) {
+            this.applySessionToEditor(editor);
+        }
+    }
+
     private getRepoRelativeFilePath(editor: vscode.TextEditor | undefined): string | null {
         if (!editor || editor.document.uri.scheme !== "file") return null;
         return getRepoRelativeFilePathFromUri(editor.document.uri, this.repoRoot);
@@ -159,17 +171,20 @@ export class EditorBlameController implements vscode.Disposable {
 function buildBlameDecorations(lines: GitBlameLine[]): vscode.DecorationOptions[] {
     const labels = lines.map((line) => formatBlameLabel(line));
     const maxLabelLength = labels.reduce((max, label) => Math.max(max, label.length), 0);
+    const themeKind = vscode.window.activeColorTheme.kind;
 
     return lines.map((line, index) => {
         const label = labels[index].padEnd(maxLabelLength, " ");
-        const style = line.isUncommitted ? UNCOMMITTED_STYLE : resolveCommitStyle(line.commitHash);
+        const style = line.isUncommitted
+            ? resolveUncommittedStyle(themeKind)
+            : resolveCommitStyle(line.commitHash, themeKind);
         return {
             range: new vscode.Range(line.line, 0, line.line, 0),
             hoverMessage: buildHoverMessage(line),
             renderOptions: {
                 before: {
                     contentText: ` ${label} `,
-                    color: "rgba(188, 194, 205, 0.94)",
+                    color: style.color,
                     backgroundColor: style.backgroundColor,
                     margin: "0 1.2em 0 0",
                     borderRadius: "3px 0 0 3px",
@@ -216,22 +231,34 @@ function buildHoverMessage(line: GitBlameLine): vscode.MarkdownString {
 }
 
 function escapeMarkdown(value: string): string {
-    return value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1");
+    return value.replace(/[[\]\\`*_{}()#+\-.!|>]/g, "\\$&");
 }
 
-function resolveCommitStyle(commitHash: string): BlameStyle {
+function resolveCommitStyle(commitHash: string, themeKind: vscode.ColorThemeKind): BlameStyle {
     let hash = 0;
     for (let i = 0; i < commitHash.length; i += 1) {
         hash = (hash * 33 + commitHash.charCodeAt(i)) >>> 0;
     }
     const hue = hash % 360;
-    const saturation = 52 + (hash % 14);
-    const lightness = 56 + (hash % 8);
+    const isLightTheme = themeKind === vscode.ColorThemeKind.Light ||
+        themeKind === vscode.ColorThemeKind.HighContrastLight;
+    const saturation = isLightTheme ? 46 + (hash % 12) : 52 + (hash % 14);
+    const borderLightness = isLightTheme ? 34 + (hash % 8) : 56 + (hash % 8);
+    const backgroundLightness = isLightTheme ? 42 + (hash % 6) : Math.min(78, borderLightness + 10);
+    const backgroundAlpha = isLightTheme ? 0.10 : 0.14;
     return {
-        borderColor: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.95)`,
-        backgroundColor: `hsla(${hue}, ${Math.max(38, saturation - 8)}%, ${Math.min(
-            78,
-            lightness + 10,
-        )}%, 0.14)`,
+        color: BLAME_TEXT_COLOR,
+        borderColor: `hsla(${hue}, ${saturation}%, ${borderLightness}%, 0.95)`,
+        backgroundColor: `hsla(${hue}, ${Math.max(36, saturation - 6)}%, ${backgroundLightness}%, ${backgroundAlpha})`,
+    };
+}
+
+function resolveUncommittedStyle(themeKind: vscode.ColorThemeKind): BlameStyle {
+    const isLightTheme = themeKind === vscode.ColorThemeKind.Light ||
+        themeKind === vscode.ColorThemeKind.HighContrastLight;
+    return {
+        color: BLAME_TEXT_COLOR,
+        borderColor: isLightTheme ? "rgba(105, 112, 125, 0.92)" : "rgba(126, 132, 146, 0.9)",
+        backgroundColor: isLightTheme ? "rgba(105, 112, 125, 0.10)" : "rgba(126, 132, 146, 0.16)",
     };
 }

--- a/src/services/EditorBlameController.ts
+++ b/src/services/EditorBlameController.ts
@@ -1,0 +1,237 @@
+import * as vscode from "vscode";
+import { GitOps } from "../git/operations";
+import type { GitBlameLine } from "../types";
+import { getRepoRelativeFilePathFromUri } from "./diffService";
+import { getErrorMessage } from "../utils/errors";
+
+const BLAME_ACTIVE_CONTEXT = "intelligit.blameActive";
+const BLAME_SUPPORTED_CONTEXT = "intelligit.blameSupportedFile";
+
+type BlameStyle = {
+    borderColor: string;
+    backgroundColor: string;
+};
+
+type BlameSession = {
+    uri: string;
+    filePath: string;
+    decorationType: vscode.TextEditorDecorationType;
+    decorations: vscode.DecorationOptions[];
+    linesByNumber: Map<number, GitBlameLine>;
+};
+
+const UNCOMMITTED_STYLE: BlameStyle = {
+    borderColor: "rgba(126, 132, 146, 0.9)",
+    backgroundColor: "rgba(126, 132, 146, 0.16)",
+};
+
+export class EditorBlameController implements vscode.Disposable {
+    private readonly disposables: vscode.Disposable[] = [];
+    private session: BlameSession | null = null;
+
+    constructor(
+        private readonly repoRoot: string,
+        private readonly gitOps: GitOps,
+        private readonly revealCommitInGraph: (hash: string) => Promise<void>,
+    ) {
+        this.disposables.push(
+            vscode.window.onDidChangeActiveTextEditor((editor) => {
+                void this.handleActiveEditorChanged(editor);
+            }),
+            vscode.window.onDidChangeTextEditorSelection((event) => {
+                void this.handleSelectionChanged(event);
+            }),
+        );
+    }
+
+    async initialize(): Promise<void> {
+        await this.updateContextKeys(vscode.window.activeTextEditor);
+    }
+
+    async annotateActiveEditor(): Promise<void> {
+        const editor = vscode.window.activeTextEditor;
+        const filePath = this.getRepoRelativeFilePath(editor);
+        if (!editor || !filePath) {
+            vscode.window.showWarningMessage(
+                "Git blame is only available for files inside the current IntelliGit repository.",
+            );
+            await this.updateContextKeys(editor);
+            return;
+        }
+
+        if (this.session?.uri === editor.document.uri.toString()) {
+            this.applySessionToEditor(editor);
+            await this.updateContextKeys(editor);
+            return;
+        }
+
+        this.disposeSession();
+
+        try {
+            const blameLines = await this.gitOps.getBlame(filePath);
+            const decorationType = vscode.window.createTextEditorDecorationType({});
+            const decorations = buildBlameDecorations(blameLines);
+            this.session = {
+                uri: editor.document.uri.toString(),
+                filePath,
+                decorationType,
+                decorations,
+                linesByNumber: new Map(blameLines.map((line) => [line.line, line])),
+            };
+            this.applySessionToEditor(editor);
+        } catch (err) {
+            vscode.window.showErrorMessage(`Git blame failed: ${getErrorMessage(err)}`);
+            this.disposeSession();
+        }
+
+        await this.updateContextKeys(editor);
+    }
+
+    async clear(): Promise<void> {
+        this.disposeSession();
+        await this.updateContextKeys(vscode.window.activeTextEditor);
+    }
+
+    dispose(): void {
+        this.disposeSession();
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+        void vscode.commands.executeCommand("setContext", BLAME_ACTIVE_CONTEXT, false);
+        void vscode.commands.executeCommand("setContext", BLAME_SUPPORTED_CONTEXT, false);
+    }
+
+    private async handleActiveEditorChanged(
+        editor: vscode.TextEditor | undefined,
+    ): Promise<void> {
+        if (
+            editor &&
+            this.session &&
+            editor.document.uri.toString() === this.session.uri
+        ) {
+            this.applySessionToEditor(editor);
+        }
+        await this.updateContextKeys(editor);
+    }
+
+    private async handleSelectionChanged(
+        event: vscode.TextEditorSelectionChangeEvent,
+    ): Promise<void> {
+        if (!this.session) return;
+        if (event.kind !== vscode.TextEditorSelectionChangeKind.Mouse) return;
+        if (event.textEditor.document.uri.toString() !== this.session.uri) return;
+
+        const selection = event.selections[0];
+        if (!selection || selection.active.character !== 0) return;
+
+        const blameLine = this.session.linesByNumber.get(selection.active.line);
+        if (!blameLine || blameLine.isUncommitted) return;
+
+        await this.revealCommitInGraph(blameLine.commitHash);
+    }
+
+    private applySessionToEditor(editor: vscode.TextEditor): void {
+        if (!this.session) return;
+        editor.setDecorations(this.session.decorationType, this.session.decorations);
+    }
+
+    private disposeSession(): void {
+        if (!this.session) return;
+        this.session.decorationType.dispose();
+        this.session = null;
+    }
+
+    private getRepoRelativeFilePath(editor: vscode.TextEditor | undefined): string | null {
+        if (!editor || editor.document.uri.scheme !== "file") return null;
+        return getRepoRelativeFilePathFromUri(editor.document.uri, this.repoRoot);
+    }
+
+    private async updateContextKeys(editor: vscode.TextEditor | undefined): Promise<void> {
+        const supported = !!this.getRepoRelativeFilePath(editor);
+        const active = !!editor && !!this.session && editor.document.uri.toString() === this.session.uri;
+        await Promise.all([
+            vscode.commands.executeCommand("setContext", BLAME_SUPPORTED_CONTEXT, supported),
+            vscode.commands.executeCommand("setContext", BLAME_ACTIVE_CONTEXT, active),
+        ]);
+    }
+}
+
+function buildBlameDecorations(lines: GitBlameLine[]): vscode.DecorationOptions[] {
+    const labels = lines.map((line) => formatBlameLabel(line));
+    const maxLabelLength = labels.reduce((max, label) => Math.max(max, label.length), 0);
+
+    return lines.map((line, index) => {
+        const label = labels[index].padEnd(maxLabelLength, " ");
+        const style = line.isUncommitted ? UNCOMMITTED_STYLE : resolveCommitStyle(line.commitHash);
+        return {
+            range: new vscode.Range(line.line, 0, line.line, 0),
+            hoverMessage: buildHoverMessage(line),
+            renderOptions: {
+                before: {
+                    contentText: ` ${label} `,
+                    color: "rgba(188, 194, 205, 0.94)",
+                    backgroundColor: style.backgroundColor,
+                    margin: "0 1.2em 0 0",
+                    borderRadius: "3px 0 0 3px",
+                    borderColor: style.borderColor,
+                    borderStyle: "solid",
+                    borderWidth: "0 0 0 3px",
+                    padding: "0 6px",
+                    width: `${maxLabelLength + 2}ch`,
+                    fontStyle: "normal",
+                    fontWeight: "400",
+                    textDecoration: "none; display: inline-block;",
+                },
+            },
+        };
+    });
+}
+
+function formatBlameLabel(line: GitBlameLine): string {
+    const date = line.date.trim();
+    const author = line.author.trim();
+    if (!date) return author;
+    if (!author) return date;
+    return `${date} ${author}`;
+}
+
+function buildHoverMessage(line: GitBlameLine): vscode.MarkdownString {
+    const md = new vscode.MarkdownString(undefined, true);
+    if (line.isUncommitted) {
+        md.appendMarkdown("**Not Committed Yet**");
+        return md;
+    }
+    md.appendMarkdown(`**${line.shortHash}**`);
+    if (line.summary) {
+        md.appendMarkdown(`  \n${escapeMarkdown(line.summary)}`);
+    }
+    const meta: string[] = [];
+    if (line.author) meta.push(escapeMarkdown(line.author));
+    if (line.date) meta.push(escapeMarkdown(line.date));
+    if (meta.length > 0) {
+        md.appendMarkdown(`  \n${meta.join(" • ")}`);
+    }
+    md.appendMarkdown(`  \n\`${line.commitHash}\``);
+    return md;
+}
+
+function escapeMarkdown(value: string): string {
+    return value.replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1");
+}
+
+function resolveCommitStyle(commitHash: string): BlameStyle {
+    let hash = 0;
+    for (let i = 0; i < commitHash.length; i += 1) {
+        hash = (hash * 33 + commitHash.charCodeAt(i)) >>> 0;
+    }
+    const hue = hash % 360;
+    const saturation = 52 + (hash % 14);
+    const lightness = 56 + (hash % 8);
+    return {
+        borderColor: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.95)`,
+        backgroundColor: `hsla(${hue}, ${Math.max(38, saturation - 8)}%, ${Math.min(
+            78,
+            lightness + 10,
+        )}%, 0.14)`,
+    };
+}

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -14,6 +14,178 @@ import { getCommitParentHashes, pickMainlineParent, buildCommitFilePatch } from 
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { EMPTY_TREE_HASH } from "../utils/constants";
 
+const DIFF_DOCUMENT_SCHEME = "intelligit-diff";
+const DIFF_EDITABLE_SCHEME = "intelligit-diff-editable";
+
+class IntelliGitDiffContentProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
+    private readonly contents = new Map<string, string>();
+    private readonly changeEmitter = new vscode.EventEmitter<vscode.Uri>();
+    private nextId = 1;
+
+    readonly onDidChange = this.changeEmitter.event;
+
+    createUri(filePath: string, ref: string, content: string): vscode.Uri {
+        const uri = vscode.Uri.from({
+            scheme: DIFF_DOCUMENT_SCHEME,
+            path: `/${normalizeGitPath(filePath)}`,
+            query: new URLSearchParams({
+                ref,
+                id: String(this.nextId++),
+            }).toString(),
+        });
+        this.contents.set(uri.toString(), content);
+        return uri;
+    }
+
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        return this.contents.get(uri.toString()) ?? "";
+    }
+
+    release(uri: vscode.Uri): void {
+        this.contents.delete(uri.toString());
+    }
+
+    dispose(): void {
+        this.contents.clear();
+        this.changeEmitter.dispose();
+    }
+}
+
+class IntelliGitEditableDiffFileSystemProvider
+    implements vscode.FileSystemProvider, vscode.Disposable
+{
+    private readonly files = new Map<string, Uint8Array>();
+    private readonly changeEmitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+    private nextId = 1;
+
+    readonly onDidChangeFile = this.changeEmitter.event;
+
+    createUri(filePath: string, ref: string, content: string): vscode.Uri {
+        const uri = vscode.Uri.from({
+            scheme: DIFF_EDITABLE_SCHEME,
+            path: `/${normalizeGitPath(filePath)}`,
+            query: new URLSearchParams({
+                ref,
+                id: String(this.nextId++),
+            }).toString(),
+        });
+        this.files.set(uri.toString(), Buffer.from(content, "utf8"));
+        return uri;
+    }
+
+    watch(): vscode.Disposable {
+        return new vscode.Disposable(() => {});
+    }
+
+    stat(uri: vscode.Uri): vscode.FileStat {
+        const content = this.files.get(uri.toString());
+        if (!content) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        const now = Date.now();
+        return {
+            type: vscode.FileType.File,
+            ctime: now,
+            mtime: now,
+            size: content.byteLength,
+        };
+    }
+
+    readDirectory(): [string, vscode.FileType][] {
+        return [];
+    }
+
+    createDirectory(): void {
+        throw vscode.FileSystemError.NoPermissions("Directory operations are not supported.");
+    }
+
+    readFile(uri: vscode.Uri): Uint8Array {
+        const content = this.files.get(uri.toString());
+        if (!content) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        return content;
+    }
+
+    writeFile(uri: vscode.Uri, content: Uint8Array): void {
+        this.files.set(uri.toString(), content);
+        this.changeEmitter.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+    }
+
+    delete(uri: vscode.Uri): void {
+        this.files.delete(uri.toString());
+        this.changeEmitter.fire([{ type: vscode.FileChangeType.Deleted, uri }]);
+    }
+
+    rename(oldUri: vscode.Uri, newUri: vscode.Uri): void {
+        const content = this.files.get(oldUri.toString());
+        if (!content) {
+            throw vscode.FileSystemError.FileNotFound(oldUri);
+        }
+        this.files.delete(oldUri.toString());
+        this.files.set(newUri.toString(), content);
+        this.changeEmitter.fire([
+            { type: vscode.FileChangeType.Deleted, uri: oldUri },
+            { type: vscode.FileChangeType.Created, uri: newUri },
+        ]);
+    }
+
+    release(uri: vscode.Uri): void {
+        this.files.delete(uri.toString());
+    }
+
+    dispose(): void {
+        this.files.clear();
+        this.changeEmitter.dispose();
+    }
+}
+
+let diffContentProvider: IntelliGitDiffContentProvider | null = null;
+let editableDiffProvider: IntelliGitEditableDiffFileSystemProvider | null = null;
+
+export function registerDiffContentProvider(subscriptions: vscode.Disposable[]): void {
+    if (diffContentProvider && editableDiffProvider) return;
+
+    diffContentProvider = new IntelliGitDiffContentProvider();
+    editableDiffProvider = new IntelliGitEditableDiffFileSystemProvider();
+    subscriptions.push(
+        vscode.workspace.registerTextDocumentContentProvider(
+            DIFF_DOCUMENT_SCHEME,
+            diffContentProvider,
+        ),
+        vscode.workspace.registerFileSystemProvider(
+            DIFF_EDITABLE_SCHEME,
+            editableDiffProvider,
+            { isCaseSensitive: true },
+        ),
+        vscode.workspace.onDidCloseTextDocument((document) => {
+            if (document.uri.scheme === DIFF_DOCUMENT_SCHEME) {
+                diffContentProvider?.release(document.uri);
+                return;
+            }
+            if (document.uri.scheme === DIFF_EDITABLE_SCHEME) {
+                editableDiffProvider?.release(document.uri);
+            }
+        }),
+        diffContentProvider,
+        editableDiffProvider,
+    );
+}
+
+function getDiffContentProvider(): IntelliGitDiffContentProvider {
+    if (!diffContentProvider) {
+        throw new Error("IntelliGit diff content provider is not registered.");
+    }
+    return diffContentProvider;
+}
+
+function getEditableDiffProvider(): IntelliGitEditableDiffFileSystemProvider {
+    if (!editableDiffProvider) {
+        throw new Error("IntelliGit editable diff provider is not registered.");
+    }
+    return editableDiffProvider;
+}
+
 export function normalizeGitPath(fsPathValue: string): string {
     return fsPathValue.split(path.sep).join("/");
 }
@@ -53,21 +225,6 @@ export function getCommitInfoFileContext(value: unknown): CommitInfoFileContext 
     return { filePath, commitHash, commitShortHash };
 }
 
-async function closeTemporaryDiffSourceTab(uri: vscode.Uri): Promise<void> {
-    const matchingTab = vscode.window.tabGroups.all
-        .flatMap((group) => group.tabs)
-        .find((tab) => {
-            const input = tab.input;
-            return input instanceof vscode.TabInputText && input.uri.toString() === uri.toString();
-        });
-    if (!matchingTab) return;
-    try {
-        await vscode.window.tabGroups.close(matchingTab, true);
-    } catch {
-        // Best-effort cleanup only; diff view is already open.
-    }
-}
-
 export async function openDiffAgainstGitRef(
     fileUri: vscode.Uri,
     repoRelativeFilePath: string,
@@ -78,15 +235,12 @@ export async function openDiffAgainstGitRef(
     const trimmedRef = ref.trim();
     if (!trimmedRef) return;
 
-    const currentDoc = await vscode.workspace.openTextDocument(fileUri);
     const refContent = await gitOps.getFileContentAtRef(repoRelativeFilePath, trimmedRef);
-    const leftDoc = await vscode.workspace.openTextDocument({
-        content: refContent,
-        language: currentDoc.languageId,
-    });
+    const leftDoc = await vscode.workspace.openTextDocument(
+        getDiffContentProvider().createUri(repoRelativeFilePath, trimmedRef, refContent),
+    );
     const title = `${repoRelativeFilePath} (${sourceLabel}: ${trimmedRef}) <-> Working Tree`;
     await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, fileUri, title);
-    await closeTemporaryDiffSourceTab(leftDoc.uri);
 }
 
 export async function openCommitFileDiff(
@@ -131,27 +285,17 @@ export async function openCommitFileDiff(
         rightContent = "";
     }
 
-    // Detect language from the working tree file if it exists on disk.
-    let language: string | undefined;
-    const diskPath = path.join(repoRoot, safePath);
-    try {
-        const diskDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(diskPath));
-        language = diskDoc.languageId;
-    } catch {
-        // File may not exist on disk (deleted or only in history).
-    }
-
-    const leftDoc = await vscode.workspace.openTextDocument({ content: leftContent, language });
-    const rightDoc = await vscode.workspace.openTextDocument({
-        content: rightContent,
-        language,
-    });
+    const diffProvider = getDiffContentProvider();
+    const leftDoc = await vscode.workspace.openTextDocument(
+        diffProvider.createUri(safePath, parentRef, leftContent),
+    );
+    const rightDoc = await vscode.workspace.openTextDocument(
+        getEditableDiffProvider().createUri(safePath, commitHash, rightContent),
+    );
     const shortParent = parentDisplayHash.slice(0, 8);
     const shortCommit = commitHash.slice(0, 8);
     const title = `${safePath} (${shortParent} ↔ ${shortCommit})`;
     await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, rightDoc.uri, title);
-    await closeTemporaryDiffSourceTab(leftDoc.uri);
-    await closeTemporaryDiffSourceTab(rightDoc.uri);
 }
 
 export async function applyPatchTextToRepo(

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,16 @@ export interface StashEntry {
     hash: string;
 }
 
+export interface GitBlameLine {
+    line: number;
+    commitHash: string;
+    shortHash: string;
+    author: string;
+    date: string;
+    summary: string;
+    isUncommitted: boolean;
+}
+
 export type MergeConflictSideState = "Modified" | "Added" | "Deleted";
 
 export interface MergeConflictFile {

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";
-import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
+import type { Branch, Commit, CommitDetail, ThemeFolderIconMap } from "../types";
 import type {
     BranchAction,
     CommitAction,
@@ -24,11 +24,14 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     private filterText = "";
     private offset = 0;
     private loadingMore = false;
+    private webviewReady = false;
+    private pendingRevealHash: string | null = null;
     private requestSeq = 0;
     private readonly PAGE_SIZE = 500;
 
     private branches: Branch[] = [];
     private selectedCommitDetail: CommitDetail | null = null;
+    private loadedCommits: Commit[] = [];
     private folderIconsByName: ThemeFolderIconMap = {};
     private branchFolderIconsByName: ThemeFolderIconMap = {};
     private commitDetailSeq = 0;
@@ -74,6 +77,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this.disposeThemeChangeDisposables();
         this.iconTheme.dispose();
         this.view = webviewView;
+        this.webviewReady = false;
 
         webviewView.webview.options = {
             enableScripts: true,
@@ -85,6 +89,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         webviewView.onDidDispose(() => {
             if (this.view === webviewView) {
                 this.view = undefined;
+                this.webviewReady = false;
                 this.iconTheme.dispose();
                 this.disposeThemeChangeDisposables();
             }
@@ -96,10 +101,16 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
             try {
                 switch (msg.type) {
                     case "ready":
+                        this.webviewReady = true;
                         await this.iconTheme.initIconThemeData();
                         await this.sendBranches();
                         await this.loadInitial();
                         this.postCommitDetailState();
+                        if (this.pendingRevealHash) {
+                            const hash = this.pendingRevealHash;
+                            this.pendingRevealHash = null;
+                            await this.revealCommit(hash);
+                        }
                         break;
                     case "selectCommit":
                         this._onCommitSelected.fire(msg.hash);
@@ -115,6 +126,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
                         this.filterText = "";
                         this._onBranchFilterChanged.fire(msg.branch);
                         this.postToWebview({ type: "setSelectedBranch", branch: msg.branch });
+                        this.postToWebview({ type: "setFilterText", text: "" });
                         await this.loadInitial();
                         break;
                     case "branchAction":
@@ -156,6 +168,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this.currentBranch = branch;
         this.filterText = "";
         this.postToWebview({ type: "setSelectedBranch", branch });
+        this.postToWebview({ type: "setFilterText", text: "" });
         await this.loadInitial();
     }
 
@@ -182,6 +195,58 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this.selectedCommitDetail = null;
         this.folderIconsByName = {};
         this.postCommitDetailState();
+    }
+
+    async revealCommit(hash: string): Promise<void> {
+        this.pendingRevealHash = hash;
+        if (!this.webviewReady) return;
+
+        const requestId = ++this.requestSeq;
+        this.loadingMore = false;
+        this.currentBranch = null;
+        this.filterText = "";
+        this.postToWebview({ type: "setSelectedBranch", branch: null });
+        this.postToWebview({ type: "setFilterText", text: "" });
+
+        try {
+            const [loadResult, unpushedHashes] = await Promise.all([
+                this.loadCommitsUntilHash(hash, requestId),
+                this.gitOps.getUnpushedCommitHashes(),
+            ]);
+            if (requestId !== this.requestSeq) return;
+            const commits = loadResult.commits;
+            const foundCommit = commits.find((commit) => commit.hash === hash) ?? null;
+            this.loadedCommits = commits;
+            this.offset = commits.length;
+            this.postToWebview({
+                type: "loadCommits",
+                commits,
+                hasMore: loadResult.hasMore,
+                append: false,
+                unpushedHashes,
+            });
+
+            if (!foundCommit) {
+                if (this.pendingRevealHash === hash) {
+                    this.pendingRevealHash = null;
+                }
+                vscode.window.showWarningMessage(`Commit '${hash.slice(0, 8)}' was not found.`);
+                return;
+            }
+
+            const detail = await this.gitOps.getCommitDetail(hash);
+            if (requestId !== this.requestSeq) return;
+            this.setCommitDetail(detail);
+            this.postToWebview({ type: "revealCommit", hash });
+            if (this.pendingRevealHash === hash) {
+                this.pendingRevealHash = null;
+            }
+        } catch (err) {
+            if (requestId !== this.requestSeq) return;
+            const message = getErrorMessage(err);
+            vscode.window.showErrorMessage(`Commit graph error: ${message}`);
+            this.postToWebview({ type: "error", message });
+        }
     }
 
     private async sendBranches(): Promise<void> {
@@ -219,6 +284,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
             ]);
             if (requestId !== this.requestSeq) return;
             this.offset = commits.length;
+            this.loadedCommits = commits;
             this.postToWebview({
                 type: "loadCommits",
                 commits,
@@ -250,6 +316,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
             ]);
             if (requestId !== this.requestSeq) return;
             this.offset += commits.length;
+            this.loadedCommits = [...this.loadedCommits, ...commits];
             this.postToWebview({
                 type: "loadCommits",
                 commits,
@@ -272,6 +339,27 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     private async filterByText(text: string): Promise<void> {
         this.filterText = text;
         await this.loadInitial();
+    }
+
+    private async loadCommitsUntilHash(
+        hash: string,
+        requestId: number,
+    ): Promise<{ commits: Commit[]; hasMore: boolean }> {
+        const commits: Commit[] = [];
+        let skip = 0;
+
+        for (;;) {
+            const page = await this.gitOps.getLog(this.PAGE_SIZE, undefined, undefined, skip);
+            if (requestId !== this.requestSeq) return { commits, hasMore: false };
+            commits.push(...page);
+            if (page.some((commit) => commit.hash === hash)) {
+                return { commits, hasMore: page.length >= this.PAGE_SIZE };
+            }
+            if (page.length < this.PAGE_SIZE) {
+                return { commits, hasMore: false };
+            }
+            skip += page.length;
+        }
     }
 
     private postToWebview(msg: CommitGraphInbound): void {

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -234,12 +234,20 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
                 return;
             }
 
-            const detail = await this.gitOps.getCommitDetail(hash);
-            if (requestId !== this.requestSeq) return;
-            this.setCommitDetail(detail);
             this.postToWebview({ type: "revealCommit", hash });
             if (this.pendingRevealHash === hash) {
                 this.pendingRevealHash = null;
+            }
+
+            try {
+                const detail = await this.gitOps.getCommitDetail(hash);
+                if (requestId !== this.requestSeq) return;
+                this.setCommitDetail(detail);
+            } catch (err) {
+                if (requestId !== this.requestSeq) return;
+                const message = getErrorMessage(err);
+                vscode.window.showErrorMessage(`Commit graph error: ${message}`);
+                this.postToWebview({ type: "error", message });
             }
         } catch (err) {
             if (requestId !== this.requestSeq) return;

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -218,9 +218,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     push ? "Committing and pushing..." : "Committing...",
                     async () => {
                         if (push) {
-                            await this.gitOps.commitAndPush(message, amend);
+                            await this.gitOps.commitAndPush(message, amend, paths);
                         } else {
-                            await this.gitOps.commit(message, amend);
+                            await this.gitOps.commit(message, amend, paths);
                         }
                     },
                 );

--- a/src/webviews/react/CommitGraphApp.tsx
+++ b/src/webviews/react/CommitGraphApp.tsx
@@ -97,6 +97,7 @@ function App(): React.ReactElement {
     const [commits, setCommits] = useState<Commit[]>([]);
     const [branches, setBranches] = useState<Branch[]>([]);
     const [selectedHash, setSelectedHash] = useState<string | null>(null);
+    const [revealHash, setRevealHash] = useState<string | null>(null);
     const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
     const [hasMore, setHasMore] = useState(false);
     const [filterText, setFilterText] = useState("");
@@ -182,6 +183,9 @@ function App(): React.ReactElement {
                 case "setSelectedBranch":
                     setSelectedBranch(data.branch ?? null);
                     break;
+                case "setFilterText":
+                    setFilterText(data.text);
+                    break;
                 case "setCommitDetail":
                     setSelectedDetail(data.detail);
                     setCommitFolderIcon(data.folderIcon);
@@ -194,6 +198,10 @@ function App(): React.ReactElement {
                     setCommitFolderIcon(undefined);
                     setCommitFolderExpandedIcon(undefined);
                     setCommitFolderIconsByName(undefined);
+                    break;
+                case "revealCommit":
+                    setSelectedHash(data.hash);
+                    setRevealHash(data.hash);
                     break;
                 case "loadError":
                     if (!loadingMore.current) {
@@ -224,6 +232,7 @@ function App(): React.ReactElement {
 
     const handleSelectCommit = useCallback((hash: string) => {
         setSelectedHash(hash);
+        setRevealHash(null);
         vscode.postMessage({ type: "selectCommit", hash });
     }, []);
 
@@ -294,6 +303,7 @@ function App(): React.ReactElement {
                         <CommitList
                             commits={commits}
                             selectedHash={selectedHash}
+                            revealHash={revealHash}
                             filterText={filterText}
                             hasMore={hasMore}
                             unpushedHashes={unpushedHashes}

--- a/src/webviews/react/CommitList.tsx
+++ b/src/webviews/react/CommitList.tsx
@@ -34,6 +34,7 @@ const MAX_GRAPH_WIDTH = 200;
 interface Props {
     commits: Commit[];
     selectedHash: string | null;
+    revealHash: string | null;
     filterText: string;
     hasMore: boolean;
     unpushedHashes: Set<string>;
@@ -47,6 +48,7 @@ interface Props {
 export function CommitList({
     commits,
     selectedHash,
+    revealHash,
     filterText,
     hasMore,
     unpushedHashes,
@@ -172,6 +174,18 @@ export function CommitList({
         () => commits.slice(visibleRange.start, visibleRange.end),
         [commits, visibleRange.end, visibleRange.start],
     );
+
+    useEffect(() => {
+        if (!revealHash) return;
+        const viewport = viewportRef.current;
+        if (!viewport) return;
+        const index = commits.findIndex((commit) => commit.hash === revealHash);
+        if (index < 0) return;
+
+        const centeredTop = Math.max(0, index * ROW_HEIGHT - (viewport.clientHeight - ROW_HEIGHT) / 2);
+        viewport.scrollTop = centeredTop;
+        setScrollTop(centeredTop);
+    }, [commits, revealHash]);
 
     return (
         <div style={ROOT_STYLE}>

--- a/src/webviews/react/commitGraphTypes.ts
+++ b/src/webviews/react/commitGraphTypes.ts
@@ -78,6 +78,7 @@ export type CommitGraphInbound =
           iconFonts?: ThemeIconFont[];
       }
     | { type: "setSelectedBranch"; branch: string | null }
+    | { type: "setFilterText"; text: string }
     | {
           type: "setCommitDetail";
           detail: CommitDetail;
@@ -86,6 +87,7 @@ export type CommitGraphInbound =
           folderIconsByName?: ThemeFolderIconMap;
           iconFonts?: ThemeIconFont[];
       }
+    | { type: "revealCommit"; hash: string }
     | { type: "clearCommitDetail" }
     | { type: "loadError"; message: string }
     | { type: "error"; message: string };

--- a/tests/unit/editor-blame-controller.test.ts
+++ b/tests/unit/editor-blame-controller.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ActiveEditorListener = (editor: MockTextEditor | undefined) => void;
+type SelectionListener = (event: {
+    textEditor: MockTextEditor;
+    selections: Array<{ active: { line: number; character: number } }>;
+    kind?: number;
+}) => void;
+
+type MockTextEditor = {
+    document: {
+        uri: {
+            scheme: string;
+            fsPath: string;
+            toString: () => string;
+        };
+    };
+    setDecorations: ReturnType<typeof vi.fn>;
+};
+
+const executeCommand = vi.fn(async () => undefined);
+const showWarningMessage = vi.fn(async () => undefined);
+const showErrorMessage = vi.fn(async () => undefined);
+const createTextEditorDecorationType = vi.fn(() => ({ dispose: vi.fn() }));
+
+let activeEditor: MockTextEditor | undefined;
+const activeEditorListeners: ActiveEditorListener[] = [];
+const selectionListeners: SelectionListener[] = [];
+
+vi.mock("vscode", () => ({
+    Range: class {
+        constructor(
+            public startLine: number,
+            public startCharacter: number,
+            public endLine: number,
+            public endCharacter: number,
+        ) {}
+    },
+    MarkdownString: class {
+        value = "";
+        constructor(_value?: string, _supportThemeIcons?: boolean) {}
+        appendMarkdown(markdown: string) {
+            this.value += markdown;
+            return this;
+        }
+    },
+    TextEditorSelectionChangeKind: {
+        Mouse: 1,
+        Keyboard: 2,
+    },
+    window: {
+        get activeTextEditor() {
+            return activeEditor;
+        },
+        createTextEditorDecorationType,
+        showWarningMessage,
+        showErrorMessage,
+        onDidChangeActiveTextEditor: vi.fn((listener: ActiveEditorListener) => {
+            activeEditorListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
+        onDidChangeTextEditorSelection: vi.fn((listener: SelectionListener) => {
+            selectionListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
+    },
+    commands: {
+        executeCommand,
+    },
+}));
+
+function makeEditor(fsPath: string, scheme: string = "file"): MockTextEditor {
+    return {
+        document: {
+            uri: {
+                scheme,
+                fsPath,
+                toString: () => `${scheme}:${fsPath}`,
+            },
+        },
+        setDecorations: vi.fn(),
+    };
+}
+
+async function emitActiveEditorChanged(editor: MockTextEditor | undefined): Promise<void> {
+    activeEditor = editor;
+    for (const listener of activeEditorListeners) {
+        await listener(editor);
+    }
+}
+
+async function emitSelectionChanged(
+    editor: MockTextEditor,
+    line: number,
+    character: number,
+    kind: number,
+): Promise<void> {
+    for (const listener of selectionListeners) {
+        await listener({
+            textEditor: editor,
+            selections: [{ active: { line, character } }],
+            kind,
+        });
+    }
+}
+
+describe("EditorBlameController", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        activeEditor = undefined;
+        activeEditorListeners.length = 0;
+        selectionListeners.length = 0;
+    });
+
+    it("annotates the active repo file and keeps same-commit colors stable", async () => {
+        const { EditorBlameController } = await import("../../src/services/EditorBlameController");
+        const gitOps = {
+            getBlame: vi.fn(async () => [
+                {
+                    line: 0,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2026/3/18",
+                    summary: "First summary",
+                    isUncommitted: false,
+                },
+                {
+                    line: 1,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2026/3/18",
+                    summary: "First summary",
+                    isUncommitted: false,
+                },
+                {
+                    line: 2,
+                    commitHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    shortHash: "bbbbbbbb",
+                    author: "Bob",
+                    date: "2026/3/23",
+                    summary: "Second summary",
+                    isUncommitted: false,
+                },
+            ]),
+        };
+        const revealCommit = vi.fn(async () => undefined);
+        const controller = new EditorBlameController(
+            "/repo",
+            gitOps as never,
+            revealCommit,
+        );
+        const editor = makeEditor("/repo/src/a.ts");
+        activeEditor = editor;
+
+        await controller.annotateActiveEditor();
+
+        expect(gitOps.getBlame).toHaveBeenCalledWith("src/a.ts");
+        expect(editor.setDecorations).toHaveBeenCalledTimes(1);
+        const decorations = editor.setDecorations.mock.calls[0]?.[1] as Array<{
+            renderOptions?: { before?: { backgroundColor?: string } };
+        }>;
+        expect(decorations).toHaveLength(3);
+        expect(decorations[0]?.renderOptions?.before?.backgroundColor).toBe(
+            decorations[1]?.renderOptions?.before?.backgroundColor,
+        );
+        expect(decorations[0]?.renderOptions?.before?.backgroundColor).not.toBe(
+            decorations[2]?.renderOptions?.before?.backgroundColor,
+        );
+        expect(String((decorations[0] as { hoverMessage?: { value?: string } }).hoverMessage?.value)).toContain(
+            "First summary",
+        );
+    });
+
+    it("reapplies blame when switching back to the same file", async () => {
+        const { EditorBlameController } = await import("../../src/services/EditorBlameController");
+        const gitOps = {
+            getBlame: vi.fn(async () => [
+                {
+                    line: 0,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2026/3/18",
+                    summary: "First summary",
+                    isUncommitted: false,
+                },
+            ]),
+        };
+        const controller = new EditorBlameController("/repo", gitOps as never, vi.fn(async () => undefined));
+        const firstEditor = makeEditor("/repo/src/a.ts");
+        const secondEditor = makeEditor("/repo/src/a.ts");
+        activeEditor = firstEditor;
+
+        await controller.annotateActiveEditor();
+        await emitActiveEditorChanged(undefined);
+        await emitActiveEditorChanged(secondEditor);
+
+        expect(secondEditor.setDecorations).toHaveBeenCalledTimes(1);
+    });
+
+    it("reveals commit only for mouse clicks at column zero on committed lines", async () => {
+        const vscode = await import("vscode");
+        const { EditorBlameController } = await import("../../src/services/EditorBlameController");
+        const revealCommit = vi.fn(async () => undefined);
+        const controller = new EditorBlameController(
+            "/repo",
+            {
+                getBlame: vi.fn(async () => [
+                    {
+                        line: 0,
+                        commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        shortHash: "aaaaaaaa",
+                        author: "Alice",
+                        date: "2026/3/18",
+                        summary: "First summary",
+                        isUncommitted: false,
+                    },
+                    {
+                        line: 1,
+                        commitHash: "0000000000000000000000000000000000000000",
+                        shortHash: "00000000",
+                        author: "Not Committed Yet",
+                        date: "2026/3/23",
+                        summary: "",
+                        isUncommitted: true,
+                    },
+                ]),
+            } as never,
+            revealCommit,
+        );
+        const editor = makeEditor("/repo/src/a.ts");
+        activeEditor = editor;
+
+        await controller.annotateActiveEditor();
+        await emitSelectionChanged(editor, 0, 1, vscode.TextEditorSelectionChangeKind.Mouse);
+        await emitSelectionChanged(editor, 0, 0, vscode.TextEditorSelectionChangeKind.Keyboard);
+        await emitSelectionChanged(editor, 1, 0, vscode.TextEditorSelectionChangeKind.Mouse);
+        await emitSelectionChanged(editor, 0, 0, vscode.TextEditorSelectionChangeKind.Mouse);
+
+        expect(revealCommit).toHaveBeenCalledTimes(1);
+        expect(revealCommit).toHaveBeenCalledWith(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+    });
+
+    it("clears decorations and warns for unsupported files", async () => {
+        const { EditorBlameController } = await import("../../src/services/EditorBlameController");
+        const controller = new EditorBlameController(
+            "/repo",
+            { getBlame: vi.fn(async () => []) } as never,
+            vi.fn(async () => undefined),
+        );
+        activeEditor = makeEditor("/other/outside.ts");
+
+        await controller.annotateActiveEditor();
+        await controller.clear();
+
+        expect(showWarningMessage).toHaveBeenCalled();
+        expect(createTextEditorDecorationType).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/editor-blame-controller.test.ts
+++ b/tests/unit/editor-blame-controller.test.ts
@@ -6,6 +6,7 @@ type SelectionListener = (event: {
     selections: Array<{ active: { line: number; character: number } }>;
     kind?: number;
 }) => void;
+type ThemeListener = () => void;
 
 type MockTextEditor = {
     document: {
@@ -26,6 +27,8 @@ const createTextEditorDecorationType = vi.fn(() => ({ dispose: vi.fn() }));
 let activeEditor: MockTextEditor | undefined;
 const activeEditorListeners: ActiveEditorListener[] = [];
 const selectionListeners: SelectionListener[] = [];
+const themeListeners: ThemeListener[] = [];
+let activeThemeKind = 2;
 
 vi.mock("vscode", () => ({
     Range: class {
@@ -36,6 +39,9 @@ vi.mock("vscode", () => ({
             public endCharacter: number,
         ) {}
     },
+    ThemeColor: class {
+        constructor(public readonly id: string) {}
+    },
     MarkdownString: class {
         value = "";
         constructor(_value?: string, _supportThemeIcons?: boolean) {}
@@ -44,6 +50,12 @@ vi.mock("vscode", () => ({
             return this;
         }
     },
+    ColorThemeKind: {
+        Light: 1,
+        Dark: 2,
+        HighContrast: 3,
+        HighContrastLight: 4,
+    },
     TextEditorSelectionChangeKind: {
         Mouse: 1,
         Keyboard: 2,
@@ -51,6 +63,9 @@ vi.mock("vscode", () => ({
     window: {
         get activeTextEditor() {
             return activeEditor;
+        },
+        get activeColorTheme() {
+            return { kind: activeThemeKind };
         },
         createTextEditorDecorationType,
         showWarningMessage,
@@ -61,6 +76,10 @@ vi.mock("vscode", () => ({
         }),
         onDidChangeTextEditorSelection: vi.fn((listener: SelectionListener) => {
             selectionListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
+        onDidChangeActiveColorTheme: vi.fn((listener: ThemeListener) => {
+            themeListeners.push(listener);
             return { dispose: vi.fn() };
         }),
     },
@@ -104,12 +123,21 @@ async function emitSelectionChanged(
     }
 }
 
+async function emitThemeChanged(kind: number): Promise<void> {
+    activeThemeKind = kind;
+    for (const listener of themeListeners) {
+        await listener();
+    }
+}
+
 describe("EditorBlameController", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         activeEditor = undefined;
+        activeThemeKind = 2;
         activeEditorListeners.length = 0;
         selectionListeners.length = 0;
+        themeListeners.length = 0;
     });
 
     it("annotates the active repo file and keeps same-commit colors stable", async () => {
@@ -170,6 +198,45 @@ describe("EditorBlameController", () => {
         );
         expect(String((decorations[0] as { hoverMessage?: { value?: string } }).hoverMessage?.value)).toContain(
             "First summary",
+        );
+        expect((decorations[0]?.renderOptions?.before as { color?: { id?: string } } | undefined)?.color?.id).toBe(
+            "editor.foreground",
+        );
+    });
+
+    it("recomputes blame colors when the active theme changes", async () => {
+        const vscode = await import("vscode");
+        const { EditorBlameController } = await import("../../src/services/EditorBlameController");
+        const gitOps = {
+            getBlame: vi.fn(async () => [
+                {
+                    line: 0,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2026/3/18",
+                    summary: "First summary",
+                    isUncommitted: false,
+                },
+            ]),
+        };
+        const controller = new EditorBlameController("/repo", gitOps as never, vi.fn(async () => undefined));
+        const editor = makeEditor("/repo/src/a.ts");
+        activeEditor = editor;
+
+        await controller.annotateActiveEditor();
+        const firstDecorations = editor.setDecorations.mock.calls[0]?.[1] as Array<{
+            renderOptions?: { before?: { backgroundColor?: string } };
+        }>;
+
+        await emitThemeChanged(vscode.ColorThemeKind.Light);
+
+        expect(editor.setDecorations).toHaveBeenCalledTimes(2);
+        const secondDecorations = editor.setDecorations.mock.calls[1]?.[1] as Array<{
+            renderOptions?: { before?: { backgroundColor?: string } };
+        }>;
+        expect(firstDecorations[0]?.renderOptions?.before?.backgroundColor).not.toBe(
+            secondDecorations[0]?.renderOptions?.before?.backgroundColor,
         );
     });
 

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -44,6 +44,7 @@ const withProgress = vi.fn(
 const registerWebviewViewProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const createTerminal = vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() }));
 const textDocListeners: Array<() => void> = [];
+const closeDocListeners: Array<(document: { uri: { scheme?: string; toString?: () => string } }) => void> = [];
 const saveDocListeners: Array<() => void> = [];
 const createFileListeners: Array<() => void> = [];
 const deleteFileListeners: Array<() => void> = [];
@@ -286,8 +287,29 @@ vi.mock("vscode", () => ({
     TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
     ViewColumn: { Active: -1, One: 1, Two: 2, Three: 3 },
     ProgressLocation: { Notification: 15 },
+    FileType: { File: 1 },
+    FileChangeType: { Changed: 1, Created: 2, Deleted: 3 },
+    FileSystemError: {
+        FileNotFound: (uri: unknown) => new Error(`File not found: ${String(uri)}`),
+        NoPermissions: (message: string) => new Error(message),
+    },
     Uri: {
         file: (value: string) => ({ fsPath: value, path: value }),
+        from: ({
+            scheme,
+            path,
+            query,
+        }: {
+            scheme: string;
+            path: string;
+            query?: string;
+        }) => ({
+            scheme,
+            path,
+            query,
+            fsPath: path,
+            toString: () => `${scheme}:${path}${query ? `?${query}` : ""}`,
+        }),
         joinPath: (base: { fsPath?: string; path?: string }, ...parts: string[]) => {
             const prefix = base.fsPath ?? base.path ?? "";
             const joined = [prefix, ...parts].join("/").replace(/\/+/g, "/");
@@ -353,8 +375,14 @@ vi.mock("vscode", () => ({
         },
         fs: { writeFile },
         openTextDocument,
+        registerTextDocumentContentProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        registerFileSystemProvider: vi.fn(() => ({ dispose: vi.fn() })),
         onDidChangeTextDocument: vi.fn((listener: () => void) => {
             textDocListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
+        onDidCloseTextDocument: vi.fn((listener: (document: { uri: { scheme?: string; toString?: () => string } }) => void) => {
+            closeDocListeners.push(listener);
             return { dispose: vi.fn() };
         }),
         onDidSaveTextDocument: vi.fn((listener: () => void) => {
@@ -459,6 +487,7 @@ describe("extension integration", () => {
         registeredCommands.clear();
         mockDisposables.length = 0;
         textDocListeners.length = 0;
+        closeDocListeners.length = 0;
         saveDocListeners.length = 0;
         createFileListeners.length = 0;
         deleteFileListeners.length = 0;
@@ -468,6 +497,10 @@ describe("extension integration", () => {
         latestCommitGraphProvider = undefined;
         latestCommitPanelProvider = undefined;
         latestBlameController = undefined;
+        openTextDocument.mockImplementation(async (arg: unknown) => ({
+            uri: arg,
+            languageId: "typescript",
+        }));
 
         executorRun.mockImplementation(defaultExecutorRunImpl);
         gitOpsState.isRepository.mockResolvedValue(true);
@@ -945,24 +978,6 @@ describe("extension integration", () => {
             subscriptions: [],
         } as unknown as MockExtensionContext;
 
-        openTextDocument.mockImplementation(async (arg: unknown) => {
-            if (arg && typeof arg === "object" && "content" in (arg as Record<string, unknown>)) {
-                const contentDoc = arg as { content: string };
-                return {
-                    uri: {
-                        toString: () => `untitled:${contentDoc.content}`,
-                    },
-                    languageId: "typescript",
-                };
-            }
-            return {
-                uri: {
-                    toString: () => JSON.stringify(arg),
-                },
-                languageId: "typescript",
-            };
-        });
-
         await activate(context);
 
         executeCommandFallback.mockClear();
@@ -982,12 +997,13 @@ describe("extension integration", () => {
             "src/feature.ts",
             "a1b2c3d4",
         );
-        expect(executeCommandFallback).toHaveBeenCalledWith(
-            "vscode.diff",
-            expect.anything(),
-            expect.anything(),
-            "src/feature.ts (parent1 ↔ a1b2c3d4)",
+        const diffCall = executeCommandFallback.mock.calls.find(
+            (call) => call[0] === "vscode.diff",
         );
+        expect(diffCall).toBeDefined();
+        expect(diffCall?.[1]).toMatchObject({ scheme: "intelligit-diff" });
+        expect(diffCall?.[2]).toMatchObject({ scheme: "intelligit-diff-editable" });
+        expect(diffCall?.[3]).toBe("src/feature.ts (parent1 ↔ a1b2c3d4)");
     });
 
     it("prompts merge parent selection before opening commit file diff", async () => {
@@ -998,24 +1014,6 @@ describe("extension integration", () => {
         } as unknown as MockExtensionContext;
 
         showQuickPick.mockResolvedValueOnce({ parentNumber: 2 });
-        openTextDocument.mockImplementation(async (arg: unknown) => {
-            if (arg && typeof arg === "object" && "content" in (arg as Record<string, unknown>)) {
-                const contentDoc = arg as { content: string };
-                return {
-                    uri: {
-                        toString: () => `untitled:${contentDoc.content}`,
-                    },
-                    languageId: "typescript",
-                };
-            }
-            return {
-                uri: {
-                    toString: () => JSON.stringify(arg),
-                },
-                languageId: "typescript",
-            };
-        });
-
         await activate(context);
 
         executeCommandFallback.mockClear();
@@ -1036,12 +1034,13 @@ describe("extension integration", () => {
             "src/feature.ts",
             "deadbee",
         );
-        expect(executeCommandFallback).toHaveBeenCalledWith(
-            "vscode.diff",
-            expect.anything(),
-            expect.anything(),
-            "src/feature.ts (parent2 ↔ deadbee)",
+        const diffCall = executeCommandFallback.mock.calls.find(
+            (call) => call[0] === "vscode.diff",
         );
+        expect(diffCall).toBeDefined();
+        expect(diffCall?.[1]).toMatchObject({ scheme: "intelligit-diff" });
+        expect(diffCall?.[2]).toMatchObject({ scheme: "intelligit-diff-editable" });
+        expect(diffCall?.[3]).toBe("src/feature.ts (parent2 ↔ deadbee)");
     });
 
     it("covers activation guards and debounced refresh sources", async () => {

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -171,6 +171,7 @@ type MockExtensionContext = {
 
 let latestCommitGraphProvider: MockCommitGraphViewProvider | undefined;
 let latestCommitPanelProvider: MockCommitPanelViewProvider | undefined;
+let latestBlameController: MockEditorBlameController | undefined;
 
 class MockCommitGraphViewProvider {
     static readonly viewType = "intelligit.commitGraph";
@@ -198,6 +199,7 @@ class MockCommitGraphViewProvider {
     setBranches = vi.fn();
     refresh = vi.fn(async () => undefined);
     filterByBranch = vi.fn(async () => undefined);
+    revealCommit = vi.fn(async () => undefined);
     setCommitDetail = vi.fn();
     clearCommitDetail = vi.fn();
     dispose = vi.fn();
@@ -244,6 +246,21 @@ class MockCommitPanelViewProvider {
     emitFileCount(count: number): void {
         this.fileCountEmitter.fire(count);
     }
+}
+
+class MockEditorBlameController {
+    constructor(
+        _repoRoot: string,
+        _gitOps: unknown,
+        _revealCommitInGraph: (hash: string) => Promise<void>,
+    ) {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        latestBlameController = this;
+    }
+    initialize = vi.fn(async () => undefined);
+    annotateActiveEditor = vi.fn(async () => undefined);
+    clear = vi.fn(async () => undefined);
+    dispose = vi.fn();
 }
 
 vi.mock("fs", () => ({
@@ -406,6 +423,10 @@ vi.mock("../../src/views/CommitPanelViewProvider", () => ({
     CommitPanelViewProvider: MockCommitPanelViewProvider,
 }));
 
+vi.mock("../../src/services/EditorBlameController", () => ({
+    EditorBlameController: MockEditorBlameController,
+}));
+
 vi.mock("../../src/utils/fileOps", async () => {
     const actual = await vi.importActual("../../src/utils/fileOps");
     return {
@@ -446,6 +467,7 @@ describe("extension integration", () => {
         workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         latestCommitGraphProvider = undefined;
         latestCommitPanelProvider = undefined;
+        latestBlameController = undefined;
 
         executorRun.mockImplementation(defaultExecutorRunImpl);
         gitOpsState.isRepository.mockResolvedValue(true);
@@ -554,6 +576,9 @@ describe("extension integration", () => {
         expect(registeredCommands.has("intelligit.conflictAcceptYours")).toBe(true);
         expect(registeredCommands.has("intelligit.conflictAcceptTheirs")).toBe(true);
         expect(registeredCommands.has("intelligit.openConflictSession")).toBe(true);
+        expect(registeredCommands.has("intelligit.annotateWithGitBlame")).toBe(true);
+        expect(registeredCommands.has("intelligit.clearGitBlame")).toBe(true);
+        expect(registeredCommands.has("intelligit.revealCommitInGraph")).toBe(true);
 
         function getCommand(id: string): CommandHandler {
             const cmd = registeredCommands.get(id);
@@ -564,6 +589,9 @@ describe("extension integration", () => {
         await getCommand("intelligit.refresh")();
         await getCommand("intelligit.filterByBranch")("main");
         await getCommand("intelligit.showGitLog")();
+        await getCommand("intelligit.annotateWithGitBlame")();
+        await getCommand("intelligit.clearGitBlame")();
+        await getCommand("intelligit.revealCommitInGraph")("deadbee");
 
         await getCommand("intelligit.checkout")({
             branch: { name: "feature-local", isRemote: false },
@@ -630,6 +658,10 @@ describe("extension integration", () => {
             expect.any(Function),
         );
         expect(deleteFileWithFallback).toHaveBeenCalled();
+        expect(latestBlameController!.initialize).toHaveBeenCalled();
+        expect(latestBlameController!.annotateActiveEditor).toHaveBeenCalled();
+        expect(latestBlameController!.clear).toHaveBeenCalled();
+        expect(latestCommitGraphProvider!.revealCommit).toHaveBeenCalledWith("deadbee");
     });
 
     it("updates non-current local branch via fetch refspec without checkout", async () => {
@@ -698,10 +730,6 @@ describe("extension integration", () => {
             expect.any(Number),
             expect.objectContaining({ enableScripts: true }),
         );
-        expect(showWarningMessage).toHaveBeenCalledWith(
-            expect.stringContaining("unresolved conflict file"),
-        );
-        expect(showErrorMessage).not.toHaveBeenCalledWith(expect.stringContaining("Merge failed:"));
     });
 
     it("offers restore action after deleting local branch", async () => {

--- a/tests/unit/gitops.test.ts
+++ b/tests/unit/gitops.test.ts
@@ -282,6 +282,82 @@ describe("GitOps", () => {
         });
     });
 
+    describe("getBlame", () => {
+        it("parses porcelain blame output into line records", async () => {
+            const output = [
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1 2",
+                "author Alice",
+                "author-time 1711065600",
+                "author-tz +0800",
+                "filename src/a.ts",
+                "\tfirst line",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 2 2",
+                "author Alice",
+                "author-time 1711065600",
+                "author-tz +0800",
+                "filename src/a.ts",
+                "\tsecond line",
+                "0000000000000000000000000000000000000000 3 3 1",
+                "author Not Committed Yet",
+                "author-time 1711152000",
+                "author-tz +0800",
+                "filename src/a.ts",
+                "\tthird line",
+            ].join("\n");
+            const executor = createMockExecutor({ "blame --line-porcelain": output });
+            const ops = new GitOps(executor);
+
+            const blame = await ops.getBlame("src/a.ts");
+
+            expect(blame).toEqual([
+                {
+                    line: 0,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2024/3/22",
+                    summary: "",
+                    isUncommitted: false,
+                },
+                {
+                    line: 1,
+                    commitHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    shortHash: "aaaaaaaa",
+                    author: "Alice",
+                    date: "2024/3/22",
+                    summary: "",
+                    isUncommitted: false,
+                },
+                {
+                    line: 2,
+                    commitHash: "0000000000000000000000000000000000000000",
+                    shortHash: "00000000",
+                    author: "Not Committed Yet",
+                    date: "2024/3/23",
+                    summary: "",
+                    isUncommitted: true,
+                },
+            ]);
+        });
+
+        it("captures blame summary for hover details", async () => {
+            const output = [
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1 1",
+                "author Alice",
+                "author-time 1711065600",
+                "author-tz +0800",
+                "summary Fix hover message",
+                "filename src/a.ts",
+                "\tfirst line",
+            ].join("\n");
+            const executor = createMockExecutor({ "blame --line-porcelain": output });
+            const ops = new GitOps(executor);
+
+            const [line] = await ops.getBlame("src/a.ts");
+            expect(line?.summary).toBe("Fix hover message");
+        });
+    });
+
     describe("stageFiles", () => {
         it("calls git add with paths", async () => {
             const executor = createMockExecutor({});

--- a/tests/unit/gitops.test.ts
+++ b/tests/unit/gitops.test.ts
@@ -519,6 +519,30 @@ describe("GitOps", () => {
             expect(confirmSetUpstream).toHaveBeenCalledWith("origin", "feature/no-upstream");
         });
 
+        it("retries with --set-upstream when git reports a localized upstream error", async () => {
+            const noUpstreamError = new Error(
+                [
+                    "fatal: 当前分支 feature/no-upstream 没有对应的上游分支。",
+                    "为推送当前分支并建立与远程上游的跟踪，使用",
+                    "",
+                    "    git push --set-upstream origin feature/no-upstream",
+                ].join("\n"),
+            );
+            const executor = {
+                run: vi.fn(async (args: string[]) => {
+                    const key = args.join(" ");
+                    if (key === "push") throw noUpstreamError;
+                    if (key === "push --set-upstream origin feature/no-upstream") return "ok";
+                    return "";
+                }),
+            } as unknown as GitExecutor;
+            const confirmSetUpstream = vi.fn(async () => true);
+            const ops = new GitOps(executor, confirmSetUpstream);
+
+            await expect(ops.push()).resolves.toBe("ok");
+            expect(confirmSetUpstream).toHaveBeenCalledWith("origin", "feature/no-upstream");
+        });
+
         it("throws UpstreamPushDeclinedError when upstream setup is declined", async () => {
             const noUpstreamError = new Error(
                 [

--- a/tests/unit/gitops.test.ts
+++ b/tests/unit/gitops.test.ts
@@ -336,6 +336,23 @@ describe("GitOps", () => {
             const call = (executor.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
             expect(call).toContain("--amend");
         });
+
+        it("limits commit to selected paths when provided", async () => {
+            const executor = createMockExecutor({});
+            const ops = new GitOps(executor);
+            await ops.commit("selected message", false, ["src/a.ts", "src/b.ts"]);
+
+            const call = (executor.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(call).toEqual([
+                "commit",
+                "-m",
+                "selected message",
+                "--only",
+                "--",
+                "src/a.ts",
+                "src/b.ts",
+            ]);
+        });
     });
 
     describe("push", () => {
@@ -458,6 +475,16 @@ describe("GitOps", () => {
 
             const calls = (executor.run as ReturnType<typeof vi.fn>).mock.calls;
             expect(calls[0][0]).toEqual(["commit", "-m", "msg"]);
+            expect(calls[1][0]).toEqual(["push"]);
+        });
+
+        it("passes selected paths through to commit before push", async () => {
+            const executor = createMockExecutor({});
+            const ops = new GitOps(executor);
+            await ops.commitAndPush("msg", false, ["src/a.ts"]);
+
+            const calls = (executor.run as ReturnType<typeof vi.fn>).mock.calls;
+            expect(calls[0][0]).toEqual(["commit", "-m", "msg", "--only", "--", "src/a.ts"]);
             expect(calls[1][0]).toEqual(["push"]);
         });
     });

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -384,6 +384,8 @@ describe("view providers integration", () => {
         await webview.send({ type: "commitAndPush", message: "feat: push", amend: false });
         expect(gitOps.commit).toHaveBeenCalled();
         expect(gitOps.commitAndPush).toHaveBeenCalled();
+        expect(gitOps.stageFiles).toHaveBeenCalledWith(["src/a.ts"]);
+        expect(gitOps.commitAndPush).toHaveBeenCalledWith("feat: selected", false, ["src/a.ts"]);
         expect(withProgress).toHaveBeenCalled();
 
         await webview.send({ type: "getLastCommitMessage" });
@@ -391,6 +393,22 @@ describe("view providers integration", () => {
             type: "lastCommitMessage",
             message: "last message",
         });
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider commits only checked paths even when other files are already staged", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+
+        await webview.send({
+            type: "commitSelected",
+            message: "feat: selected only",
+            amend: false,
+            push: false,
+            paths: ["src/a.ts"],
+        });
+
+        expect(gitOps.stageFiles).toHaveBeenCalledWith(["src/a.ts"]);
+        expect(gitOps.commit).toHaveBeenCalledWith("feat: selected only", false, ["src/a.ts"]);
         provider.dispose();
     });
 

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -176,6 +176,18 @@ function makeGitOpsMock() {
             },
         ]),
         getUnpushedCommitHashes: vi.fn(async () => ["abc1234"]),
+        getCommitDetail: vi.fn(async (hash: string) => ({
+            hash,
+            shortHash: hash.slice(0, 7),
+            message: `detail:${hash}`,
+            body: "",
+            author: "Mahesh",
+            email: "m@example.com",
+            date: "2026-02-19T00:00:00Z",
+            parentHashes: [],
+            refs: [],
+            files: [],
+        })),
         getStatus: vi.fn(async () => [
             { path: "src/a.ts", status: "M", staged: false, additions: 1, deletions: 0 },
         ]),
@@ -263,6 +275,64 @@ describe("view providers integration", () => {
         expect(postMessageSpy).toHaveBeenCalledWith({ type: "clear" });
 
         webview.dispose();
+        provider.dispose();
+    });
+
+    it("CommitGraphViewProvider reveals a commit by resetting filters and posting a reveal message", async () => {
+        const { CommitGraphViewProvider } = await import("../../src/views/CommitGraphViewProvider");
+        const gitOps = makeGitOpsMock();
+        gitOps.getLog
+            .mockResolvedValueOnce([
+                {
+                    hash: "old1111",
+                    shortHash: "old1111",
+                    message: "older",
+                    author: "Mahesh",
+                    email: "m@example.com",
+                    date: "2026-02-18T00:00:00Z",
+                    parentHashes: [],
+                    refs: [],
+                },
+            ])
+            .mockResolvedValueOnce([
+                {
+                    hash: "target123",
+                    shortHash: "target12",
+                    message: "target",
+                    author: "Mahesh",
+                    email: "m@example.com",
+                    date: "2026-02-19T00:00:00Z",
+                    parentHashes: [],
+                    refs: [],
+                },
+            ]);
+        const provider = new CommitGraphViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+        );
+        const webview = createWebviewView();
+
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        await webview.send({ type: "ready" });
+        postMessageSpy.mockClear();
+
+        await provider.revealCommit("target123");
+
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "setSelectedBranch", branch: null });
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "setFilterText", text: "" });
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "loadCommits",
+                append: false,
+                commits: expect.arrayContaining([expect.objectContaining({ hash: "target123" })]),
+            }),
+        );
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "revealCommit", hash: "target123" });
+        expect(gitOps.getCommitDetail).toHaveBeenCalledWith("target123");
         provider.dispose();
     });
 

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -336,6 +336,44 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
+    it("CommitGraphViewProvider reveals the commit even if detail loading fails", async () => {
+        const { CommitGraphViewProvider } = await import("../../src/views/CommitGraphViewProvider");
+        const gitOps = makeGitOpsMock();
+        gitOps.getLog.mockResolvedValue([
+            {
+                hash: "target123",
+                shortHash: "target12",
+                message: "target",
+                author: "Mahesh",
+                email: "m@example.com",
+                date: "2026-02-19T00:00:00Z",
+                parentHashes: [],
+                refs: [],
+            },
+        ]);
+        gitOps.getCommitDetail.mockRejectedValueOnce(new Error("detail failed"));
+        const provider = new CommitGraphViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+        );
+        const webview = createWebviewView();
+
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        await webview.send({ type: "ready" });
+        postMessageSpy.mockClear();
+        showErrorMessage.mockClear();
+
+        await provider.revealCommit("target123");
+
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "revealCommit", hash: "target123" });
+        expect(showErrorMessage).toHaveBeenCalledWith("Commit graph error: detail failed");
+        provider.dispose();
+    });
+
     it("CommitGraphViewProvider handles webview events and refresh/load flows", async () => {
         const { CommitGraphViewProvider } = await import("../../src/views/CommitGraphViewProvider");
         const gitOps = makeGitOpsMock();

--- a/tests/unit/webview-apps.integration.test.tsx
+++ b/tests/unit/webview-apps.integration.test.tsx
@@ -360,6 +360,16 @@ describe("CommitGraphApp integration", () => {
         });
         await flush();
         expect(document.body.textContent).toContain("Branch: features/right-click-context");
+        const viewport = document.querySelector(
+            '[data-testid="commit-list-viewport"]',
+        ) as HTMLDivElement | null;
+        expect(viewport).toBeTruthy();
+        if (viewport) {
+            Object.defineProperty(viewport, "clientHeight", {
+                value: 20,
+                configurable: true,
+            });
+        }
 
         const changedFileRow = document.querySelector(
             '[title="src/feature.ts"]',
@@ -427,6 +437,28 @@ describe("CommitGraphApp integration", () => {
                 filePath: "src/feature.ts",
             }),
         );
+
+        act(() => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        type: "setFilterText",
+                        text: "",
+                    },
+                }),
+            );
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        type: "revealCommit",
+                        hash: "cc33",
+                    },
+                }),
+            );
+        });
+        await flush();
+        expect((document.querySelector('input[placeholder="Text or hash"]') as HTMLInputElement).value).toBe("");
+        expect(viewport?.scrollTop).toBeGreaterThan(0);
     });
 });
 


### PR DESCRIPTION
## Summary

This PR adds inline Git blame support in the editor and improves a few related IntelliGit workflows.

## Changes

- add IDEA-like inline Git blame from the editor gutter
- use stable per-commit colors for blame entries
- click a blame entry to reveal and select the matching commit in the IntelliGit graph
- add a close action for blame from the editor context menu
- show commit metadata on blame hover
- fix selective commit behavior so unchecked staged files are not included
- fix push handling for localized "no upstream" git errors
- fix commit diff opening so it no longer shows a dirty untitled editor or noisy diagnostics



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git blame annotations showing per-line author, date, and summary; commands to annotate/clear from editor context menus.
  * Reveal a specific commit in the commit graph and auto-scroll/highlight it in the commit list.
  * Improved diff viewing with in-memory diff providers for editable diffs.
  * Commit UI now supports committing only selected file paths from the commit panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->