### PR TITLE
Codex/persist commit draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Persist unsaved commit message drafts per repository so the Commit panel restores the last typed text after closing and reopening the project or restarting VS Code.
 
+### Tests
+
+- Add integration coverage for restoring, saving, and clearing persisted commit drafts in the commit panel provider.
+
 ## [0.6.3] - 2026-04-06
 
 ### Fixed
@@ -18,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix commits failing when VS Code opens a subfolder of a git repository (e.g. opening `/root/client/project2` when the git root is `/root/client`). The extension now discovers the actual git repository root via `git rev-parse --show-toplevel` instead of assuming the workspace folder is the repo root.
 - Fix file paths being doubled (e.g. `project2/project2/file.ts`) when opening files, showing diffs, jumping to source, or deleting files from the commit panel in nested workspace scenarios.
 - Fix `.git` directory file watchers silently failing to register when the workspace folder differs from the git root, causing auto-refresh to stop working.
-
-### Tests
-
-- Add integration coverage for restoring, saving, and clearing persisted commit drafts in the commit panel provider.
 
 ## [0.6.2] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3] - 2026-04-08
+
+### Added
+
+- Persist unsaved commit message drafts per repository so the Commit panel restores the last typed text after closing and reopening the project or restarting VS Code.
+
+### Tests
+
+- Add integration coverage for restoring, saving, and clearing persisted commit drafts in the commit panel provider.
+
 ## [0.6.2] - 2026-03-16
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     const commitGraph = new CommitGraphViewProvider(context.extensionUri, gitOps);
     const commitInfo = new CommitInfoViewProvider(context.extensionUri);
-    const commitPanel = new CommitPanelViewProvider(context.extensionUri, gitOps);
+    const commitPanel = new CommitPanelViewProvider(
+        context.extensionUri,
+        gitOps,
+        repoRoot,
+        context.workspaceState,
+    );
     const mergeConflicts = new MergeConflictsTreeProvider(gitOps, workspaceFolder.uri);
 
     // --- Register views ---

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -16,6 +16,7 @@ import { registerThemeChangeListeners, disposeAll } from "./shared/themeListener
 
 export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = "intelligit.commitPanel";
+    private static readonly COMMIT_DRAFT_KEY_PREFIX = "commitDraft:";
 
     private view?: vscode.WebviewView;
     private files: WorkingFile[] = [];
@@ -33,6 +34,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     constructor(
         private readonly extensionUri: vscode.Uri,
         private readonly gitOps: GitOps,
+        private readonly repoRoot: string,
+        private readonly workspaceState: vscode.Memento,
     ) {
         this.iconTheme = new IconThemeService(this.extensionUri);
     }
@@ -176,11 +179,24 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         switch (msg.type) {
             case "ready":
                 await this.refreshData();
+                this.postToWebview({
+                    type: "restoreCommitDraft",
+                    message: this.getStoredCommitDraft(),
+                });
                 break;
 
             case "refresh":
                 await this.refreshData();
                 break;
+
+            case "saveCommitDraft": {
+                const message = this.assertString(msg.message, "message");
+                await this.workspaceState.update(
+                    this.getCommitDraftStorageKey(),
+                    message || undefined,
+                );
+                break;
+            }
 
             case "stageFiles": {
                 const paths = this.assertRepoPathArray(msg.paths, "paths");
@@ -227,6 +243,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 vscode.window.showInformationMessage(
                     push ? "Committed and pushed successfully." : "Committed successfully.",
                 );
+                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -243,6 +260,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     await this.gitOps.commit(message, amend);
                 });
                 vscode.window.showInformationMessage("Committed successfully.");
+                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -259,6 +277,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     await this.gitOps.commitAndPush(message, amend);
                 });
                 vscode.window.showInformationMessage("Committed and pushed successfully.");
+                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -443,6 +462,18 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             title: "Commit",
             backgroundVar: "var(--vscode-sideBar-background, var(--vscode-editor-background))",
         });
+    }
+
+    private getCommitDraftStorageKey(): string {
+        return `${CommitPanelViewProvider.COMMIT_DRAFT_KEY_PREFIX}${this.repoRoot}`;
+    }
+
+    private getStoredCommitDraft(): string {
+        return this.workspaceState.get<string>(this.getCommitDraftStorageKey()) ?? "";
+    }
+
+    private async clearStoredCommitDraft(): Promise<void> {
+        await this.workspaceState.update(this.getCommitDraftStorageKey(), undefined);
     }
 
     dispose(): void {

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -33,8 +33,9 @@ function App(): React.ReactElement {
     const handleMessageChange = useCallback(
         (message: string) => {
             dispatch({ type: "SET_COMMIT_MESSAGE", message });
+            vscode.postMessage({ type: "saveCommitDraft", message });
         },
-        [dispatch],
+        [dispatch, vscode],
     );
 
     const handleAmendChange = useCallback(

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -37,6 +37,8 @@ function reducer(state: CommitPanelState, action: CommitPanelAction): CommitPane
             };
         case "SET_REFRESHING":
             return { ...state, isRefreshing: action.active };
+        case "RESTORE_COMMIT_DRAFT":
+            return { ...state, commitMessage: action.message };
         case "SET_LAST_COMMIT_MESSAGE":
             return { ...state, commitMessage: action.message };
         case "COMMITTED":
@@ -71,6 +73,9 @@ export function useExtensionMessages(): [CommitPanelState, React.Dispatch<Commit
                         folderIconsByName: msg.folderIconsByName,
                         iconFonts: msg.iconFonts,
                     });
+                    break;
+                case "restoreCommitDraft":
+                    dispatch({ type: "RESTORE_COMMIT_DRAFT", message: msg.message });
                     break;
                 case "lastCommitMessage":
                     dispatch({ type: "SET_LAST_COMMIT_MESSAGE", message: msg.message });

--- a/src/webviews/react/commit-panel/types.ts
+++ b/src/webviews/react/commit-panel/types.ts
@@ -17,6 +17,7 @@ import type {
 export type OutboundMessage =
     | { type: "ready" }
     | { type: "refresh" }
+    | { type: "saveCommitDraft"; message: string }
     | { type: "stageFiles"; paths: string[] }
     | { type: "unstageFiles"; paths: string[] }
     | { type: "commitSelected"; paths: string[]; message: string; amend: boolean; push: boolean }
@@ -48,6 +49,7 @@ export type InboundMessage =
           folderIconsByName?: ThemeFolderIconMap;
           iconFonts?: ThemeIconFont[];
       }
+    | { type: "restoreCommitDraft"; message: string }
     | { type: "lastCommitMessage"; message: string }
     | { type: "committed" }
     | { type: "refreshing"; active: boolean }
@@ -82,6 +84,7 @@ export type CommitPanelAction =
           folderIconsByName?: ThemeFolderIconMap;
           iconFonts?: ThemeIconFont[];
       }
+    | { type: "RESTORE_COMMIT_DRAFT"; message: string }
     | { type: "SET_LAST_COMMIT_MESSAGE"; message: string }
     | { type: "COMMITTED" }
     | { type: "SET_REFRESHING"; active: boolean }

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -57,6 +57,20 @@ const workspaceState: {
     workspaceFolders: [{ uri: { fsPath: "/repo", path: "/repo" } }],
 };
 
+function createMemento(initial: Record<string, string> = {}) {
+    const store = new Map<string, string>(Object.entries(initial));
+    return {
+        get: vi.fn((key: string) => store.get(key)),
+        update: vi.fn(async (key: string, value: string | undefined) => {
+            if (value === undefined) {
+                store.delete(key);
+            } else {
+                store.set(key, value);
+            }
+        }),
+    };
+}
+
 const vscodeMock = {
     EventEmitter: FakeEventEmitter,
     TreeItem: FakeTreeItem,
@@ -204,9 +218,12 @@ function makeGitOpsMock() {
 async function setupCommitPanelProvider() {
     const { CommitPanelViewProvider } = await import("../../src/views/CommitPanelViewProvider");
     const gitOps = makeGitOpsMock();
+    const draftStore = createMemento();
     const provider = new CommitPanelViewProvider(
         { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
         gitOps as unknown as object,
+        "/repo",
+        draftStore as unknown as object,
     );
     const webview = createWebviewView();
     provider.resolveWebviewView(
@@ -215,7 +232,7 @@ async function setupCommitPanelProvider() {
         {} as unknown as object,
     );
     await webview.send({ type: "ready" });
-    return { provider, gitOps, webview };
+    return { provider, gitOps, webview, draftStore };
 }
 
 describe("view providers integration", () => {
@@ -359,7 +376,7 @@ describe("view providers integration", () => {
     });
 
     it("CommitPanelViewProvider handles commit flows", async () => {
-        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const { provider, gitOps, webview, draftStore } = await setupCommitPanelProvider();
         await webview.send({ type: "commit", message: "", amend: false });
         expect(showWarningMessage).toHaveBeenCalledWith("Enter a commit message.");
 
@@ -385,12 +402,43 @@ describe("view providers integration", () => {
         expect(gitOps.commit).toHaveBeenCalled();
         expect(gitOps.commitAndPush).toHaveBeenCalled();
         expect(withProgress).toHaveBeenCalled();
+        expect(draftStore.update).toHaveBeenCalledWith("commitDraft:/repo", undefined);
 
         await webview.send({ type: "getLastCommitMessage" });
         expect(postMessageSpy).toHaveBeenCalledWith({
             type: "lastCommitMessage",
             message: "last message",
         });
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider restores and saves commit draft text per repo", async () => {
+        const { CommitPanelViewProvider } = await import("../../src/views/CommitPanelViewProvider");
+        const gitOps = makeGitOpsMock();
+        const draftStore = createMemento({ "commitDraft:/repo": "draft from storage" });
+        const provider = new CommitPanelViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+            "/repo",
+            draftStore as unknown as object,
+        );
+        const webview = createWebviewView();
+
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        await webview.send({ type: "ready" });
+
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "restoreCommitDraft",
+            message: "draft from storage",
+        });
+
+        await webview.send({ type: "saveCommitDraft", message: "draft changed" });
+        expect(draftStore.update).toHaveBeenCalledWith("commitDraft:/repo", "draft changed");
+
         provider.dispose();
     });
 
@@ -431,9 +479,12 @@ describe("view providers integration", () => {
     it("CommitPanelViewProvider updates description and fires file count after commit", async () => {
         const { CommitPanelViewProvider } = await import("../../src/views/CommitPanelViewProvider");
         const gitOps = makeGitOpsMock();
+        const draftStore = createMemento();
         const provider = new CommitPanelViewProvider(
             { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
             gitOps as unknown as object,
+            "/repo",
+            draftStore as unknown as object,
         );
         const webview = createWebviewView();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit message drafts are now persisted per repository and restored in the Commit panel when reopening VS Code or switching projects.
  * Drafts are cleared automatically after a successful commit.

* **Tests**
  * Added integration tests covering saving, restoring, and clearing of persisted commit drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->