### PR TITLE
fix: Resolve commits failing when workspace folder differs from git r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-04-06
+
+### Fixed
+
+- Fix commits failing when VS Code opens a subfolder of a git repository (e.g. opening `/root/client/project2` when the git root is `/root/client`). The extension now discovers the actual git repository root via `git rev-parse --show-toplevel` instead of assuming the workspace folder is the repo root.
+- Fix file paths being doubled (e.g. `project2/project2/file.ts`) when opening files, showing diffs, jumping to source, or deleting files from the commit panel in nested workspace scenarios.
+- Fix `.git` directory file watchers silently failing to register when the workspace folder differs from the git root, causing auto-refresh to stop working.
+
 ## [0.6.2] - 2026-03-16
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,16 +36,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (!workspaceFolder) return;
 
-    const repoRoot = workspaceFolder.uri.fsPath;
-    const executor = new GitExecutor(repoRoot);
-    const gitOps = new GitOps(executor);
+    // Use the workspace folder to bootstrap a temporary GitOps for repo discovery.
+    // The actual git repo root may differ from the workspace folder when a subfolder
+    // of a repository is opened directly (e.g. opening /root/client/project2 when
+    // the git root is /root/client).
+    const workspacePath = workspaceFolder.uri.fsPath;
+    const bootstrapExecutor = new GitExecutor(workspacePath);
+    const bootstrapGitOps = new GitOps(bootstrapExecutor);
 
+    let repoRoot: string;
     try {
-        const isRepo = await gitOps.isRepository();
+        const isRepo = await bootstrapGitOps.isRepository();
         if (!isRepo) return;
+        repoRoot = await bootstrapGitOps.getRepositoryRoot();
     } catch {
         return;
     }
+
+    // Create the real executor rooted at the actual git repository root.
+    const executor = new GitExecutor(repoRoot);
+    const gitOps = new GitOps(executor);
 
     // Cached branch list for webview context menu lookups
     let currentBranches: Branch[] = [];
@@ -53,10 +63,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // --- Providers ---
 
+    const repoRootUri = vscode.Uri.file(repoRoot);
     const commitGraph = new CommitGraphViewProvider(context.extensionUri, gitOps);
     const commitInfo = new CommitInfoViewProvider(context.extensionUri);
-    const commitPanel = new CommitPanelViewProvider(context.extensionUri, gitOps);
-    const mergeConflicts = new MergeConflictsTreeProvider(gitOps, workspaceFolder.uri);
+    const commitPanel = new CommitPanelViewProvider(context.extensionUri, gitOps, repoRootUri);
+    const mergeConflicts = new MergeConflictsTreeProvider(gitOps, repoRootUri);
 
     // --- Register views ---
 
@@ -424,9 +435,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             "intelligit.fileJumpToSource",
             async (ctx: { filePath?: string }) => {
                 if (!ctx?.filePath) return;
-                const uri = vscode.Uri.joinPath(
-                    workspaceFolder.uri,
-                    assertRepoRelativePath(ctx.filePath),
+                const uri = vscode.Uri.file(
+                    path.join(repoRoot, assertRepoRelativePath(ctx.filePath)),
                 );
                 await vscode.window.showTextDocument(uri);
             },
@@ -443,7 +453,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 );
                 if (confirm !== "Delete") return;
 
-                const deleted = await deleteFileWithFallback(gitOps, workspaceFolder.uri, safePath);
+                const deleted = await deleteFileWithFallback(
+                    gitOps,
+                    vscode.Uri.file(repoRoot),
+                    safePath,
+                );
                 if (!deleted) return;
 
                 vscode.window.showInformationMessage(`Deleted ${safePath}`);

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -87,6 +87,11 @@ export class GitOps {
         }
     }
 
+    async getRepositoryRoot(): Promise<string> {
+        const root = await this.executor.run(["rev-parse", "--show-toplevel"]);
+        return root.trim();
+    }
+
     async getBranches(): Promise<Branch[]> {
         const format =
             "%(refname)\t%(refname:short)\t%(objectname:short)\t%(upstream:short)\t%(upstream:track,nobracket)\t%(HEAD)";

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -33,6 +33,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     constructor(
         private readonly extensionUri: vscode.Uri,
         private readonly gitOps: GitOps,
+        private readonly repoRootUri?: vscode.Uri,
     ) {
         this.iconTheme = new IconThemeService(this.extensionUri);
     }
@@ -428,6 +429,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     }
 
     private getWorkspaceRoot(): vscode.Uri {
+        if (this.repoRootUri) return this.repoRootUri;
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceRoot) {
             throw new Error("No workspace folder is open.");

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -97,6 +97,7 @@ const executorRun = vi.fn(defaultExecutorRunImpl);
 
 const gitOpsState = {
     isRepository: vi.fn(async () => true),
+    getRepositoryRoot: vi.fn(async () => "/repo"),
     getBranches: vi.fn(async () => [
         { name: "main", hash: "feed1234", isRemote: false, isCurrent: true, ahead: 0, behind: 0 },
         {
@@ -374,6 +375,7 @@ vi.mock("../../src/git/operations", async (importOriginal) => {
         UpstreamPushDeclinedError: actual.UpstreamPushDeclinedError,
         GitOps: class {
             isRepository = gitOpsState.isRepository;
+            getRepositoryRoot = gitOpsState.getRepositoryRoot;
             getBranches = gitOpsState.getBranches;
             getCommitDetail = gitOpsState.getCommitDetail;
             getUnpushedCommitHashes = gitOpsState.getUnpushedCommitHashes;

--- a/tests/unit/nested-repo-root.test.ts
+++ b/tests/unit/nested-repo-root.test.ts
@@ -1,7 +1,7 @@
 // Tests for the nested subfolder commit fix: verifying correct git repository
 // root discovery when VS Code workspace folder differs from the git repo root.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 // Mock vscode before any imports that depend on it
 vi.mock("vscode", () => ({
@@ -35,10 +35,7 @@ vi.mock("vscode", () => ({
 
 import { GitOps } from "../../src/git/operations";
 import type { GitExecutor } from "../../src/git/executor";
-import {
-    getRepoRelativeFilePathFromUri,
-    normalizeGitPath,
-} from "../../src/services/diffService";
+import { getRepoRelativeFilePathFromUri, normalizeGitPath } from "../../src/services/diffService";
 import { assertRepoRelativePath } from "../../src/utils/fileOps";
 import * as path from "path";
 

--- a/tests/unit/nested-repo-root.test.ts
+++ b/tests/unit/nested-repo-root.test.ts
@@ -1,0 +1,366 @@
+// Tests for the nested subfolder commit fix: verifying correct git repository
+// root discovery when VS Code workspace folder differs from the git repo root.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock vscode before any imports that depend on it
+vi.mock("vscode", () => ({
+    Uri: {
+        file: (fsPath: string) => ({ scheme: "file", fsPath, path: fsPath }),
+        joinPath: (base: { fsPath: string }, ...segments: string[]) => {
+            const joined = [base.fsPath, ...segments].join("/");
+            return { scheme: "file", fsPath: joined, path: joined };
+        },
+    },
+    window: {
+        showQuickPick: vi.fn(),
+        showWarningMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showTextDocument: vi.fn(),
+        showInputBox: vi.fn(),
+        activeTextEditor: undefined,
+        createOutputChannel: vi.fn(() => ({ appendLine: vi.fn() })),
+        tabGroups: { all: [] },
+    },
+    workspace: {
+        workspaceFolders: [{ uri: { fsPath: "/workspace", path: "/workspace" } }],
+        openTextDocument: vi.fn(async () => ({ languageId: "typescript" })),
+        fs: { delete: vi.fn() },
+    },
+    commands: {
+        executeCommand: vi.fn(),
+    },
+}));
+
+import { GitOps } from "../../src/git/operations";
+import type { GitExecutor } from "../../src/git/executor";
+import {
+    getRepoRelativeFilePathFromUri,
+    normalizeGitPath,
+} from "../../src/services/diffService";
+import { assertRepoRelativePath } from "../../src/utils/fileOps";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockExecutor(responses: Record<string, string> = {}): GitExecutor {
+    const run = vi.fn(async (args: string[]) => {
+        const key = args.join(" ");
+        for (const [pattern, response] of Object.entries(responses)) {
+            if (key.includes(pattern)) return response;
+        }
+        return "";
+    });
+    return { run } as unknown as GitExecutor;
+}
+
+function createThrowingExecutor(): GitExecutor {
+    return {
+        run: vi.fn(async () => {
+            throw new Error("not a git repository");
+        }),
+    } as unknown as GitExecutor;
+}
+
+// Minimal vscode.Uri stub for getRepoRelativeFilePathFromUri tests.
+function fakeFileUri(fsPathValue: string): { scheme: string; fsPath: string } {
+    return { scheme: "file", fsPath: fsPathValue };
+}
+
+// ---------------------------------------------------------------------------
+// GitOps.getRepositoryRoot
+// ---------------------------------------------------------------------------
+
+describe("GitOps.getRepositoryRoot", () => {
+    it("returns trimmed output of git rev-parse --show-toplevel", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/root/client\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/root/client");
+    });
+
+    it("returns correct root when workspace is a subfolder", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/root/client\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/root/client");
+        expect(root).not.toBe("/root/client/project2");
+    });
+
+    it("handles trailing whitespace and newlines", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "  /some/path  \n\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/some/path");
+    });
+
+    it("propagates errors for non-git directories", async () => {
+        const executor = createThrowingExecutor();
+        const ops = new GitOps(executor);
+        await expect(ops.getRepositoryRoot()).rejects.toThrow("not a git repository");
+    });
+
+    it("handles Windows-style paths", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "C:/Users/dev/project\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("C:/Users/dev/project");
+    });
+
+    it("calls executor with correct arguments", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/repo\n",
+        });
+        const ops = new GitOps(executor);
+        await ops.getRepositoryRoot();
+        expect(executor.run).toHaveBeenCalledWith(["rev-parse", "--show-toplevel"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Path resolution: repo root vs workspace folder
+// ---------------------------------------------------------------------------
+
+describe("path resolution with nested repo structure", () => {
+    const gitRoot = "/root/client";
+    const workspaceFolder = "/root/client/project2";
+
+    describe("getRepoRelativeFilePathFromUri", () => {
+        it("computes correct relative path when using git root", () => {
+            const uri = fakeFileUri("/root/client/project2/src/file.ts");
+            const result = getRepoRelativeFilePathFromUri(
+                uri as Parameters<typeof getRepoRelativeFilePathFromUri>[0],
+                gitRoot,
+            );
+            expect(result).toBe("project2/src/file.ts");
+        });
+
+        it("returns null when file is outside the repo root", () => {
+            const uri = fakeFileUri("/other/project/file.ts");
+            const result = getRepoRelativeFilePathFromUri(
+                uri as Parameters<typeof getRepoRelativeFilePathFromUri>[0],
+                gitRoot,
+            );
+            expect(result).toBeNull();
+        });
+
+        it("returns null for non-file scheme URIs", () => {
+            const uri = { scheme: "untitled", fsPath: "/root/client/file.ts" };
+            const result = getRepoRelativeFilePathFromUri(
+                uri as Parameters<typeof getRepoRelativeFilePathFromUri>[0],
+                gitRoot,
+            );
+            expect(result).toBeNull();
+        });
+
+        it("returns file at repo root level correctly", () => {
+            const uri = fakeFileUri("/root/client/README.md");
+            const result = getRepoRelativeFilePathFromUri(
+                uri as Parameters<typeof getRepoRelativeFilePathFromUri>[0],
+                gitRoot,
+            );
+            expect(result).toBe("README.md");
+        });
+
+        it("handles deeply nested files", () => {
+            const uri = fakeFileUri("/root/client/project2/src/lib/deep/file.ts");
+            const result = getRepoRelativeFilePathFromUri(
+                uri as Parameters<typeof getRepoRelativeFilePathFromUri>[0],
+                gitRoot,
+            );
+            expect(result).toBe("project2/src/lib/deep/file.ts");
+        });
+    });
+
+    describe("path.join with correct git root vs wrong workspace root", () => {
+        it("constructs correct disk path from git-relative path using git root", () => {
+            const gitRelativePath = "project2/src/file.ts";
+            const correctDiskPath = path.join(gitRoot, gitRelativePath);
+            expect(correctDiskPath).toBe("/root/client/project2/src/file.ts");
+        });
+
+        it("produces doubled path when using workspace folder (the bug)", () => {
+            const gitRelativePath = "project2/src/file.ts";
+            const wrongDiskPath = path.join(workspaceFolder, gitRelativePath);
+            // The doubled path is the exact bug: /root/client/project2/project2/src/file.ts
+            expect(wrongDiskPath).toBe("/root/client/project2/project2/src/file.ts");
+            expect(wrongDiskPath).not.toBe("/root/client/project2/src/file.ts");
+        });
+
+        it("constructs correct path for files in a different subproject", () => {
+            // When working from project2 but a file in project5 is changed
+            const gitRelativePath = "project5/src/utils.ts";
+            const correctDiskPath = path.join(gitRoot, gitRelativePath);
+            expect(correctDiskPath).toBe("/root/client/project5/src/utils.ts");
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// assertRepoRelativePath validation
+// ---------------------------------------------------------------------------
+
+describe("assertRepoRelativePath with nested paths", () => {
+    it("accepts paths with subfolder prefixes", () => {
+        expect(assertRepoRelativePath("project2/src/file.ts")).toBe("project2/src/file.ts");
+    });
+
+    it("accepts simple filenames", () => {
+        expect(assertRepoRelativePath("file.ts")).toBe("file.ts");
+    });
+
+    it("rejects absolute paths", () => {
+        expect(() => assertRepoRelativePath("/root/client/file.ts")).toThrow(
+            "Rejected non-relative path",
+        );
+    });
+
+    it("rejects path traversal", () => {
+        expect(() => assertRepoRelativePath("../outside/file.ts")).toThrow(
+            "Rejected path escaping repo root",
+        );
+    });
+
+    it("rejects empty string", () => {
+        expect(() => assertRepoRelativePath("")).toThrow("Rejected non-relative path");
+    });
+
+    it("rejects paths with null bytes", () => {
+        expect(() => assertRepoRelativePath("file\0.ts")).toThrow(
+            "Rejected path containing control characters",
+        );
+    });
+
+    it("rejects paths with newlines", () => {
+        expect(() => assertRepoRelativePath("file\n.ts")).toThrow(
+            "Rejected path containing control characters",
+        );
+    });
+
+    it("rejects dot-only path (repo root reference)", () => {
+        expect(() => assertRepoRelativePath(".")).toThrow("Rejected repo root path");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeGitPath
+// ---------------------------------------------------------------------------
+
+describe("normalizeGitPath", () => {
+    it("leaves forward-slash paths unchanged on Unix", () => {
+        if (path.sep === "/") {
+            expect(normalizeGitPath("project2/src/file.ts")).toBe("project2/src/file.ts");
+        }
+    });
+
+    it("handles nested subfolder paths", () => {
+        if (path.sep === "/") {
+            expect(normalizeGitPath("project2/packages/core/index.ts")).toBe(
+                "project2/packages/core/index.ts",
+            );
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap flow: isRepository + getRepositoryRoot
+// ---------------------------------------------------------------------------
+
+describe("bootstrap flow for nested subfolder", () => {
+    it("discovers repo root after confirming it is a repository", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --is-inside-work-tree": "true",
+            "rev-parse --show-toplevel": "/root/client\n",
+        });
+        const ops = new GitOps(executor);
+
+        const isRepo = await ops.isRepository();
+        expect(isRepo).toBe(true);
+
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/root/client");
+    });
+
+    it("isRepository returns true even from a subfolder", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --is-inside-work-tree": "true",
+        });
+        const ops = new GitOps(executor);
+        expect(await ops.isRepository()).toBe(true);
+    });
+
+    it("two-phase bootstrap uses discovered root, not workspace folder", async () => {
+        const bootstrapExecutor = createMockExecutor({
+            "rev-parse --is-inside-work-tree": "true",
+            "rev-parse --show-toplevel": "/root/client\n",
+        });
+        const bootstrapOps = new GitOps(bootstrapExecutor);
+
+        const repoRoot = await bootstrapOps.getRepositoryRoot();
+        expect(repoRoot).toBe("/root/client");
+        expect(repoRoot).not.toBe("/root/client/project2");
+    });
+
+    it("isRepository returns false for non-git directories", async () => {
+        const executor = createThrowingExecutor();
+        const ops = new GitOps(executor);
+        expect(await ops.isRepository()).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases for repo root discovery
+// ---------------------------------------------------------------------------
+
+describe("repo root discovery edge cases", () => {
+    it("handles repo root same as workspace folder (no nesting)", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/myproject\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/myproject");
+    });
+
+    it("handles repo root that is parent of workspace by multiple levels", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/root/client\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/root/client");
+
+        const gitRelativePath = "project2/packages/core/index.ts";
+        const diskPath = path.join(root, gitRelativePath);
+        expect(diskPath).toBe("/root/client/project2/packages/core/index.ts");
+    });
+
+    it("handles paths with spaces", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/Users/dev/My Projects/client\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/Users/dev/My Projects/client");
+    });
+
+    it("handles bare repo root at filesystem root", async () => {
+        const executor = createMockExecutor({
+            "rev-parse --show-toplevel": "/\n",
+        });
+        const ops = new GitOps(executor);
+        const root = await ops.getRepositoryRoot();
+        expect(root).toBe("/");
+    });
+});


### PR DESCRIPTION


When VS Code opens a subfolder of a git repository (e.g. /root/client/project2 where git root is /root/client), all git operations failed because the extension assumed workspace folder === repo root. This caused doubled file paths, broken staging/committing, and silent file watcher failures.

The fix uses a two-phase bootstrap: a temporary GitExecutor discovers the actual repo root via `git rev-parse --show-toplevel`, then a real executor is created with the correct cwd. All path construction now uses the discovered git root instead of the workspace folder URI.

Bumps version to 0.6.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository root detection when opening VS Code in a subfolder, avoiding doubled paths and ensuring repo-relative operations target the real git root
  * Corrected file path handling for nested workspace scenarios across commit-panel actions
  * Restored auto-refresh for file watchers when the .git directory lies outside the workspace folder

* **Tests**
  * Added unit tests covering repo-root discovery and repo-relative path resolution

* **Chores**
  * Bumped extension version and updated changelog
<!-- end of auto-generated comment: release notes by coderabbit.ai -->