### PR TITLE
Preserve commit drafts after successful push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2026-04-08
+
+### Fixed
+
+- Preserve the last typed commit message text after successful commit flows so reopening the same project restores the draft instead of showing an empty commit message box.
+
+### Tests
+
+- Update commit panel provider coverage to verify successful commit paths keep the persisted commit draft text.
+
 ## [0.6.4] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -243,7 +243,6 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 vscode.window.showInformationMessage(
                     push ? "Committed and pushed successfully." : "Committed successfully.",
                 );
-                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -260,7 +259,6 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     await this.gitOps.commit(message, amend);
                 });
                 vscode.window.showInformationMessage("Committed successfully.");
-                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -277,7 +275,6 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     await this.gitOps.commitAndPush(message, amend);
                 });
                 vscode.window.showInformationMessage("Committed and pushed successfully.");
-                await this.clearStoredCommitDraft();
                 this.postToWebview({ type: "committed" });
                 await this.refreshData();
                 break;
@@ -477,11 +474,6 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private getStoredCommitDraft(): string {
         return this.workspaceState?.get<string>(this.getCommitDraftStorageKey()) ?? "";
     }
-
-    private async clearStoredCommitDraft(): Promise<void> {
-        await this.workspaceState?.update(this.getCommitDraftStorageKey(), undefined);
-    }
-
     dispose(): void {
         this.iconTheme.dispose();
         this.disposeThemeChangeDisposables();

--- a/tests/unit/view-providers.integration.test.ts
+++ b/tests/unit/view-providers.integration.test.ts
@@ -375,8 +375,9 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
-    it("CommitPanelViewProvider handles commit flows", async () => {
+    it("CommitPanelViewProvider preserves stored commit text after successful commit flows", async () => {
         const { provider, gitOps, webview, draftStore } = await setupCommitPanelProvider();
+        await webview.send({ type: "saveCommitDraft", message: "feat: keep draft" });
         await webview.send({ type: "commit", message: "", amend: false });
         expect(showWarningMessage).toHaveBeenCalledWith("Enter a commit message.");
 
@@ -402,7 +403,13 @@ describe("view providers integration", () => {
         expect(gitOps.commit).toHaveBeenCalled();
         expect(gitOps.commitAndPush).toHaveBeenCalled();
         expect(withProgress).toHaveBeenCalled();
-        expect(draftStore.update).toHaveBeenCalledWith("commitDraft:/repo", undefined);
+        expect(draftStore.update).toHaveBeenCalledWith("commitDraft:/repo", "feat: keep draft");
+        expect(
+            draftStore.update.mock.calls.some(
+                ([key, value]: [string, string | undefined]) =>
+                    key === "commitDraft:/repo" && value === undefined,
+            ),
+        ).toBe(false);
 
         await webview.send({ type: "getLastCommitMessage" });
         expect(postMessageSpy).toHaveBeenCalledWith({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit message drafts are now retained after successful commit operations and will be restored when reopening the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->