### PR TITLE
Codex/diff double click readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-05-26
+
+### Changed
+
+- Open commit Changed Files diffs on double-click instead of single-click, matching standard VS Code and PyCharm tree interactions.
+
+### Fixed
+
+- Render commit diff sides from read-only virtual documents so historical file snapshots cannot be edited accidentally and closing the diff does not prompt to save.
+
+### Tests
+
+- Add regression coverage for Changed Files single-click suppression, double-click diff opening, and read-only diff URI usage.
+
 ## [0.8.4] - 2026-05-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.8.4",
+    "version": "0.8.5",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import {
     compareCommitInfoFileWithLocal,
     applySelectedCommitFileChange,
     openCommitFileDiff,
+    registerReadonlyDiffContentProvider,
 } from "./services/diffService";
 import { runWithNotificationProgress } from "./utils/notifications";
 import { discoverGitRepositories, type DiscoveredRepository } from "./services/repositoryDiscovery";
@@ -103,6 +104,7 @@ function registerUnavailableCommands(context: vscode.ExtensionContext): void {
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     registerStaleUndockedPanelSerializer(context);
+    registerReadonlyDiffContentProvider(context);
 
     if (!vscode.workspace.workspaceFolders?.length) {
         registerUnavailableCommands(context);

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -19,6 +19,44 @@ import {
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { EMPTY_TREE_HASH } from "../utils/constants";
 
+const READONLY_DIFF_SCHEME = "intelligit-diff";
+const readonlyDiffDocuments = new Map<string, string>();
+let readonlyDiffDocumentSeq = 0;
+
+class ReadonlyDiffContentProvider implements vscode.TextDocumentContentProvider {
+    provideTextDocumentContent(uri: vscode.Uri): string {
+        return readonlyDiffDocuments.get(uri.toString()) ?? "";
+    }
+}
+
+export function registerReadonlyDiffContentProvider(
+    context: vscode.ExtensionContext,
+): vscode.Disposable {
+    const disposable = vscode.workspace.registerTextDocumentContentProvider(
+        READONLY_DIFF_SCHEME,
+        new ReadonlyDiffContentProvider(),
+    );
+    context.subscriptions.push(disposable);
+    return disposable;
+}
+
+function encodePathForVirtualUri(filePath: string): string {
+    return filePath.split("/").map(encodeURIComponent).join("/");
+}
+
+function createReadonlyDiffUri(filePath: string, content: string, refLabel: string): vscode.Uri {
+    readonlyDiffDocumentSeq += 1;
+    const query = new URLSearchParams({
+        id: String(readonlyDiffDocumentSeq),
+        ref: refLabel,
+    });
+    const uri = vscode.Uri.parse(
+        `${READONLY_DIFF_SCHEME}:/${encodePathForVirtualUri(filePath)}?${query.toString()}`,
+    );
+    readonlyDiffDocuments.set(uri.toString(), content);
+    return uri;
+}
+
 export function normalizeGitPath(fsPathValue: string): string {
     return fsPathValue.split(path.sep).join("/");
 }
@@ -58,21 +96,6 @@ export function getCommitInfoFileContext(value: unknown): CommitInfoFileContext 
     return { filePath, commitHash, commitShortHash };
 }
 
-async function closeTemporaryDiffSourceTab(uri: vscode.Uri): Promise<void> {
-    const matchingTab = vscode.window.tabGroups.all
-        .flatMap((group) => group.tabs)
-        .find((tab) => {
-            const input = tab.input;
-            return input instanceof vscode.TabInputText && input.uri.toString() === uri.toString();
-        });
-    if (!matchingTab) return;
-    try {
-        await vscode.window.tabGroups.close(matchingTab, true);
-    } catch {
-        // Best-effort cleanup only; diff view is already open.
-    }
-}
-
 export async function openDiffAgainstGitRef(
     fileUri: vscode.Uri,
     repoRelativeFilePath: string,
@@ -83,21 +106,16 @@ export async function openDiffAgainstGitRef(
     const trimmedRef = ref.trim();
     if (!trimmedRef) return;
 
-    const currentDoc = await vscode.workspace.openTextDocument(fileUri);
     const refContent = await gitOps.getFileContentAtRef(repoRelativeFilePath, trimmedRef);
-    const leftDoc = await vscode.workspace.openTextDocument({
-        content: refContent,
-        language: currentDoc.languageId,
-    });
+    const leftUri = createReadonlyDiffUri(repoRelativeFilePath, refContent, trimmedRef);
     const title = `${repoRelativeFilePath} (${sourceLabel}: ${trimmedRef}) <-> Working Tree`;
-    await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, fileUri, title);
-    await closeTemporaryDiffSourceTab(leftDoc.uri);
+    await vscode.commands.executeCommand("vscode.diff", leftUri, fileUri, title);
 }
 
 export async function openCommitFileDiff(
     commitHash: string,
     filePath: string,
-    repoRoot: string,
+    _repoRoot: string,
     gitOps: GitOps,
     executor: GitExecutor,
 ): Promise<void> {
@@ -140,27 +158,12 @@ export async function openCommitFileDiff(
         rightContent = "";
     }
 
-    // Detect language from the working tree file if it exists on disk.
-    let language: string | undefined;
-    const diskPath = path.join(repoRoot, safePath);
-    try {
-        const diskDoc = await vscode.workspace.openTextDocument(vscode.Uri.file(diskPath));
-        language = diskDoc.languageId;
-    } catch {
-        // File may not exist on disk (deleted or only in history).
-    }
-
-    const leftDoc = await vscode.workspace.openTextDocument({ content: leftContent, language });
-    const rightDoc = await vscode.workspace.openTextDocument({
-        content: rightContent,
-        language,
-    });
     const shortParent = parentDisplayHash.slice(0, 8);
     const shortCommit = validatedHash.slice(0, 8);
+    const leftUri = createReadonlyDiffUri(safePath, leftContent, shortParent);
+    const rightUri = createReadonlyDiffUri(safePath, rightContent, shortCommit);
     const title = `${safePath} (${shortParent} ↔ ${shortCommit})`;
-    await vscode.commands.executeCommand("vscode.diff", leftDoc.uri, rightDoc.uri, title);
-    await closeTemporaryDiffSourceTab(leftDoc.uri);
-    await closeTemporaryDiffSourceTab(rightDoc.uri);
+    await vscode.commands.executeCommand("vscode.diff", leftUri, rightUri, title);
 }
 
 export async function applyPatchTextToRepo(

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -27,17 +27,34 @@ class ReadonlyDiffContentProvider implements vscode.TextDocumentContentProvider 
     provideTextDocumentContent(uri: vscode.Uri): string {
         return readonlyDiffDocuments.get(uri.toString()) ?? "";
     }
+
+    dispose(): void {
+        readonlyDiffDocuments.clear();
+    }
 }
 
 export function registerReadonlyDiffContentProvider(
     context: vscode.ExtensionContext,
 ): vscode.Disposable {
-    const disposable = vscode.workspace.registerTextDocumentContentProvider(
+    const provider = new ReadonlyDiffContentProvider();
+    const providerRegistration = vscode.workspace.registerTextDocumentContentProvider(
         READONLY_DIFF_SCHEME,
-        new ReadonlyDiffContentProvider(),
+        provider,
     );
-    context.subscriptions.push(disposable);
-    return disposable;
+    const closeListener = vscode.workspace.onDidCloseTextDocument((document) => {
+        if (document.uri.scheme === READONLY_DIFF_SCHEME) {
+            readonlyDiffDocuments.delete(document.uri.toString());
+        }
+    });
+    const cleanup = {
+        dispose: () => {
+            providerRegistration.dispose();
+            closeListener.dispose();
+            provider.dispose();
+        },
+    };
+    context.subscriptions.push(providerRegistration, closeListener, cleanup);
+    return cleanup;
 }
 
 function encodePathForVirtualUri(filePath: string): string {

--- a/src/webviews/react/commit-info/CommitInfoPane.tsx
+++ b/src/webviews/react/commit-info/CommitInfoPane.tsx
@@ -515,7 +515,7 @@ const CommitFileRow = React.memo(function CommitFileRow({
             tabIndex={0}
             _hover={{ bg: JETBRAINS_UI.color.hover }}
             data-vscode-context={vscodeContext}
-            onClick={openDiff}
+            onDoubleClick={openDiff}
             title={file.path}
         >
             <InfoIndentGuides treeDepth={depth} />

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -46,6 +46,7 @@ const withProgress = vi.fn(
 );
 const registerWebviewViewProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const registerWebviewPanelSerializer = vi.fn(() => ({ dispose: vi.fn() }));
+const registerTextDocumentContentProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const createTerminal = vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() }));
 const textDocListeners: Array<() => void> = [];
 const saveDocListeners: Array<() => void> = [];
@@ -339,6 +340,12 @@ vi.mock("vscode", () => ({
     ProgressLocation: { Notification: 15 },
     Uri: {
         file: (value: string) => ({ fsPath: value, path: value }),
+        parse: (value: string) => ({
+            fsPath: value,
+            path: value,
+            scheme: value.split(":", 1)[0],
+            toString: () => value,
+        }),
         joinPath: (base: { fsPath?: string; path?: string }, ...parts: string[]) => {
             const prefix = base.fsPath ?? base.path ?? "";
             const joined = [prefix, ...parts].join("/").replace(/\/+/g, "/");
@@ -411,6 +418,7 @@ vi.mock("vscode", () => ({
         onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
         fs: { writeFile },
         openTextDocument,
+        registerTextDocumentContentProvider,
         onDidChangeTextDocument: vi.fn((listener: () => void) => {
             textDocListeners.push(listener);
             return { dispose: vi.fn() };
@@ -1304,6 +1312,15 @@ describe("extension integration", () => {
             expect.anything(),
             "src/feature.ts (parent1 ↔ a1b2c3d4)",
         );
+        expect(registerTextDocumentContentProvider).toHaveBeenCalledWith(
+            "intelligit-diff",
+            expect.objectContaining({ provideTextDocumentContent: expect.any(Function) }),
+        );
+        const diffCall = executeCommandFallback.mock.calls.find(
+            ([command]) => command === "vscode.diff",
+        );
+        expect((diffCall?.[1] as { scheme?: string }).scheme).toBe("intelligit-diff");
+        expect((diffCall?.[2] as { scheme?: string }).scheme).toBe("intelligit-diff");
     });
 
     it("prompts merge parent selection before opening commit file diff", async () => {

--- a/tests/unit/extension.integration.test.ts
+++ b/tests/unit/extension.integration.test.ts
@@ -49,6 +49,9 @@ const registerWebviewPanelSerializer = vi.fn(() => ({ dispose: vi.fn() }));
 const registerTextDocumentContentProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const createTerminal = vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() }));
 const textDocListeners: Array<() => void> = [];
+const closeDocListeners: Array<
+    (document: { uri: { scheme: string; toString: () => string } }) => void
+> = [];
 const saveDocListeners: Array<() => void> = [];
 const createFileListeners: Array<() => void> = [];
 const deleteFileListeners: Array<() => void> = [];
@@ -419,6 +422,12 @@ vi.mock("vscode", () => ({
         fs: { writeFile },
         openTextDocument,
         registerTextDocumentContentProvider,
+        onDidCloseTextDocument: vi.fn(
+            (listener: (document: { uri: { scheme: string; toString: () => string } }) => void) => {
+                closeDocListeners.push(listener);
+                return { dispose: vi.fn() };
+            },
+        ),
         onDidChangeTextDocument: vi.fn((listener: () => void) => {
             textDocListeners.push(listener);
             return { dispose: vi.fn() };
@@ -548,6 +557,7 @@ describe("extension integration", () => {
         registeredCommands.clear();
         mockDisposables.length = 0;
         textDocListeners.length = 0;
+        closeDocListeners.length = 0;
         saveDocListeners.length = 0;
         createFileListeners.length = 0;
         deleteFileListeners.length = 0;
@@ -1319,8 +1329,24 @@ describe("extension integration", () => {
         const diffCall = executeCommandFallback.mock.calls.find(
             ([command]) => command === "vscode.diff",
         );
-        expect((diffCall?.[1] as { scheme?: string }).scheme).toBe("intelligit-diff");
-        expect((diffCall?.[2] as { scheme?: string }).scheme).toBe("intelligit-diff");
+        const leftUri = diffCall?.[1] as { scheme?: string; toString: () => string };
+        const rightUri = diffCall?.[2] as { scheme?: string; toString: () => string };
+        expect(leftUri.scheme).toBe("intelligit-diff");
+        expect(rightUri.scheme).toBe("intelligit-diff");
+
+        const provider = registerTextDocumentContentProvider.mock.calls.at(-1)?.[1] as {
+            provideTextDocumentContent: (uri: unknown) => string;
+            dispose: () => void;
+        };
+        expect(provider.provideTextDocumentContent(leftUri)).toBe("content:parent1");
+        expect(provider.provideTextDocumentContent(rightUri)).toBe("content:a1b2c3d4");
+
+        closeDocListeners.forEach((listener) => listener({ uri: leftUri }));
+        expect(provider.provideTextDocumentContent(leftUri)).toBe("");
+        expect(provider.provideTextDocumentContent(rightUri)).toBe("content:a1b2c3d4");
+
+        provider.dispose();
+        expect(provider.provideTextDocumentContent(rightUri)).toBe("");
     });
 
     it("prompts merge parent selection before opening commit file diff", async () => {

--- a/tests/unit/webview-apps.integration.test.tsx
+++ b/tests/unit/webview-apps.integration.test.tsx
@@ -409,8 +409,23 @@ describe("CommitGraphApp integration", () => {
             '[title="src/feature.ts"]',
         ) as HTMLElement | null;
         expect(changedFileRow).toBeTruthy();
+        const openDiffMessagesBeforeClick = vscode.postMessage.mock.calls.filter(
+            ([message]) =>
+                (message as { type?: string }).type === "openCommitFileDiff" &&
+                (message as { filePath?: string }).filePath === "src/feature.ts",
+        ).length;
         act(() => {
             changedFileRow?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(
+            vscode.postMessage.mock.calls.filter(
+                ([message]) =>
+                    (message as { type?: string }).type === "openCommitFileDiff" &&
+                    (message as { filePath?: string }).filePath === "src/feature.ts",
+            ),
+        ).toHaveLength(openDiffMessagesBeforeClick);
+        act(() => {
+            changedFileRow?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
         });
 
         const branchRow = Array.from(document.querySelectorAll(".branch-row")).find((row) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * File diffs in commit view now open on double-click instead of single-click
  * Fixed issue where viewing file diffs could cause unintended edits and save prompts

* **Testing**
  * Enhanced test coverage for diff viewing interactions and behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaheshKok/IntelliGit/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->