### PR TITLE
Fix/commit window position and spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.12] - 2026-05-29
+
+### Added
+
+- Added `intelligit.commitWindowPosition` to place the undocked/tabbed Commit window on the left or right side, defaulting to `left`.
+
+### Fixed
+
+- Commit window Refresh button now spins only for explicit user-triggered refreshes, not for theme changes or background workspace updates.
+
 ## [0.8.11] - 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ Why this helps:
 4. Open the bottom IntelliGit panel to inspect graph history, filter by branch, and review commit details.
 5. Use branch or commit context menus for advanced operations.
 
+## Settings
+
+You can configure IntelliGit from VS Code Settings or by adding these keys to `settings.json`.
+
+```jsonc
+{
+  // JetBrains IDE binary path/command or a macOS .app bundle path.
+  // Possible values: "", "pycharm", "idea", "webstorm", "/Applications/PyCharm.app", "C:\\Program Files\\JetBrains\\PyCharm 2025.1\\bin\\pycharm64.exe"
+  "intelligit.jetbrainsMergeTool.path": "",
+
+  // Prefer JetBrains merge tool for conflicts, falling back to VS Code if unavailable.
+  // Possible values: true, false
+  "intelligit.jetbrainsMergeTool.preferExternal": true,
+
+  // Enable tooltips inside IntelliGit webviews.
+  // Possible values: true, false
+  "intelligit.tooltips.enabled": true,
+
+  // Open IntelliGit as a unified editor tab when Show Git Log is invoked.
+  // Possible values: true, false
+  "intelligit.undockableWindow": false,
+
+  // Icon style used in IntelliGit panels.
+  // Possible values: "standard", "color"
+  "intelligit.icons": "standard",
+
+  // Commit panel position inside the undocked/tabbed IntelliGit window.
+  // Possible values: "left", "right"
+  "intelligit.commitWindowPosition": "left"
+}
+```
+
 ## JetBrains Merge Tool Setup (Optional)
 
 IntelliGit can open merge conflicts in a JetBrains IDE merge tool (PyCharm, IntelliJ IDEA, WebStorm, etc.).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "IntelliJ-style Git UI for VS Code with commit graph, commit details, shelf workflow, and file change explorer.",
-    "version": "0.8.11",
+    "version": "0.8.12",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",
@@ -499,6 +499,19 @@
                     ],
                     "default": "standard",
                     "markdownDescription": "Icon style for the IntelliGit commit panel. `standard` uses VS Code's monochromatic icon foreground (default); `color` uses IntelliGit's coloured icons."
+                },
+                "intelligit.commitWindowPosition": {
+                    "type": "string",
+                    "enum": [
+                        "left",
+                        "right"
+                    ],
+                    "enumDescriptions": [
+                        "Place the commit panel on the left side of the undocked/tabbed window (default).",
+                        "Place the commit panel on the right side of the undocked/tabbed window."
+                    ],
+                    "default": "left",
+                    "markdownDescription": "Position of the commit panel within the undocked/tabbed IntelliGit window. `left` (default) places it on the left side of the graph; `right` places it on the right."
                 }
             }
         }

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -186,9 +186,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
 
     private async refreshData(silent = true): Promise<void> {
         if (!silent) this.postToWebview({ type: "refreshing", active: true });
-        void Promise.resolve(
-            vscode.commands.executeCommand("setContext", "intelligit.commitPanel.refreshing", true),
-        ).catch(() => {});
+        if (!silent) {
+            void Promise.resolve(
+                vscode.commands.executeCommand(
+                    "setContext",
+                    "intelligit.commitPanel.refreshing",
+                    true,
+                ),
+            ).catch(() => {});
+        }
         try {
             await this.iconTheme.initIconThemeData();
             const files = await this.iconTheme.decorateWorkingFiles(await this.gitOps.getStatus());
@@ -238,13 +244,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             });
         } finally {
             if (!silent) this.postToWebview({ type: "refreshing", active: false });
-            void Promise.resolve(
-                vscode.commands.executeCommand(
-                    "setContext",
-                    "intelligit.commitPanel.refreshing",
-                    false,
-                ),
-            ).catch(() => {});
+            if (!silent) {
+                void Promise.resolve(
+                    vscode.commands.executeCommand(
+                        "setContext",
+                        "intelligit.commitPanel.refreshing",
+                        false,
+                    ),
+                ).catch(() => {});
+            }
         }
     }
 

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -184,8 +184,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         await this.refreshGraphData();
     }
 
-    private async refreshData(): Promise<void> {
-        this.postToWebview({ type: "refreshing", active: true });
+    private async refreshData(silent = true): Promise<void> {
+        if (!silent) this.postToWebview({ type: "refreshing", active: true });
         void Promise.resolve(
             vscode.commands.executeCommand("setContext", "intelligit.commitPanel.refreshing", true),
         ).catch(() => {});
@@ -237,7 +237,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 iconFonts,
             });
         } finally {
-            this.postToWebview({ type: "refreshing", active: false });
+            if (!silent) this.postToWebview({ type: "refreshing", active: false });
             void Promise.resolve(
                 vscode.commands.executeCommand(
                     "setContext",
@@ -399,7 +399,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 break;
 
             case "refresh":
-                await this.refreshData();
+                await this.refreshData(false);
                 await this.refreshGraphData();
                 break;
 

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -268,7 +268,7 @@ export class UndockedViewProvider {
 
             // Commit-panel-side
             case "refresh":
-                await this.refreshCommitPanelData();
+                await this.refreshCommitPanelData(false);
                 break;
 
             case "saveCommitDraft": {
@@ -625,8 +625,8 @@ export class UndockedViewProvider {
 
     // --- Commit panel data fetching -----------------------------------------
 
-    private async refreshCommitPanelData(): Promise<void> {
-        this.postToWebview({ type: "refreshing", active: true });
+    private async refreshCommitPanelData(silent = true): Promise<void> {
+        if (!silent) this.postToWebview({ type: "refreshing", active: true });
         try {
             await this.iconTheme.initIconThemeData();
             const files = await this.iconTheme.decorateWorkingFiles(await this.gitOps.getStatus());
@@ -666,7 +666,7 @@ export class UndockedViewProvider {
                 iconFonts,
             });
         } finally {
-            this.postToWebview({ type: "refreshing", active: false });
+            if (!silent) this.postToWebview({ type: "refreshing", active: false });
         }
     }
 
@@ -760,7 +760,17 @@ export class UndockedViewProvider {
     private registerThemeChangeListeners(): void {
         this.themeChangeDisposables.push(
             ...registerThemeChangeListeners(() => this.refreshThemeDataWithErrorHandling()),
+            vscode.workspace.onDidChangeConfiguration((event) => {
+                if (event.affectsConfiguration("intelligit.commitWindowPosition")) {
+                    this.reloadWebviewHtml();
+                }
+            }),
         );
+    }
+
+    private reloadWebviewHtml(): void {
+        if (!this.panel) return;
+        this.panel.webview.html = this.getHtml(this.panel.webview);
     }
 
     private disposeThemeChangeDisposables(): void {

--- a/src/views/webviewHtml.ts
+++ b/src/views/webviewHtml.ts
@@ -30,6 +30,7 @@ export function buildWebviewShellHtml({
     let hoverDelay = 300;
     let tooltipsEnabled = true;
     let iconStyle: "color" | "standard" = "standard";
+    let commitWindowPosition: "left" | "right" = "left";
     try {
         const config = vscode.workspace?.getConfiguration?.();
         if (config) {
@@ -37,6 +38,8 @@ export function buildWebviewShellHtml({
             tooltipsEnabled = config.get?.<boolean>("intelligit.tooltips.enabled") !== false;
             const rawIconStyle = config.get?.<string>("intelligit.icons") ?? "color";
             iconStyle = rawIconStyle === "color" ? "color" : "standard";
+            const rawPosition = config.get?.<string>("intelligit.commitWindowPosition") ?? "left";
+            commitWindowPosition = rawPosition === "right" ? "right" : "left";
         }
     } catch {
         // Safe fallback when workspace is not mocked or available
@@ -68,7 +71,8 @@ ${styleLinks ? `${styleLinks}\n` : ""}
         window.intelligitSettings = {
             hoverDelay: ${hoverDelay},
             tooltipsEnabled: ${tooltipsEnabled},
-            iconStyle: "${iconStyle}"
+            iconStyle: "${iconStyle}",
+            commitWindowPosition: "${commitWindowPosition}"
         };
     </script>
     <script nonce="${nonce}" src="${scriptUri}"></script>

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -15,6 +15,7 @@ import { ThemeIconFontFaces } from "./shared/components";
 import { getVsCodeApi } from "./shared/vscodeApi";
 import { useCheckedFiles } from "./commit-panel/hooks/useCheckedFiles";
 import theme from "./commit-panel/theme";
+import { getSettings } from "./shared/settings";
 import type {
     Branch,
     Commit,
@@ -285,6 +286,8 @@ function App(): React.ReactElement {
         }
     });
 
+    const commitPanelPosition = getSettings().commitWindowPosition;
+
     // --- Drag handlers ---
     const onBranchDividerMouseDown = useColumnDrag(
         branchWidth,
@@ -305,7 +308,7 @@ function App(): React.ReactElement {
         setCommitPanelWidth,
         MIN_COMMIT_PANEL_WIDTH,
         MAX_COMMIT_PANEL_WIDTH,
-        true,
+        commitPanelPosition === "right",
     );
 
     // --- Persist column widths ---
@@ -561,7 +564,79 @@ function App(): React.ReactElement {
                     </button>
                 </Box>
                 <Box display="flex" flex={1} overflow="hidden" minHeight={0}>
-                    {/* ======== LEFT: Graph panel ======== */}
+                    {/* Divider and commit panel — only on left side */}
+                    {commitPanelPosition === "left" && (
+                        <>
+                            <Box
+                                width={`${commitPanelWidth}px`}
+                                flexShrink={0}
+                                overflow="hidden"
+                                display="flex"
+                                flexDirection="column"
+                            >
+                                <Box
+                                    flex={1}
+                                    overflow="hidden"
+                                    display="flex"
+                                    flexDirection="column"
+                                >
+                                    <TabBar
+                                        stashCount={cpState.stashes.length}
+                                        commitContent={
+                                            <CommitTab
+                                                files={cpState.files}
+                                                commitMessage={cpState.commitMessage}
+                                                isAmend={cpState.isAmend}
+                                                amendBranchCommits={cpState.amendBranchCommits}
+                                                amendBranchHistoryLoaded={
+                                                    cpState.amendBranchHistoryLoaded
+                                                }
+                                                isRefreshing={cpState.isRefreshing}
+                                                checkedPaths={checkedPaths}
+                                                onToggleFile={toggleFile}
+                                                onToggleFolder={toggleFolder}
+                                                onToggleSection={toggleSection}
+                                                isAllChecked={isAllChecked}
+                                                isSomeChecked={isSomeChecked}
+                                                onMessageChange={handleMessageChange}
+                                                onAmendChange={handleAmendChange}
+                                                onCommit={handleCommit}
+                                                onCommitAndPush={handleCommitAndPush}
+                                                folderIcon={cpState.folderIcon}
+                                                folderExpandedIcon={cpState.folderExpandedIcon}
+                                                folderIconsByName={cpState.folderIconsByName}
+                                                groupByDir={groupByDir}
+                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                                            />
+                                        }
+                                        shelfContent={
+                                            <ShelfTab
+                                                stashes={cpState.stashes}
+                                                shelfFiles={cpState.shelfFiles}
+                                                selectedIndex={cpState.selectedShelfIndex}
+                                                folderIcon={cpState.folderIcon}
+                                                folderExpandedIcon={cpState.folderExpandedIcon}
+                                                folderIconsByName={cpState.folderIconsByName}
+                                                groupByDir={groupByDir}
+                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                                            />
+                                        }
+                                    />
+                                </Box>
+                            </Box>
+
+                            <Box
+                                width="4px"
+                                flexShrink={0}
+                                cursor="col-resize"
+                                bg="var(--vscode-panel-border)"
+                                onMouseDown={onCommitPanelDividerMouseDown}
+                                _hover={{ bg: "var(--vscode-focusBorder, #007acc)" }}
+                            />
+                        </>
+                    )}
+
+                    {/* Graph panel */}
                     <Box flex={1} display="flex" overflow="hidden" minWidth={0}>
                         <div style={{ width: branchWidth, flexShrink: 0, overflow: "hidden" }}>
                             <BranchColumn
@@ -629,67 +704,77 @@ function App(): React.ReactElement {
                         </div>
                     </Box>
 
-                    {/* ======== Divider between graph and commit panel ======== */}
-                    <Box
-                        width="4px"
-                        flexShrink={0}
-                        cursor="col-resize"
-                        bg="var(--vscode-panel-border)"
-                        onMouseDown={onCommitPanelDividerMouseDown}
-                        _hover={{ bg: "var(--vscode-focusBorder, #007acc)" }}
-                    />
-
-                    {/* ======== RIGHT: Commit panel ======== */}
-                    <Box
-                        width={`${commitPanelWidth}px`}
-                        flexShrink={0}
-                        overflow="hidden"
-                        display="flex"
-                        flexDirection="column"
-                    >
-                        <Box flex={1} overflow="hidden" display="flex" flexDirection="column">
-                            <TabBar
-                                stashCount={cpState.stashes.length}
-                                commitContent={
-                                    <CommitTab
-                                        files={cpState.files}
-                                        commitMessage={cpState.commitMessage}
-                                        isAmend={cpState.isAmend}
-                                        amendBranchCommits={cpState.amendBranchCommits}
-                                        amendBranchHistoryLoaded={cpState.amendBranchHistoryLoaded}
-                                        isRefreshing={cpState.isRefreshing}
-                                        checkedPaths={checkedPaths}
-                                        onToggleFile={toggleFile}
-                                        onToggleFolder={toggleFolder}
-                                        onToggleSection={toggleSection}
-                                        isAllChecked={isAllChecked}
-                                        isSomeChecked={isSomeChecked}
-                                        onMessageChange={handleMessageChange}
-                                        onAmendChange={handleAmendChange}
-                                        onCommit={handleCommit}
-                                        onCommitAndPush={handleCommitAndPush}
-                                        folderIcon={cpState.folderIcon}
-                                        folderExpandedIcon={cpState.folderExpandedIcon}
-                                        folderIconsByName={cpState.folderIconsByName}
-                                        groupByDir={groupByDir}
-                                        onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                    />
-                                }
-                                shelfContent={
-                                    <ShelfTab
-                                        stashes={cpState.stashes}
-                                        shelfFiles={cpState.shelfFiles}
-                                        selectedIndex={cpState.selectedShelfIndex}
-                                        folderIcon={cpState.folderIcon}
-                                        folderExpandedIcon={cpState.folderExpandedIcon}
-                                        folderIconsByName={cpState.folderIconsByName}
-                                        groupByDir={groupByDir}
-                                        onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                    />
-                                }
+                    {/* Divider and commit panel — only on right side */}
+                    {commitPanelPosition === "right" && (
+                        <>
+                            <Box
+                                width="4px"
+                                flexShrink={0}
+                                cursor="col-resize"
+                                bg="var(--vscode-panel-border)"
+                                onMouseDown={onCommitPanelDividerMouseDown}
+                                _hover={{ bg: "var(--vscode-focusBorder, #007acc)" }}
                             />
-                        </Box>
-                    </Box>
+
+                            <Box
+                                width={`${commitPanelWidth}px`}
+                                flexShrink={0}
+                                overflow="hidden"
+                                display="flex"
+                                flexDirection="column"
+                            >
+                                <Box
+                                    flex={1}
+                                    overflow="hidden"
+                                    display="flex"
+                                    flexDirection="column"
+                                >
+                                    <TabBar
+                                        stashCount={cpState.stashes.length}
+                                        commitContent={
+                                            <CommitTab
+                                                files={cpState.files}
+                                                commitMessage={cpState.commitMessage}
+                                                isAmend={cpState.isAmend}
+                                                amendBranchCommits={cpState.amendBranchCommits}
+                                                amendBranchHistoryLoaded={
+                                                    cpState.amendBranchHistoryLoaded
+                                                }
+                                                isRefreshing={cpState.isRefreshing}
+                                                checkedPaths={checkedPaths}
+                                                onToggleFile={toggleFile}
+                                                onToggleFolder={toggleFolder}
+                                                onToggleSection={toggleSection}
+                                                isAllChecked={isAllChecked}
+                                                isSomeChecked={isSomeChecked}
+                                                onMessageChange={handleMessageChange}
+                                                onAmendChange={handleAmendChange}
+                                                onCommit={handleCommit}
+                                                onCommitAndPush={handleCommitAndPush}
+                                                folderIcon={cpState.folderIcon}
+                                                folderExpandedIcon={cpState.folderExpandedIcon}
+                                                folderIconsByName={cpState.folderIconsByName}
+                                                groupByDir={groupByDir}
+                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                                            />
+                                        }
+                                        shelfContent={
+                                            <ShelfTab
+                                                stashes={cpState.stashes}
+                                                shelfFiles={cpState.shelfFiles}
+                                                selectedIndex={cpState.selectedShelfIndex}
+                                                folderIcon={cpState.folderIcon}
+                                                folderExpandedIcon={cpState.folderExpandedIcon}
+                                                folderIconsByName={cpState.folderIconsByName}
+                                                groupByDir={groupByDir}
+                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                                            />
+                                        }
+                                    />
+                                </Box>
+                            </Box>
+                        </>
+                    )}
                 </Box>
             </Box>
         </ChakraProvider>

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -122,6 +122,23 @@ interface CommitPanelState {
     error: string | null;
 }
 
+interface CommitPanelPaneProps {
+    width: number;
+    cpState: CommitPanelState;
+    checkedPaths: Set<string>;
+    onToggleFile: (path: string) => void;
+    onToggleFolder: (files: WorkingFile[]) => void;
+    onToggleSection: (files: WorkingFile[]) => void;
+    isAllChecked: (files: WorkingFile[]) => boolean;
+    isSomeChecked: (files: WorkingFile[]) => boolean;
+    onMessageChange: (message: string) => void;
+    onAmendChange: (isAmend: boolean) => void;
+    onCommit: () => void;
+    onCommitAndPush: () => void;
+    groupByDir: boolean;
+    onToggleGroupBy: () => void;
+}
+
 type CommitPanelAction =
     | {
           type: "SET_FILES_AND_STASHES";
@@ -159,6 +176,76 @@ const initialCommitPanelState: CommitPanelState = {
     isRefreshing: false,
     error: null,
 };
+
+function CommitPanelPane({
+    width,
+    cpState,
+    checkedPaths,
+    onToggleFile,
+    onToggleFolder,
+    onToggleSection,
+    isAllChecked,
+    isSomeChecked,
+    onMessageChange,
+    onAmendChange,
+    onCommit,
+    onCommitAndPush,
+    groupByDir,
+    onToggleGroupBy,
+}: CommitPanelPaneProps): React.ReactElement {
+    return (
+        <Box
+            width={`${width}px`}
+            flexShrink={0}
+            overflow="hidden"
+            display="flex"
+            flexDirection="column"
+        >
+            <Box flex={1} overflow="hidden" display="flex" flexDirection="column">
+                <TabBar
+                    stashCount={cpState.stashes.length}
+                    commitContent={
+                        <CommitTab
+                            files={cpState.files}
+                            commitMessage={cpState.commitMessage}
+                            isAmend={cpState.isAmend}
+                            amendBranchCommits={cpState.amendBranchCommits}
+                            amendBranchHistoryLoaded={cpState.amendBranchHistoryLoaded}
+                            isRefreshing={cpState.isRefreshing}
+                            checkedPaths={checkedPaths}
+                            onToggleFile={onToggleFile}
+                            onToggleFolder={onToggleFolder}
+                            onToggleSection={onToggleSection}
+                            isAllChecked={isAllChecked}
+                            isSomeChecked={isSomeChecked}
+                            onMessageChange={onMessageChange}
+                            onAmendChange={onAmendChange}
+                            onCommit={onCommit}
+                            onCommitAndPush={onCommitAndPush}
+                            folderIcon={cpState.folderIcon}
+                            folderExpandedIcon={cpState.folderExpandedIcon}
+                            folderIconsByName={cpState.folderIconsByName}
+                            groupByDir={groupByDir}
+                            onToggleGroupBy={onToggleGroupBy}
+                        />
+                    }
+                    shelfContent={
+                        <ShelfTab
+                            stashes={cpState.stashes}
+                            shelfFiles={cpState.shelfFiles}
+                            selectedIndex={cpState.selectedShelfIndex}
+                            folderIcon={cpState.folderIcon}
+                            folderExpandedIcon={cpState.folderExpandedIcon}
+                            folderIconsByName={cpState.folderIconsByName}
+                            groupByDir={groupByDir}
+                            onToggleGroupBy={onToggleGroupBy}
+                        />
+                    }
+                />
+            </Box>
+        </Box>
+    );
+}
 
 function commitPanelReducer(state: CommitPanelState, action: CommitPanelAction): CommitPanelState {
     switch (action.type) {
@@ -567,63 +654,22 @@ function App(): React.ReactElement {
                     {/* Divider and commit panel — only on left side */}
                     {commitPanelPosition === "left" && (
                         <>
-                            <Box
-                                width={`${commitPanelWidth}px`}
-                                flexShrink={0}
-                                overflow="hidden"
-                                display="flex"
-                                flexDirection="column"
-                            >
-                                <Box
-                                    flex={1}
-                                    overflow="hidden"
-                                    display="flex"
-                                    flexDirection="column"
-                                >
-                                    <TabBar
-                                        stashCount={cpState.stashes.length}
-                                        commitContent={
-                                            <CommitTab
-                                                files={cpState.files}
-                                                commitMessage={cpState.commitMessage}
-                                                isAmend={cpState.isAmend}
-                                                amendBranchCommits={cpState.amendBranchCommits}
-                                                amendBranchHistoryLoaded={
-                                                    cpState.amendBranchHistoryLoaded
-                                                }
-                                                isRefreshing={cpState.isRefreshing}
-                                                checkedPaths={checkedPaths}
-                                                onToggleFile={toggleFile}
-                                                onToggleFolder={toggleFolder}
-                                                onToggleSection={toggleSection}
-                                                isAllChecked={isAllChecked}
-                                                isSomeChecked={isSomeChecked}
-                                                onMessageChange={handleMessageChange}
-                                                onAmendChange={handleAmendChange}
-                                                onCommit={handleCommit}
-                                                onCommitAndPush={handleCommitAndPush}
-                                                folderIcon={cpState.folderIcon}
-                                                folderExpandedIcon={cpState.folderExpandedIcon}
-                                                folderIconsByName={cpState.folderIconsByName}
-                                                groupByDir={groupByDir}
-                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                            />
-                                        }
-                                        shelfContent={
-                                            <ShelfTab
-                                                stashes={cpState.stashes}
-                                                shelfFiles={cpState.shelfFiles}
-                                                selectedIndex={cpState.selectedShelfIndex}
-                                                folderIcon={cpState.folderIcon}
-                                                folderExpandedIcon={cpState.folderExpandedIcon}
-                                                folderIconsByName={cpState.folderIconsByName}
-                                                groupByDir={groupByDir}
-                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                            />
-                                        }
-                                    />
-                                </Box>
-                            </Box>
+                            <CommitPanelPane
+                                width={commitPanelWidth}
+                                cpState={cpState}
+                                checkedPaths={checkedPaths}
+                                onToggleFile={toggleFile}
+                                onToggleFolder={toggleFolder}
+                                onToggleSection={toggleSection}
+                                isAllChecked={isAllChecked}
+                                isSomeChecked={isSomeChecked}
+                                onMessageChange={handleMessageChange}
+                                onAmendChange={handleAmendChange}
+                                onCommit={handleCommit}
+                                onCommitAndPush={handleCommitAndPush}
+                                groupByDir={groupByDir}
+                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                            />
 
                             <Box
                                 width="4px"
@@ -716,63 +762,22 @@ function App(): React.ReactElement {
                                 _hover={{ bg: "var(--vscode-focusBorder, #007acc)" }}
                             />
 
-                            <Box
-                                width={`${commitPanelWidth}px`}
-                                flexShrink={0}
-                                overflow="hidden"
-                                display="flex"
-                                flexDirection="column"
-                            >
-                                <Box
-                                    flex={1}
-                                    overflow="hidden"
-                                    display="flex"
-                                    flexDirection="column"
-                                >
-                                    <TabBar
-                                        stashCount={cpState.stashes.length}
-                                        commitContent={
-                                            <CommitTab
-                                                files={cpState.files}
-                                                commitMessage={cpState.commitMessage}
-                                                isAmend={cpState.isAmend}
-                                                amendBranchCommits={cpState.amendBranchCommits}
-                                                amendBranchHistoryLoaded={
-                                                    cpState.amendBranchHistoryLoaded
-                                                }
-                                                isRefreshing={cpState.isRefreshing}
-                                                checkedPaths={checkedPaths}
-                                                onToggleFile={toggleFile}
-                                                onToggleFolder={toggleFolder}
-                                                onToggleSection={toggleSection}
-                                                isAllChecked={isAllChecked}
-                                                isSomeChecked={isSomeChecked}
-                                                onMessageChange={handleMessageChange}
-                                                onAmendChange={handleAmendChange}
-                                                onCommit={handleCommit}
-                                                onCommitAndPush={handleCommitAndPush}
-                                                folderIcon={cpState.folderIcon}
-                                                folderExpandedIcon={cpState.folderExpandedIcon}
-                                                folderIconsByName={cpState.folderIconsByName}
-                                                groupByDir={groupByDir}
-                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                            />
-                                        }
-                                        shelfContent={
-                                            <ShelfTab
-                                                stashes={cpState.stashes}
-                                                shelfFiles={cpState.shelfFiles}
-                                                selectedIndex={cpState.selectedShelfIndex}
-                                                folderIcon={cpState.folderIcon}
-                                                folderExpandedIcon={cpState.folderExpandedIcon}
-                                                folderIconsByName={cpState.folderIconsByName}
-                                                groupByDir={groupByDir}
-                                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                                            />
-                                        }
-                                    />
-                                </Box>
-                            </Box>
+                            <CommitPanelPane
+                                width={commitPanelWidth}
+                                cpState={cpState}
+                                checkedPaths={checkedPaths}
+                                onToggleFile={toggleFile}
+                                onToggleFolder={toggleFolder}
+                                onToggleSection={toggleSection}
+                                isAllChecked={isAllChecked}
+                                isSomeChecked={isSomeChecked}
+                                onMessageChange={handleMessageChange}
+                                onAmendChange={handleAmendChange}
+                                onCommit={handleCommit}
+                                onCommitAndPush={handleCommitAndPush}
+                                groupByDir={groupByDir}
+                                onToggleGroupBy={() => setGroupByDir((g) => !g)}
+                            />
                         </>
                     )}
                 </Box>

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -76,12 +76,7 @@ function App(): React.ReactElement {
     }, [stageCheckedAndCommit]);
 
     return (
-        <Box
-            display="flex"
-            flexDirection="column"
-            h="100%"
-            bg="var(--intelligit-pycharm-panel)"
-        >
+        <Box display="flex" flexDirection="column" h="100%" bg="var(--intelligit-pycharm-panel)">
             <ThemeIconFontFaces fonts={state.iconFonts} />
             <TabBar
                 stashCount={state.stashes.length}

--- a/src/webviews/react/commit-panel/components/CommitTab.tsx
+++ b/src/webviews/react/commit-panel/components/CommitTab.tsx
@@ -123,12 +123,7 @@ export function CommitTab({
                 />
             ) : null}
 
-            <Box
-                flex="1 1 auto"
-                overflowY="auto"
-                minH="40px"
-                bg="var(--intelligit-pycharm-panel)"
-            >
+            <Box flex="1 1 auto" overflowY="auto" minH="40px" bg="var(--intelligit-pycharm-panel)">
                 <FileTree
                     files={files}
                     groupByDir={groupByDir}

--- a/src/webviews/react/shared/settings.ts
+++ b/src/webviews/react/shared/settings.ts
@@ -2,6 +2,7 @@ export interface IntelligitSettings {
     hoverDelay: number;
     tooltipsEnabled: boolean;
     iconStyle: "color" | "standard";
+    commitWindowPosition: "left" | "right";
 }
 
 export const getSettings = (): IntelligitSettings => {
@@ -9,6 +10,7 @@ export const getSettings = (): IntelligitSettings => {
         hoverDelay: 300,
         tooltipsEnabled: true,
         iconStyle: "standard",
+        commitWindowPosition: "left",
     };
     if (typeof window !== "undefined") {
         const settings = (window as Window & { intelligitSettings?: unknown }).intelligitSettings;
@@ -19,6 +21,8 @@ export const getSettings = (): IntelligitSettings => {
                     typeof settingsObj.hoverDelay === "number" ? settingsObj.hoverDelay : 300,
                 tooltipsEnabled: settingsObj.tooltipsEnabled !== false,
                 iconStyle: settingsObj.iconStyle === "color" ? "color" : "standard",
+                commitWindowPosition:
+                    settingsObj.commitWindowPosition === "right" ? "right" : "left",
             };
         }
     }

--- a/tests/unit/core-utils.test.ts
+++ b/tests/unit/core-utils.test.ts
@@ -197,6 +197,41 @@ describe("core utilities", () => {
         expect(html).toContain("script-src 'nonce-");
         expect(html).toContain('src="webview:///dist/webview-commitgraph.js"');
         expect(html).toContain("background: #123");
+        expect(html).toContain('commitWindowPosition: "left"');
+    });
+
+    it("buildWebviewShellHtml injects explicit right commit window position", async () => {
+        const joinPath = vi.fn(
+            (_base: { path?: string }, ...parts: string[]): { path: string } => ({
+                path: `/${parts.join("/")}`,
+            }),
+        );
+        vi.doMock("vscode", () => ({
+            Uri: { joinPath },
+            workspace: {
+                getConfiguration: () => ({
+                    get: (key: string) =>
+                        key === "intelligit.commitWindowPosition" ? "right" : undefined,
+                }),
+            },
+        }));
+        const { buildWebviewShellHtml } = await import("../../src/views/webviewHtml");
+        const extensionUri = { path: "/ext" } as unknown as Parameters<
+            typeof buildWebviewShellHtml
+        >[0]["extensionUri"];
+        const webview = {
+            cspSource: "vscode-resource:",
+            asWebviewUri: (uri: { path: string }) => `webview://${uri.path}`,
+        } as unknown as Parameters<typeof buildWebviewShellHtml>[0]["webview"];
+
+        const html = buildWebviewShellHtml({
+            extensionUri,
+            webview,
+            scriptFile: "webview-undocked.js",
+            title: "IntelliGit",
+        });
+
+        expect(html).toContain('commitWindowPosition: "right"');
     });
 
     it("graph compute handles linear and merge histories", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `intelligit.commitWindowPosition` setting to control commit panel position (left or right side).

* **Bug Fixes**
  * Refresh button now displays a spinner only for explicit user-triggered refreshes, not for automatic theme or workspace changes.

* **Documentation**
  * Added Settings section to README with configuration examples and supported option keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MaheshKok/IntelliGit/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->