### PR TITLE
Fix undocked window lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-25
+
+### Fixed
+
+- Decouple the undocked editor tab lifecycle from `intelligit.undockableWindow`, so the tab opens only from user action and closing it no longer edits settings or reloads VS Code.
+
+### Tests
+
+- Add regression coverage for undocked activation, manual opening, closing, and reopening without settings mutation or window reload.
+
 ## [0.8.0] - 2026-05-25
 
 ### Added
@@ -12,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Undockable window mode via `intelligit.undockableWindow` setting: renders the commit graph and commit panel as a single unified editor tab instead of sidebar + bottom panel, enabling native VS Code undocking to a second monitor.
 - Horizontal-split layout in undocked mode: branch column, commit list, and commit details on the left; file changes, commit message, and shelf on the right, with resizable dividers between all columns.
 - `IntelliGit: Toggle Undocked Window` command to switch between docked and undocked layouts without editing settings.json.
-- Auto-fallback to sidebar/panel mode when the undocked editor tab is closed.
 
 ## [0.7.3] - 2026-05-25
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",
@@ -439,7 +439,7 @@
                 "intelligit.undockableWindow": {
                     "type": "boolean",
                     "default": false,
-                    "markdownDescription": "Render IntelliGit as a unified editor tab instead of sidebar + bottom panel. Enables native VS Code undocking to a second monitor. Changing this setting requires reloading the window."
+                    "markdownDescription": "Open IntelliGit as a unified editor tab when Show Git Log is invoked, enabling native VS Code undocking to a second monitor."
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,440 +144,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             false,
         ) ?? false;
 
-    if (restoreUndockedEditorOnActivation && undockableWindow) {
-        const repoRootUri = vscode.Uri.file(repoRoot);
-        const undocked = new UndockedViewProvider(
-            context.extensionUri,
-            gitOps,
-            repoRootUri,
-            context.workspaceState,
-        );
-        undocked.setRepositoryLabel(activeRepository.label);
-        await undocked.open();
-
-        // Wire commit selection → fetch detail
-        context.subscriptions.push(
-            undocked.onCommitSelected(async (hash) => {
-                const requestId = ++commitDetailRequestSeq;
-                try {
-                    const detail = await gitOps.getCommitDetail(hash);
-                    if (requestId !== commitDetailRequestSeq) return;
-                    undocked.setCommitDetail(detail);
-                } catch (err) {
-                    const msg = getErrorMessage(err);
-                    vscode.window.showErrorMessage(`Failed to load commit: ${msg}`);
-                }
-            }),
-        );
-
-        // Wire branch actions
-        context.subscriptions.push(
-            undocked.onBranchAction(({ action, branchName }) => {
-                const branch = currentBranches.find((b) => b.name === branchName);
-                if (!branch) return;
-                vscode.commands.executeCommand(`intelligit.${action}`, {
-                    branch,
-                });
-            }),
-        );
-
-        // Wire commit actions
-        context.subscriptions.push(
-            undocked.onCommitAction(async ({ action, hash }) => {
-                try {
-                    await handleCommitContextAction({
-                        action,
-                        hash,
-                        executor,
-                        gitOps,
-                        repoRoot,
-                        currentBranches,
-                        refreshAll: () => undocked.refresh(),
-                    });
-                } catch (error) {
-                    const message = getErrorMessage(error);
-                    console.error(`Commit action '${action}' failed:`, error);
-                    vscode.window.showErrorMessage(`Commit action failed: ${message}`);
-                }
-            }),
-        );
-
-        // Wire open commit file diff
-        context.subscriptions.push(
-            undocked.onOpenCommitFileDiff(async (params) => {
-                try {
-                    await openCommitFileDiff(
-                        params.commitHash,
-                        params.filePath,
-                        repoRoot,
-                        gitOps,
-                        executor,
-                    );
-                } catch (error) {
-                    const message = getErrorMessage(error);
-                    vscode.window.showErrorMessage(`Failed to open commit diff: ${message}`);
-                }
-            }),
-        );
-
-        // Track file count (for potential badge use)
-        context.subscriptions.push(undocked.onDidChangeFileCount(() => {}));
-
-        // Cleanup disposable
-        context.subscriptions.push(undocked);
-
-        // --- Register commands (shared with normal mode) ---
-        context.subscriptions.push(
-            vscode.commands.registerCommand("intelligit.refresh", async () => {
-                await undocked.refresh();
-            }),
-
-            vscode.commands.registerCommand("intelligit.selectRepository", async () => {
-                repositories = await discoverGitRepositories(workspaceRoots());
-                if (repositories.length === 0) {
-                    vscode.window.showInformationMessage(NO_REPOSITORY_MESSAGE);
-                    return;
-                }
-                const picked = await vscode.window.showQuickPick(
-                    repositories.map((repo) => ({
-                        label: repo.label,
-                        description: repo.root === repoRoot ? "Active" : repo.root,
-                        repository: repo,
-                    })),
-                    { placeHolder: "Select IntelliGit repository" },
-                );
-                if (!picked) return;
-                activeRepository = picked.repository;
-                repoRoot = activeRepository.root;
-                executor.setRoot(repoRoot);
-                const newRepoRootUri = vscode.Uri.file(repoRoot);
-                undocked.setRepositoryRootUri(newRepoRootUri);
-                undocked.setRepositoryLabel(activeRepository.label);
-                await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
-                currentBranches = await gitOps.getBranches();
-                undocked.setBranches(currentBranches);
-                await undocked.refresh();
-            }),
-
-            vscode.commands.registerCommand("intelligit.showGitLog", async () => {
-                undocked.reveal();
-            }),
-
-            // Toggle back to normal mode
-            vscode.commands.registerCommand("intelligit.toggleUndocked", async () => {
-                await vscode.workspace
-                    .getConfiguration("intelligit")
-                    .update("undockableWindow", false, true);
-                undocked.dispose();
-            }),
-        );
-
-        // --- Branch action commands ---
-        const openBuiltInMergeEditorForFileInUndocked = async (filePath: string): Promise<void> => {
-            const fileUri = vscode.Uri.file(path.join(repoRoot, assertRepoRelativePath(filePath)));
-            try {
-                await vscode.commands.executeCommand("git.openMergeEditor", fileUri);
-            } catch (error) {
-                const message = getErrorMessage(error);
-                vscode.window.showWarningMessage(
-                    `VS Code merge editor command failed (${message}). Opening the file instead.`,
-                );
-                await vscode.commands.executeCommand("vscode.open", fileUri);
-            }
-        };
-
-        const openMergeConflictForFileInUndocked = async (filePath: string): Promise<void> => {
-            const preferExternal = getPreferExternalMergeTool();
-            if (preferExternal && getJetBrainsMergeToolPath()) {
-                const opened = await openJetBrainsMergeToolForFile(
-                    filePath,
-                    repoRoot,
-                    gitOps,
-                    () => undocked.refresh(),
-                    openBuiltInMergeEditorForFileInUndocked,
-                );
-                if (opened) return;
-            }
-            await openBuiltInMergeEditorForFileInUndocked(filePath);
-        };
-
-        const openConflictSessionInUndocked = async (labels?: {
-            sourceBranch?: string;
-            targetBranch?: string;
-        }): Promise<void> => {
-            await MergeConflictSessionPanel.open(context.extensionUri, gitOps, labels ?? {}, {
-                onOpenMergeConflict: async (filePath) => {
-                    await openMergeConflictForFileInUndocked(filePath);
-                },
-                onConflictStateChanged: async () => {
-                    await undocked.refresh();
-                },
-            });
-        };
-
-        const branchCommands = createBranchCommands({
-            executor,
-            gitOps,
-            getCurrentBranchName: () => currentBranches.find((b) => b.isCurrent)?.name,
-            getCurrentBranches: () => currentBranches,
-            openConflictSession: openConflictSessionInUndocked,
-            refreshConflictUi: async () => {
-                // Merge conflicts not managed in undocked mode yet;
-                // delegate to refresh which reloads working tree state.
-                await undocked.refresh();
-            },
-        });
-
-        for (const cmd of branchCommands) {
-            context.subscriptions.push(
-                vscode.commands.registerCommand(cmd.id, (item: unknown) => {
-                    const validated =
-                        item && typeof item === "object" && "branch" in item
-                            ? (item as { branch?: Branch })
-                            : { branch: undefined };
-                    return cmd.handler(validated);
-                }),
-            );
-        }
-
-        // --- Register file context menu commands ---
-        context.subscriptions.push(
-            vscode.commands.registerCommand(
-                "intelligit.compareWithRevision",
-                async (ctx?: unknown) => {
-                    await compareEditorFileWithRevision(ctx, repoRoot, gitOps);
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.compareWithBranch",
-                async (ctx?: unknown) => {
-                    await compareEditorFileWithBranch(ctx, repoRoot, gitOps);
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.fileRollback",
-                async (ctx: { filePath?: string }) => {
-                    if (!ctx?.filePath) return;
-                    try {
-                        const safePath = assertRepoRelativePath(ctx.filePath);
-                        const confirm = await vscode.window.showWarningMessage(
-                            `Rollback ${safePath}?`,
-                            { modal: true },
-                            "Rollback",
-                        );
-                        if (confirm !== "Rollback") return;
-                        await gitOps.rollbackFiles([safePath]);
-                        vscode.window.showInformationMessage("Changes rolled back.");
-                    } catch (error) {
-                        const message = getErrorMessage(error);
-                        console.error("Failed to rollback file:", error);
-                        vscode.window.showErrorMessage(`Rollback failed: ${message}`);
-                    } finally {
-                        await undocked.refresh();
-                    }
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.fileJumpToSource",
-                async (ctx: { filePath?: string }) => {
-                    if (!ctx?.filePath) return;
-                    const uri = vscode.Uri.file(
-                        path.join(repoRoot, assertRepoRelativePath(ctx.filePath)),
-                    );
-                    await vscode.window.showTextDocument(uri);
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.fileDelete",
-                async (ctx: { filePath?: string }) => {
-                    if (!ctx?.filePath) return;
-                    try {
-                        const safePath = assertRepoRelativePath(ctx.filePath);
-                        const confirm = await vscode.window.showWarningMessage(
-                            `Delete ${safePath}?`,
-                            { modal: true },
-                            "Delete",
-                        );
-                        if (confirm !== "Delete") return;
-                        const deleted = await deleteFileWithFallback(
-                            gitOps,
-                            vscode.Uri.file(repoRoot),
-                            safePath,
-                        );
-                        if (deleted) {
-                            vscode.window.showInformationMessage(`Deleted ${safePath}`);
-                        }
-                    } catch (error) {
-                        const message = error instanceof Error ? error.message : String(error);
-                        vscode.window.showErrorMessage(
-                            `Delete failed for '${ctx.filePath}': ${message}`,
-                        );
-                    } finally {
-                        await undocked.refresh();
-                    }
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.fileShelve",
-                async (ctx: { filePath?: string }) => {
-                    if (!ctx?.filePath) return;
-                    try {
-                        const safePath = assertRepoRelativePath(ctx.filePath);
-                        await gitOps.shelveSave([safePath]);
-                        vscode.window.showInformationMessage(`Shelved ${safePath}.`);
-                    } catch (error) {
-                        const message = getErrorMessage(error);
-                        console.error("Failed to shelve file:", error);
-                        vscode.window.showErrorMessage(`Shelve failed: ${message}`);
-                    } finally {
-                        await undocked.refresh();
-                    }
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.fileShowHistory",
-                async (ctx: { filePath?: string }) => {
-                    if (!ctx?.filePath) return;
-                    try {
-                        const safePath = assertRepoRelativePath(ctx.filePath);
-                        const history = await gitOps.getFileHistory(safePath);
-                        const doc = await vscode.workspace.openTextDocument({
-                            content: history || "No history found.",
-                            language: "git-commit",
-                        });
-                        await vscode.window.showTextDocument(doc, {
-                            preview: true,
-                        });
-                    } catch (error) {
-                        const message = getErrorMessage(error);
-                        console.error("Failed to load file history:", error);
-                        vscode.window.showErrorMessage(`Show history failed: ${message}`);
-                    }
-                },
-            ),
-            vscode.commands.registerCommand("intelligit.fileRefresh", async () => {
-                await undocked.refresh();
-            }),
-            vscode.commands.registerCommand("intelligit.fileRefreshing", () => {
-                // No-op: visual-only command
-            }),
-            vscode.commands.registerCommand(
-                "intelligit.commitFileCompareWithLocal",
-                async (ctx: unknown) => {
-                    await compareCommitInfoFileWithLocal(ctx, repoRoot, gitOps);
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.commitFileCherryPickChange",
-                async (ctx: unknown) => {
-                    await applySelectedCommitFileChange(ctx, "cherry-pick", executor, () =>
-                        undocked.refresh(),
-                    );
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.commitFileRevertChange",
-                async (ctx: unknown) => {
-                    await applySelectedCommitFileChange(ctx, "revert", executor, () =>
-                        undocked.refresh(),
-                    );
-                },
-            ),
-            vscode.commands.registerCommand("intelligit.detectJetBrainsMergeTool", async () => {
-                await detectAndPickJetBrainsMergeToolPath();
-            }),
-        );
-
-        const resolveConflictPathInUndocked = (ctx: unknown): string | null =>
-            ctx && typeof ctx === "object" && "filePath" in ctx && typeof ctx.filePath === "string"
-                ? ctx.filePath
-                : null;
-
-        context.subscriptions.push(
-            vscode.commands.registerCommand(
-                "intelligit.openMergeConflictInJetBrains",
-                async (ctx: unknown) => {
-                    const filePath = resolveConflictPathInUndocked(ctx);
-                    if (!filePath) return;
-                    await openJetBrainsMergeToolForFile(
-                        filePath,
-                        repoRoot,
-                        gitOps,
-                        () => undocked.refresh(),
-                        openBuiltInMergeEditorForFileInUndocked,
-                    );
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.conflictAcceptYours",
-                async (ctx: unknown) => {
-                    const filePath = resolveConflictPathInUndocked(ctx);
-                    if (!filePath) return;
-                    try {
-                        await runWithNotificationProgress(
-                            `Accepting yours for ${filePath}...`,
-                            async () => {
-                                await gitOps.acceptConflictSide(filePath, "ours");
-                            },
-                        );
-                        vscode.window.showInformationMessage(`Accepted yours for ${filePath}`);
-                        await undocked.refresh();
-                    } catch (error) {
-                        const message = getErrorMessage(error);
-                        vscode.window.showErrorMessage(`Accept yours failed: ${message}`);
-                    }
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.conflictAcceptTheirs",
-                async (ctx: unknown) => {
-                    const filePath = resolveConflictPathInUndocked(ctx);
-                    if (!filePath) return;
-                    try {
-                        await runWithNotificationProgress(
-                            `Accepting theirs for ${filePath}...`,
-                            async () => {
-                                await gitOps.acceptConflictSide(filePath, "theirs");
-                            },
-                        );
-                        vscode.window.showInformationMessage(`Accepted theirs for ${filePath}`);
-                        await undocked.refresh();
-                    } catch (error) {
-                        const message = getErrorMessage(error);
-                        vscode.window.showErrorMessage(`Accept theirs failed: ${message}`);
-                    }
-                },
-            ),
-            vscode.commands.registerCommand(
-                "intelligit.openMergeConflict",
-                async (ctx: unknown) => {
-                    const filePath = resolveConflictPathInUndocked(ctx);
-                    if (!filePath) return;
-                    await openMergeConflictForFileInUndocked(filePath);
-                },
-            ),
-            vscode.commands.registerCommand("intelligit.mergeConflictsRefresh", async () => {
-                // In undocked mode, conflicts are shown via the working tree
-                await undocked.refresh();
-            }),
-            vscode.commands.registerCommand("intelligit.openConflictSession", async () => {
-                const conflicts = await gitOps.getConflictFilesDetailed();
-                if (conflicts.length === 0) {
-                    vscode.window.showInformationMessage("No unresolved merge conflicts found.");
-                    return;
-                }
-                await openConflictSessionInUndocked();
-            }),
-        );
-
-        // --- Initial load ---
-        currentBranches = await gitOps.getBranches();
-        undocked.setBranches(currentBranches);
-        await undocked.refresh();
-
-        return;
-    }
-
     // --- Providers ---
 
     let repoRootUri = vscode.Uri.file(repoRoot);
@@ -734,8 +300,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         context.subscriptions.push(undocked);
 
         context.subscriptions.push(
-            undocked.onDidDispose(() => {
+            undocked.onDidDispose(async () => {
                 undocked = undefined;
+                await context.workspaceState?.update(
+                    "intelligit.restoreUndockedEditorOnActivation",
+                    false,
+                );
             }),
             undocked.onCommitSelected(async (hash) => {
                 const requestId = ++commitDetailRequestSeq;
@@ -789,6 +359,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
         const panel = undocked;
         await panel.open();
+        if (undocked !== panel) return;
+        await context.workspaceState?.update("intelligit.restoreUndockedEditorOnActivation", true);
         currentBranches = await gitOps.getBranches();
         if (undocked !== panel) return;
         panel.setBranches(currentBranches);
@@ -938,11 +510,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             if (nextValue) {
                 await showUndockedGitLog();
             } else {
+                await context.workspaceState?.update(
+                    "intelligit.restoreUndockedEditorOnActivation",
+                    false,
+                );
                 undocked?.dispose();
                 undocked = undefined;
             }
         }),
     );
+
+    if (restoreUndockedEditorOnActivation && undockableWindow) {
+        await showUndockedGitLog();
+    }
 
     const isFilePathContext = (value: unknown): value is { filePath: string } => {
         return (

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -787,10 +787,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             undocked.onDidChangeFileCount(updateBadge),
         );
 
-        await undocked.open();
+        const panel = undocked;
+        await panel.open();
         currentBranches = await gitOps.getBranches();
-        undocked.setBranches(currentBranches);
-        await undocked.refresh();
+        if (undocked !== panel) return;
+        panel.setBranches(currentBranches);
+        await panel.refresh();
     };
 
     // --- Register view providers ---

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         .getConfiguration("intelligit")
         .get<boolean>("undockableWindow", false);
 
-    if (undockableWindow) {
+    const restoreUndockedEditorOnActivation =
+        context.workspaceState?.get<boolean>(
+            "intelligit.restoreUndockedEditorOnActivation",
+            false,
+        ) ?? false;
+
+    if (restoreUndockedEditorOnActivation && undockableWindow) {
         const repoRootUri = vscode.Uri.file(repoRoot);
         const undocked = new UndockedViewProvider(
             context.extensionUri,
@@ -220,16 +226,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // Cleanup disposable
         context.subscriptions.push(undocked);
 
-        // Fallback when panel is closed: switch back to normal mode
-        context.subscriptions.push(
-            undocked.onDidDispose(async () => {
-                await vscode.workspace
-                    .getConfiguration("intelligit")
-                    .update("undockableWindow", false, true);
-                await vscode.commands.executeCommand("workbench.action.reloadWindow");
-            }),
-        );
-
         // --- Register commands (shared with normal mode) ---
         context.subscriptions.push(
             vscode.commands.registerCommand("intelligit.refresh", async () => {
@@ -272,7 +268,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 await vscode.workspace
                     .getConfiguration("intelligit")
                     .update("undockableWindow", false, true);
-                await vscode.commands.executeCommand("workbench.action.reloadWindow");
+                undocked.dispose();
             }),
         );
 
@@ -579,29 +575,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         undocked.setBranches(currentBranches);
         await undocked.refresh();
 
-        // --- Config change listener ---
-        context.subscriptions.push(
-            vscode.workspace.onDidChangeConfiguration((e) => {
-                if (e.affectsConfiguration("intelligit.undockableWindow")) {
-                    const newVal = vscode.workspace
-                        .getConfiguration("intelligit")
-                        .get<boolean>("undockableWindow", false);
-                    if (!newVal) {
-                        vscode.window
-                            .showInformationMessage(
-                                "Reload window for IntelliGit layout change?",
-                                "Reload",
-                            )
-                            .then((choice) => {
-                                if (choice === "Reload") {
-                                    vscode.commands.executeCommand("workbench.action.reloadWindow");
-                                }
-                            });
-                    }
-                }
-            }),
-        );
-
         return;
     }
 
@@ -690,6 +663,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         refreshService.registerFileWatchers();
         await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
         await refreshActiveRepository();
+        if (undocked) {
+            undocked.setRepositoryRootUri(repoRootUri);
+            undocked.setRepositoryLabel(repository.label);
+            undocked.setBranches(currentBranches);
+            await undocked.refresh();
+        }
     };
 
     // --- Merge conflict helpers ---
@@ -735,6 +714,83 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 await refreshService.refreshConflictUi();
             },
         });
+    };
+
+    let undocked: UndockedViewProvider | undefined;
+
+    const showUndockedGitLog = async (): Promise<void> => {
+        if (undocked) {
+            undocked.reveal();
+            return;
+        }
+
+        undocked = new UndockedViewProvider(
+            context.extensionUri,
+            gitOps,
+            repoRootUri,
+            context.workspaceState,
+        );
+        undocked.setRepositoryLabel(activeRepository.label);
+        context.subscriptions.push(undocked);
+
+        context.subscriptions.push(
+            undocked.onDidDispose(() => {
+                undocked = undefined;
+            }),
+            undocked.onCommitSelected(async (hash) => {
+                const requestId = ++commitDetailRequestSeq;
+                try {
+                    const detail = await gitOps.getCommitDetail(hash);
+                    if (requestId !== commitDetailRequestSeq) return;
+                    undocked?.setCommitDetail(detail);
+                } catch (err) {
+                    const msg = getErrorMessage(err);
+                    vscode.window.showErrorMessage(`Failed to load commit: ${msg}`);
+                }
+            }),
+            undocked.onBranchAction(({ action, branchName }) => {
+                const branch = currentBranches.find((b) => b.name === branchName);
+                if (!branch) return;
+                vscode.commands.executeCommand(`intelligit.${action}`, { branch });
+            }),
+            undocked.onCommitAction(async ({ action, hash }) => {
+                try {
+                    await handleCommitContextAction({
+                        action,
+                        hash,
+                        executor,
+                        gitOps,
+                        repoRoot,
+                        currentBranches,
+                        refreshAll: () => undocked?.refresh() ?? Promise.resolve(),
+                    });
+                } catch (error) {
+                    const message = getErrorMessage(error);
+                    console.error(`Commit action '${action}' failed:`, error);
+                    vscode.window.showErrorMessage(`Commit action failed: ${message}`);
+                }
+            }),
+            undocked.onOpenCommitFileDiff(async (params) => {
+                try {
+                    await openCommitFileDiff(
+                        params.commitHash,
+                        params.filePath,
+                        repoRoot,
+                        gitOps,
+                        executor,
+                    );
+                } catch (error) {
+                    const message = getErrorMessage(error);
+                    vscode.window.showErrorMessage(`Failed to open commit diff: ${message}`);
+                }
+            }),
+            undocked.onDidChangeFileCount(updateBadge),
+        );
+
+        await undocked.open();
+        currentBranches = await gitOps.getBranches();
+        undocked.setBranches(currentBranches);
+        await undocked.refresh();
     };
 
     // --- Register view providers ---
@@ -859,6 +915,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         ),
 
         vscode.commands.registerCommand("intelligit.showGitLog", async () => {
+            const useUndockedWindow = vscode.workspace
+                .getConfiguration("intelligit")
+                .get<boolean>("undockableWindow", false);
+            if (useUndockedWindow) {
+                await showUndockedGitLog();
+                return;
+            }
             await vscode.commands.executeCommand("intelligit.commitGraph.focus");
         }),
 
@@ -867,32 +930,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }),
 
         vscode.commands.registerCommand("intelligit.toggleUndocked", async () => {
-            await vscode.workspace
-                .getConfiguration("intelligit")
-                .update("undockableWindow", true, true);
-            await vscode.commands.executeCommand("workbench.action.reloadWindow");
-        }),
-    );
-
-    // Listen for undockableWindow config changes
-    context.subscriptions.push(
-        vscode.workspace.onDidChangeConfiguration((e) => {
-            if (e.affectsConfiguration("intelligit.undockableWindow")) {
-                const newVal = vscode.workspace
-                    .getConfiguration("intelligit")
-                    .get<boolean>("undockableWindow", false);
-                if (newVal) {
-                    vscode.window
-                        .showInformationMessage(
-                            "Reload window for IntelliGit layout change?",
-                            "Reload",
-                        )
-                        .then((choice) => {
-                            if (choice === "Reload") {
-                                vscode.commands.executeCommand("workbench.action.reloadWindow");
-                            }
-                        });
-                }
+            const config = vscode.workspace.getConfiguration("intelligit");
+            const nextValue = !config.get<boolean>("undockableWindow", false);
+            await config.update("undockableWindow", nextValue, true);
+            if (nextValue) {
+                await showUndockedGitLog();
+            } else {
+                undocked?.dispose();
+                undocked = undefined;
             }
         }),
     );

--- a/src/webviews/react/shared/components/ContextMenu.tsx
+++ b/src/webviews/react/shared/components/ContextMenu.tsx
@@ -12,11 +12,17 @@ import { SYSTEM_FONT_STACK } from "../../../../utils/constants";
 const ITEM_HEIGHT = 28;
 const ITEM_FONT_SIZE = 13;
 const CONTEXT_MENU_STYLE_ID = "intelligit-ctx-styles";
+/** PyCharm New UI context menu colours, used as fallbacks when VS Code theme vars are unavailable. */
+const PYCHARM_MENU_BG = "#2B2D30";
+const PYCHARM_MENU_BORDER = "#43454A";
+const PYCHARM_MENU_FG = "#BBBFC4";
+const PYCHARM_MENU_SEPARATOR = "#3E4042";
+const PYCHARM_MENU_HINT = "#6E7074";
 const CONTEXT_MENU_STYLE_RULES = `
     .intelligit-context-item[data-disabled="false"]:hover,
     .intelligit-context-item[data-disabled="false"]:focus-visible {
-        background: var(--vscode-menu-selectionBackground, #094771);
-        color: var(--vscode-menu-selectionForeground, #fff);
+        background: var(--vscode-menu-selectionBackground, #2E436E);
+        color: var(--vscode-menu-selectionForeground, #DFE1E5);
     }
     .intelligit-context-item[data-disabled="false"]:focus-visible {
         outline: 1px solid var(--vscode-focusBorder, #007acc);
@@ -56,7 +62,6 @@ export function ContextMenu({
 }: Props): React.ReactElement {
     const ref = useRef<HTMLDivElement>(null);
     const [pos, setPos] = useState({ left: x, top: y });
-    const menuBodyPaddingX = 4;
     const hasAnyIcon = items.some((item) => !item.separator && !!item.icon);
     const hasAnyTrailing = items.some((item) => !item.separator && (!!item.hint || !!item.submenu));
 
@@ -121,14 +126,13 @@ export function ContextMenu({
                 left: pos.left,
                 top: pos.top,
                 zIndex: 9999,
-                background: "var(--vscode-menu-background, #3a4254)",
-                border: "1px solid var(--vscode-menu-border, rgba(255,255,255,0.14))",
-                borderRadius: 9,
+                background: `var(--vscode-menu-background, ${PYCHARM_MENU_BG})`,
+                border: `1px solid var(--vscode-menu-border, ${PYCHARM_MENU_BORDER})`,
+                borderRadius: 8,
                 padding: "4px 0",
                 minWidth,
                 fontFamily: SYSTEM_FONT_STACK,
-                boxShadow:
-                    "0 18px 36px rgba(0,0,0,0.46), 0 3px 9px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05)",
+                boxShadow: "0 8px 24px rgba(0,0,0,0.45), 0 2px 8px rgba(0,0,0,0.35)",
             }}
         >
             {items.map((item, i) => {
@@ -138,9 +142,8 @@ export function ContextMenu({
                             key={`sep-${i}`}
                             style={{
                                 height: 1,
-                                margin: `5px ${menuBodyPaddingX + 2}px`,
-                                background:
-                                    "var(--vscode-menu-separatorBackground, rgba(255,255,255,0.12))",
+                                margin: "4px 8px",
+                                background: `var(--vscode-menu-separatorBackground, ${PYCHARM_MENU_SEPARATOR})`,
                             }}
                         />
                     );
@@ -169,17 +172,16 @@ export function ContextMenu({
                             alignItems: "center",
                             gap: hasAnyIcon ? 8 : 0,
                             minHeight: ITEM_HEIGHT,
-                            padding: `4px ${hasAnyTrailing ? 9 : 4}px 4px ${hasAnyIcon ? 8 : 4}px`,
-                            margin: `0 ${menuBodyPaddingX}px`,
-                            borderRadius: 4,
+                            padding: `0 ${hasAnyTrailing ? 12 : 8}px 0 ${hasAnyIcon ? 12 : 8}px`,
+                            margin: 0,
+                            borderRadius: 0,
                             cursor: item.disabled ? "default" : "pointer",
                             fontSize: ITEM_FONT_SIZE,
-                            lineHeight: "18px",
+                            lineHeight: `${ITEM_HEIGHT}px`,
                             color: item.disabled
-                                ? "var(--vscode-disabledForeground, rgba(255,255,255,0.4))"
-                                : "var(--vscode-menu-foreground, #d8dbe2)",
+                                ? "var(--vscode-disabledForeground, rgba(187,191,196,1))"
+                                : `var(--vscode-menu-foreground, ${PYCHARM_MENU_FG})`,
                             whiteSpace: "nowrap",
-                            opacity: item.disabled ? 0.72 : 1,
                         }}
                     >
                         {hasAnyIcon && (
@@ -207,11 +209,11 @@ export function ContextMenu({
                                     justifyContent: "flex-end",
                                     flexShrink: 0,
                                     overflow: "visible",
-                                    fontSize: 11,
-                                    opacity: 0.7,
+                                    fontSize: 12,
                                     color: item.disabled
-                                        ? "var(--vscode-disabledForeground, rgba(255,255,255,0.4))"
-                                        : "var(--vscode-descriptionForeground, #9ea4b3)",
+                                        ? `var(--vscode-disabledForeground, ${PYCHARM_MENU_HINT})`
+                                        : `var(--vscode-descriptionForeground, ${PYCHARM_MENU_HINT})`,
+                                    paddingLeft: 16,
                                 }}
                             >
                                 {item.submenu ? (

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -51,6 +51,10 @@ const saveDocListeners: Array<() => void> = [];
 const createFileListeners: Array<() => void> = [];
 const deleteFileListeners: Array<() => void> = [];
 const renameFileListeners: Array<() => void> = [];
+const configurationValues = new Map<string, unknown>();
+const configurationUpdate = vi.fn(async (key: string, value: unknown) => {
+    configurationValues.set(key, value);
+});
 type FsWatchCallback = (...args: unknown[]) => void;
 const fsWatchCallbacks: FsWatchCallback[] = [];
 
@@ -180,6 +184,7 @@ type MockExtensionContext = {
 
 let latestCommitGraphProvider: MockCommitGraphViewProvider | undefined;
 let latestCommitPanelProvider: MockCommitPanelViewProvider | undefined;
+let latestUndockedProvider: MockUndockedViewProvider | undefined;
 
 class MockCommitGraphViewProvider {
     static readonly viewType = "intelligit.commitGraph";
@@ -256,6 +261,43 @@ class MockCommitPanelViewProvider {
     emitFileCount(count: number): void {
         this.fileCountEmitter.fire(count);
     }
+}
+
+class MockUndockedViewProvider {
+    static readonly viewType = "intelligit.undocked";
+    private commitSelectedEmitter = new MockEventEmitter<string>();
+    private branchActionEmitter = new MockEventEmitter<{ action: string; branchName: string }>();
+    private commitActionEmitter = new MockEventEmitter<{
+        action: string;
+        hash: string;
+    }>();
+    private openCommitFileDiffEmitter = new MockEventEmitter<{
+        commitHash: string;
+        filePath: string;
+    }>();
+    private fileCountEmitter = new MockEventEmitter<number>();
+    private disposeEmitter = new MockEventEmitter<void>();
+
+    constructor(_uri: unknown, _gitOps: unknown, _repoRootUri: unknown) {
+        latestUndockedProvider = this;
+    }
+
+    onCommitSelected = this.commitSelectedEmitter.event;
+    onBranchAction = this.branchActionEmitter.event;
+    onCommitAction = this.commitActionEmitter.event;
+    onOpenCommitFileDiff = this.openCommitFileDiffEmitter.event;
+    onDidChangeFileCount = this.fileCountEmitter.event;
+    onDidDispose = this.disposeEmitter.event;
+    setRepositoryLabel = vi.fn();
+    setRepositoryRootUri = vi.fn();
+    setBranches = vi.fn();
+    setCommitDetail = vi.fn();
+    open = vi.fn(async () => undefined);
+    refresh = vi.fn(async () => undefined);
+    reveal = vi.fn();
+    dispose = vi.fn(() => {
+        this.disposeEmitter.fire();
+    });
 }
 
 vi.mock("fs", () => ({
@@ -347,14 +389,9 @@ vi.mock("vscode", () => ({
             return workspaceFolders;
         },
         getConfiguration: vi.fn((_section?: string) => ({
-            get: <T>(_key: string, defaultValue: T) => defaultValue,
-            update: vi.fn(
-                async (
-                    _key: string,
-                    _value: unknown,
-                    _isGlobal?: boolean,
-                ) => undefined,
-            ),
+            get: <T>(key: string, defaultValue: T) =>
+                configurationValues.has(key) ? (configurationValues.get(key) as T) : defaultValue,
+            update: configurationUpdate,
         })),
         onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
         fs: { writeFile },
@@ -438,6 +475,10 @@ vi.mock("../../src/views/CommitPanelViewProvider", () => ({
     CommitPanelViewProvider: MockCommitPanelViewProvider,
 }));
 
+vi.mock("../../src/views/UndockedViewProvider", () => ({
+    UndockedViewProvider: MockUndockedViewProvider,
+}));
+
 vi.mock("../../src/utils/fileOps", async () => {
     const actual = await vi.importActual("../../src/utils/fileOps");
     return {
@@ -475,9 +516,11 @@ describe("extension integration", () => {
         deleteFileListeners.length = 0;
         renameFileListeners.length = 0;
         fsWatchCallbacks.length = 0;
+        configurationValues.clear();
         workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         latestCommitGraphProvider = undefined;
         latestCommitPanelProvider = undefined;
+        latestUndockedProvider = undefined;
 
         executorRun.mockImplementation(defaultExecutorRunImpl);
         gitOpsState.isRepository.mockResolvedValue(true);
@@ -662,6 +705,48 @@ describe("extension integration", () => {
             expect.any(Function),
         );
         expect(deleteFileWithFallback).toHaveBeenCalled();
+    });
+
+    it("does not open the undocked editor tab on activation when undockableWindow is enabled", async () => {
+        configurationValues.set("undockableWindow", true);
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        await activate(context);
+
+        expect(latestUndockedProvider).toBeUndefined();
+        expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
+    });
+
+    it("opens and reopens the undocked editor tab only from showGitLog without changing settings or reloading on close", async () => {
+        configurationValues.set("undockableWindow", true);
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+        await activate(context);
+
+        await registeredCommands.get("intelligit.showGitLog")?.();
+
+        const firstUndocked = latestUndockedProvider;
+        expect(firstUndocked?.open).toHaveBeenCalledTimes(1);
+        expect(firstUndocked?.refresh).toHaveBeenCalledTimes(1);
+        expect(configurationUpdate).not.toHaveBeenCalled();
+        expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
+
+        firstUndocked?.dispose();
+
+        expect(configurationUpdate).not.toHaveBeenCalled();
+        expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
+
+        await registeredCommands.get("intelligit.showGitLog")?.();
+
+        expect(latestUndockedProvider).not.toBe(firstUndocked);
+        expect(latestUndockedProvider?.open).toHaveBeenCalledTimes(1);
     });
 
     it("updates non-current local branch via fetch refspec without checkout", async () => {

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -179,12 +179,20 @@ const gitOpsState = {
 const deleteFileWithFallback = vi.fn(async () => true);
 type MockExtensionContext = {
     extensionUri: { fsPath: string; path: string };
+    workspaceState?: {
+        get: <T>(key: string, defaultValue?: T) => T | undefined;
+        update: ReturnType<typeof vi.fn>;
+    };
     subscriptions: Array<{ dispose: () => void }>;
 };
 
 let latestCommitGraphProvider: MockCommitGraphViewProvider | undefined;
 let latestCommitPanelProvider: MockCommitPanelViewProvider | undefined;
 let latestUndockedProvider: MockUndockedViewProvider | undefined;
+
+function updateLatestUndockedProvider(provider: MockUndockedViewProvider): void {
+    latestUndockedProvider = provider;
+}
 
 class MockCommitGraphViewProvider {
     static readonly viewType = "intelligit.commitGraph";
@@ -279,7 +287,7 @@ class MockUndockedViewProvider {
     private disposeEmitter = new MockEventEmitter<void>();
 
     constructor(_uri: unknown, _gitOps: unknown, _repoRootUri: unknown) {
-        latestUndockedProvider = this;
+        updateLatestUndockedProvider(this);
     }
 
     onCommitSelected = this.commitSelectedEmitter.event;
@@ -505,6 +513,20 @@ async function waitForAsync(): Promise<void> {
     await Promise.resolve();
 }
 
+function createWorkspaceState(
+    initial: Record<string, unknown> = {},
+): MockExtensionContext["workspaceState"] {
+    const values = new Map<string, unknown>(Object.entries(initial));
+    return {
+        get: vi.fn(<T>(key: string, defaultValue?: T) =>
+            values.has(key) ? (values.get(key) as T) : defaultValue,
+        ),
+        update: vi.fn(async (key: string, value: unknown) => {
+            values.set(key, value);
+        }),
+    };
+}
+
 describe("extension integration", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -724,8 +746,10 @@ describe("extension integration", () => {
     it("opens and reopens the undocked editor tab only from showGitLog without changing settings or reloading on close", async () => {
         configurationValues.set("undockableWindow", true);
         const { activate } = await import("../../src/extension");
+        const workspaceState = createWorkspaceState();
         const context = {
             extensionUri: { fsPath: "/ext", path: "/ext" },
+            workspaceState,
             subscriptions: [],
         } as unknown as MockExtensionContext;
         await activate(context);
@@ -735,11 +759,19 @@ describe("extension integration", () => {
         const firstUndocked = latestUndockedProvider;
         expect(firstUndocked?.open).toHaveBeenCalledTimes(1);
         expect(firstUndocked?.refresh).toHaveBeenCalledTimes(1);
+        expect(workspaceState?.update).toHaveBeenCalledWith(
+            "intelligit.restoreUndockedEditorOnActivation",
+            true,
+        );
         expect(configurationUpdate).not.toHaveBeenCalled();
         expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
 
         firstUndocked?.dispose();
 
+        expect(workspaceState?.update).toHaveBeenCalledWith(
+            "intelligit.restoreUndockedEditorOnActivation",
+            false,
+        );
         expect(configurationUpdate).not.toHaveBeenCalled();
         expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
 
@@ -747,6 +779,58 @@ describe("extension integration", () => {
 
         expect(latestUndockedProvider).not.toBe(firstUndocked);
         expect(latestUndockedProvider?.open).toHaveBeenCalledTimes(1);
+    });
+
+    it("restores the undocked editor after activation without skipping docked provider registration", async () => {
+        configurationValues.set("undockableWindow", true);
+        const workspaceState = createWorkspaceState({
+            "intelligit.restoreUndockedEditorOnActivation": true,
+        });
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            workspaceState,
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        await activate(context);
+
+        expect(latestUndockedProvider?.open).toHaveBeenCalledTimes(1);
+        expect(registerWebviewViewProvider).toHaveBeenCalledWith(
+            "intelligit.commitGraph",
+            expect.any(MockCommitGraphViewProvider),
+        );
+        expect(registerWebviewViewProvider).toHaveBeenCalledWith(
+            "intelligit.commitPanel",
+            expect.any(MockCommitPanelViewProvider),
+        );
+        expect(registeredCommands.has("intelligit.fileRollback")).toBe(true);
+        expect(workspaceState?.update).toHaveBeenCalledWith(
+            "intelligit.restoreUndockedEditorOnActivation",
+            true,
+        );
+    });
+
+    it("clears the undocked restore flag when toggling undocked mode off", async () => {
+        configurationValues.set("undockableWindow", true);
+        const workspaceState = createWorkspaceState();
+        const { activate } = await import("../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            workspaceState,
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+        await activate(context);
+        await registeredCommands.get("intelligit.showGitLog")?.();
+
+        await registeredCommands.get("intelligit.toggleUndocked")?.();
+
+        expect(configurationUpdate).toHaveBeenCalledWith("undockableWindow", false, true);
+        expect(workspaceState?.update).toHaveBeenCalledWith(
+            "intelligit.restoreUndockedEditorOnActivation",
+            false,
+        );
+        expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
     });
 
     it("updates non-current local branch via fetch refspec without checkout", async () => {
@@ -1440,7 +1524,9 @@ describe("extension integration", () => {
             expect.stringContaining("Show history failed: Rejected path escaping repo root"),
         );
         expect(showErrorMessage).toHaveBeenCalledWith(
-            expect.stringContaining("Delete failed for '../secret.txt': Rejected path escaping repo root"),
+            expect.stringContaining(
+                "Delete failed for '../secret.txt': Rejected path escaping repo root",
+            ),
         );
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.8.1

* **Bug Fixes**
  * Fixed undocked editor tab lifecycle to only open when "Show Git Log" is invoked; closing the tab no longer reloads VS Code or modifies settings.

* **Documentation**
  * Updated intelligit.undockableWindow configuration description to clarify behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaheshKok/IntelliGit/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->