### PR TITLE
ci: add manual publish dispatch and a CI-skip merge guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,17 @@ on:
     pull_request:
         branches:
             - main
+    workflow_dispatch:
+        inputs:
+            force_publish:
+                description: "Publish the current package.json version even if it is unchanged from the previous commit (use to recover a deploy that GitHub skipped)."
+                type: boolean
+                default: false
 
+# Keyed by event so a manual workflow_dispatch on main cannot cancel an
+# in-flight push-triggered release run (they target the same ref).
 concurrency:
-    group: build-release-${{ github.ref }}
+    group: build-release-${{ github.event_name }}-${{ github.ref }}
     cancel-in-progress: true
 
 permissions:
@@ -88,10 +96,33 @@ jobs:
                   name: extension-vsix
                   path: "*.vsix"
 
+    # Blocks a PR from carrying a CI-skip token into main via squash merge.
+    # GitHub creates zero workflow runs for a push whose commit message contains
+    # such a token, so a skipped deploy cannot be detected after the fact -- it
+    # must be prevented before merge. This job ONLY protects the repo when it is
+    # marked as a required status check on the main branch ruleset AND direct
+    # pushes to main are disallowed (both configured on ruleset 12862467).
+    guard-no-skip-ci:
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Reject CI-skip directives in PR commits and metadata
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  PR_BODY: ${{ github.event.pull_request.body }}
+              run: node scripts/check-no-skip-ci.js
+
     release:
         needs: build
         runs-on: ubuntu-latest
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         permissions:
             contents: write
 
@@ -103,9 +134,25 @@ jobs:
 
             - name: Check if version changed
               id: version-check
+              env:
+                  FORCE_PUBLISH: ${{ github.event_name == 'workflow_dispatch' && inputs.force_publish == true }}
               run: |
                   CURRENT_VERSION=$(node -p "require('./package.json').version")
                   echo "Current version: $CURRENT_VERSION"
+
+                  # force_publish is a recovery lever for when GitHub silently
+                  # skipped a push-to-main deploy (e.g. a CI-skip token reached
+                  # the merge commit). It only bypasses the version-change gate;
+                  # the publish-status guard (check-extension-publish-status.js)
+                  # still prevents re-publishing an already-live version, so a
+                  # forced re-run of the same version is safe. workflow_dispatch
+                  # itself requires repo write access, which gates who can use it.
+                  if [ "$FORCE_PUBLISH" = "true" ]; then
+                    echo "Force publish requested via workflow_dispatch; bypassing version comparison."
+                    echo "version_changed=true" >> $GITHUB_OUTPUT
+                    echo "new_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
 
                   if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
                     git checkout HEAD~1 -- package.json

--- a/scripts/check-no-skip-ci.js
+++ b/scripts/check-no-skip-ci.js
@@ -1,0 +1,161 @@
+/**
+ * Guard that blocks CI-skip directives from entering main through a PR merge.
+ *
+ * GitHub silently creates zero workflow runs for a push whose resulting commit
+ * message contains a skip token, and a squash merge concatenates every branch
+ * commit subject into the merge commit body -- so a token in ANY PR commit (or in
+ * the PR title, which becomes the default squash subject) can suppress the
+ * push-to-main deploy. This script runs as a required pull_request status check:
+ * it scans every PR commit message plus the PR title and body and exits non-zero
+ * if a skip token is present, which blocks the merge.
+ */
+
+const { execFileSync } = require("node:child_process");
+
+// GitHub's recognized skip tokens, matched case-insensitively in their exact
+// bracketed form. GitHub matches these as exact case-insensitive substrings of
+// the resulting commit message; it does NOT normalize inner whitespace, so
+// `[ skip ci ]` or `[skip  ci]` do not suppress a run and are deliberately not
+// flagged here. Mirroring GitHub's exact tokens keeps the guard aligned with the
+// real trigger and avoids blocking PRs whose prose merely mentions the phrase.
+// Source: GitHub Actions docs, "Skipping workflow runs".
+const SKIP_TOKEN_PATTERN = /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/i;
+
+// GitHub populates pull_request base.sha / head.sha with full 40-char SHA-1
+// commit hashes (64 chars under SHA-256). Validating the format before handing
+// the value to git rejects any non-hash string -- in particular one beginning
+// with `-`, which git would otherwise treat as an option rather than a revision.
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/i;
+
+// `%x00` tells git to emit a NUL byte after each commit body; NUL is used to
+// split the output because it cannot occur inside a commit message (spaces and
+// newlines can, so they would split a single message into many fragments).
+const COMMIT_RECORD_SEPARATOR = String.fromCharCode(0);
+
+/**
+ * Reports whether the given text contains a GitHub CI-skip directive.
+ *
+ * @param {unknown} text Arbitrary text (commit message, PR title, or PR body).
+ * @returns {boolean} True if a bracketed skip token is present, otherwise false.
+ */
+function containsSkipDirective(text) {
+    if (typeof text !== "string" || text.length === 0) {
+        return false;
+    }
+    return SKIP_TOKEN_PATTERN.test(text);
+}
+
+/**
+ * Returns the full message of every commit in the exclusive range base..head.
+ *
+ * @param {string} baseSha The base branch tip SHA (excluded from the range).
+ * @param {string} headSha The PR head SHA (included in the range).
+ * @param {string} [cwd] Directory to run git in (defaults to the current dir).
+ * @returns {string[]} One entry per commit, each the full `%B` message body.
+ */
+function getCommitMessages(baseSha, headSha, cwd = process.cwd()) {
+    const output = execFileSync("git", ["log", "--format=%B%x00", `${baseSha}..${headSha}`], {
+        cwd,
+        encoding: "utf8",
+    });
+    return output
+        .split(COMMIT_RECORD_SEPARATOR)
+        .map((message) => message.trim())
+        .filter((message) => message.length > 0);
+}
+
+/**
+ * Finds every PR text source that would land in the squash merge commit and
+ * contains a skip token.
+ *
+ * @param {object} input Scan inputs.
+ * @param {string} input.prTitle The PR title (default squash commit subject).
+ * @param {string} input.prBody The PR body.
+ * @param {string[]} input.commitMessages Full messages of the PR's commits.
+ * @returns {string[]} Human-readable descriptions of each offending source.
+ */
+function findOffenders({ prTitle, prBody, commitMessages }) {
+    const offenders = [];
+    if (containsSkipDirective(prTitle)) {
+        offenders.push(`PR title: ${prTitle}`);
+    }
+    if (containsSkipDirective(prBody)) {
+        offenders.push("PR body");
+    }
+    for (const message of commitMessages) {
+        if (containsSkipDirective(message)) {
+            offenders.push(`commit: ${message.split("\n")[0]}`);
+        }
+    }
+    return offenders;
+}
+
+/**
+ * Entry point: reads PR context from the environment, scans it, and exits
+ * non-zero (failing the required check) if any skip token is found. Fails closed
+ * on any error so an unscanned change can never be merged.
+ *
+ * @returns {void}
+ */
+function main() {
+    const baseSha = process.env.BASE_SHA;
+    const headSha = process.env.HEAD_SHA;
+    if (!baseSha || !headSha) {
+        console.error(
+            "check-no-skip-ci: BASE_SHA and HEAD_SHA must be set (expected on a pull_request event).",
+        );
+        process.exit(1);
+    }
+
+    if (!COMMIT_SHA_PATTERN.test(baseSha) || !COMMIT_SHA_PATTERN.test(headSha)) {
+        console.error(
+            "check-no-skip-ci: BASE_SHA and HEAD_SHA must be commit SHA hashes. " +
+                "Failing closed to avoid passing an unexpected value to git.",
+        );
+        process.exit(1);
+    }
+
+    let commitMessages;
+    try {
+        commitMessages = getCommitMessages(baseSha, headSha);
+    } catch (error) {
+        console.error(
+            `check-no-skip-ci: failed to read PR commits (${error.message}). ` +
+                "Failing closed to avoid merging an unscanned change.",
+        );
+        process.exit(1);
+    }
+
+    const offenders = findOffenders({
+        prTitle: process.env.PR_TITLE || "",
+        prBody: process.env.PR_BODY || "",
+        commitMessages,
+    });
+
+    if (offenders.length > 0) {
+        console.error(
+            "check-no-skip-ci: CI-skip directive found. A squash merge would inline this " +
+                "into main's commit message and suppress the deploy:",
+        );
+        for (const offender of offenders) {
+            console.error(`  - ${offender}`);
+        }
+        console.error(
+            "\nRemove the bracketed skip token from the listed source(s) before merging.",
+        );
+        process.exit(1);
+    }
+
+    console.log("check-no-skip-ci: no CI-skip directives found in PR commits, title, or body.");
+}
+
+if (require.main === module) {
+    main();
+}
+
+module.exports = {
+    SKIP_TOKEN_PATTERN,
+    containsSkipDirective,
+    getCommitMessages,
+    findOffenders,
+};

--- a/tests/unit/scripts/check-no-skip-ci.test.ts
+++ b/tests/unit/scripts/check-no-skip-ci.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Spec-derived tests for the CI-skip guard script. Expected behavior is derived
+ * from GitHub's documented skip-token contract -- the bracketed `[skip ci]`,
+ * `[ci skip]`, `[no ci]`, `[skip actions]`, and `[actions skip]` family, matched
+ * case-insensitively -- not from the implementation. These tests exist to catch
+ * regressions in the guard that prevents a squash merge from carrying a skip
+ * token into main and silently suppressing the deploy.
+ *
+ * If GitHub's matching is ever found to be more lenient than the exact documented
+ * tokens (e.g. tolerating inner whitespace), both the guard regex and the
+ * non-match cases below must widen together.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+    containsSkipDirective,
+    findOffenders,
+    getCommitMessages,
+} from "../../../scripts/check-no-skip-ci.js";
+
+describe("containsSkipDirective: recognized GitHub skip tokens", () => {
+    it.each(["[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"])(
+        "flags the canonical token %s",
+        (token) => {
+            expect(containsSkipDirective(token)).toBe(true);
+        },
+    );
+
+    it.each(["[SKIP CI]", "[Skip Ci]", "[Ci Skip]", "[NO CI]", "[Skip Actions]"])(
+        "is case-insensitive for %s",
+        (token) => {
+            expect(containsSkipDirective(token)).toBe(true);
+        },
+    );
+
+    it("flags a token embedded in a longer single-line message", () => {
+        expect(containsSkipDirective("chore: tidy things up [skip ci] before release")).toBe(true);
+    });
+
+    it("flags a token that appears only on a later line of a multi-line body", () => {
+        const message =
+            "feat: add widget\n\nLong description spanning\nseveral lines.\n\n[ci skip]";
+        expect(containsSkipDirective(message)).toBe(true);
+    });
+
+    it("flags a token directly adjacent to other characters", () => {
+        // GitHub matches the bracketed token as a substring regardless of neighbors.
+        expect(containsSkipDirective("wip[skip ci]done")).toBe(true);
+    });
+});
+
+describe("containsSkipDirective: text that must NOT be flagged", () => {
+    it.each(["skip ci", "ci skip", "no ci", "skip actions"])(
+        "does not flag the unbracketed phrase %s",
+        (phrase) => {
+            expect(containsSkipDirective(phrase)).toBe(false);
+        },
+    );
+
+    it.each([
+        "fix flaky ci pipeline",
+        "skip the broken cache step",
+        "feat(ci): add workflow_dispatch trigger",
+        "refactor: continuous integration cleanup",
+    ])("does not flag normal prose containing the words: %s", (message) => {
+        expect(containsSkipDirective(message)).toBe(false);
+    });
+
+    it.each(["[skip-ci]", "[ci-skip]", "[ skip ci ]", "[skip  ci]", "[skipci]"])(
+        "does not flag near-miss formatting %s (not a GitHub token)",
+        (nearMiss) => {
+            expect(containsSkipDirective(nearMiss)).toBe(false);
+        },
+    );
+
+    it.each(["[skip tests]", "[ci]", "[skip]", "[actions]"])(
+        "does not flag unrelated bracketed tokens %s",
+        (bracketed) => {
+            expect(containsSkipDirective(bracketed)).toBe(false);
+        },
+    );
+
+    it("does not flag an unbalanced bracket fragment", () => {
+        expect(containsSkipDirective("note: [skip ci is not closed")).toBe(false);
+        expect(containsSkipDirective("note: skip ci] is not opened")).toBe(false);
+    });
+});
+
+describe("containsSkipDirective: empty / non-string inputs", () => {
+    it("returns false for an empty string", () => {
+        expect(containsSkipDirective("")).toBe(false);
+    });
+
+    it("returns false for a whitespace-only string", () => {
+        expect(containsSkipDirective("   \n\t  ")).toBe(false);
+    });
+
+    it.each([null, undefined, 0, 42, true, {}, [], ["[skip ci]"]])(
+        "returns false for the non-string input %s",
+        (value) => {
+            expect(containsSkipDirective(value as unknown as string)).toBe(false);
+        },
+    );
+});
+
+describe("findOffenders", () => {
+    it("returns an empty array when title, body, and all commits are clean", () => {
+        const offenders = findOffenders({
+            prTitle: "feat: add manual dispatch",
+            prBody: "Adds a workflow_dispatch trigger.",
+            commitMessages: ["feat: a", "fix: b", "chore: c"],
+        });
+        expect(offenders).toEqual([]);
+    });
+
+    it("flags a token in the PR title (the default squash subject)", () => {
+        const offenders = findOffenders({
+            prTitle: "feat: ship it [skip ci]",
+            prBody: "clean body",
+            commitMessages: ["feat: a"],
+        });
+        expect(offenders).toEqual(["PR title: feat: ship it [skip ci]"]);
+    });
+
+    it("flags a token in the PR body", () => {
+        const offenders = findOffenders({
+            prTitle: "clean title",
+            prBody: "please [ci skip] for now",
+            commitMessages: ["feat: a"],
+        });
+        expect(offenders).toEqual(["PR body"]);
+    });
+
+    it("flags a token that appears only in an intermediate commit (the bug this guard prevents)", () => {
+        const offenders = findOffenders({
+            prTitle: "clean title",
+            prBody: "clean body",
+            commitMessages: ["feat: a", "fix: b [skip ci]", "chore: c"],
+        });
+        expect(offenders).toEqual(["commit: fix: b [skip ci]"]);
+    });
+
+    it("identifies an offending commit by its subject when the token is in the body", () => {
+        const offenders = findOffenders({
+            prTitle: "clean title",
+            prBody: "clean body",
+            commitMessages: ["feat: add thing\n\ndetails here\n[no ci]"],
+        });
+        expect(offenders).toEqual(["commit: feat: add thing"]);
+    });
+
+    it("collects every offender in title, body, then commit order", () => {
+        const offenders = findOffenders({
+            prTitle: "release [skip ci]",
+            prBody: "and [ci skip] too",
+            commitMessages: ["feat: clean", "fix: dirty [no ci]"],
+        });
+        expect(offenders).toEqual([
+            "PR title: release [skip ci]",
+            "PR body",
+            "commit: fix: dirty [no ci]",
+        ]);
+    });
+
+    it("returns an empty array when there are no commits and clean metadata", () => {
+        const offenders = findOffenders({
+            prTitle: "clean title",
+            prBody: "clean body",
+            commitMessages: [],
+        });
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe("getCommitMessages: integration against a real repository", () => {
+    // Exercises the actual git boundary (no mocking) so a regression in the
+    // `--format=%B%x00` string or the NUL split is caught -- the parsing that a
+    // prior space-based separator got wrong by fragmenting multi-line messages.
+    let repoDir: string;
+    let baseSha: string;
+
+    const git = (args: string[]): string =>
+        execFileSync("git", args, { cwd: repoDir, encoding: "utf8" }).trim();
+
+    beforeAll(() => {
+        repoDir = mkdtempSync(join(tmpdir(), "skip-ci-guard-"));
+        git(["init", "-q", "-b", "main"]);
+        git(["config", "user.email", "guard@test.local"]);
+        git(["config", "user.name", "Guard Test"]);
+        git(["config", "commit.gpgsign", "false"]);
+
+        git(["commit", "-q", "--allow-empty", "-m", "chore: init base"]);
+        baseSha = git(["rev-parse", "HEAD"]);
+
+        git(["commit", "-q", "--allow-empty", "-m", "feat: alpha feature"]);
+        // Intermediate commit with a multi-line body whose token sits on a later
+        // line -- the real-world shape of the bug this guard exists to catch.
+        git([
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "fix: bravo bug",
+            "-m",
+            "Body paragraph one.",
+            "-m",
+            "[skip ci]",
+        ]);
+        git(["commit", "-q", "--allow-empty", "-m", "chore: charlie  with  wide  spaces"]);
+    });
+
+    afterAll(() => {
+        rmSync(repoDir, { recursive: true, force: true });
+    });
+
+    it("returns exactly one entry per commit in the exclusive base..head range", () => {
+        const messages = getCommitMessages(baseSha, "HEAD", repoDir);
+        expect(messages).toHaveLength(3);
+    });
+
+    it("keeps a multi-line commit body as a single entry (NUL split, not whitespace)", () => {
+        const messages = getCommitMessages(baseSha, "HEAD", repoDir);
+        const bravo = messages.find((message) => message.startsWith("fix: bravo bug"));
+        expect(bravo).toBeDefined();
+        expect(bravo).toContain("Body paragraph one.");
+        expect(bravo).toContain("[skip ci]");
+    });
+
+    it("does not fragment a subject that contains runs of multiple spaces", () => {
+        const messages = getCommitMessages(baseSha, "HEAD", repoDir);
+        expect(messages).toContain("chore: charlie  with  wide  spaces");
+    });
+
+    it("flags an intermediate offending commit end to end via findOffenders", () => {
+        const messages = getCommitMessages(baseSha, "HEAD", repoDir);
+        const offenders = findOffenders({
+            prTitle: "feat: clean title",
+            prBody: "clean body",
+            commitMessages: messages,
+        });
+        expect(offenders).toEqual(["commit: fix: bravo bug"]);
+    });
+
+    it("returns an empty array for an empty (base..base) range", () => {
+        const messages = getCommitMessages(baseSha, baseSha, repoDir);
+        expect(messages).toEqual([]);
+    });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces two main enhancements to the CI/CD pipeline:

1.  **Manual Publish Dispatch with Recovery Option:**
    *   The `publish.yml` workflow can now be manually triggered via `workflow_dispatch`.
    *   A new `force_publish` input is available for manual triggers. When set to `true`, it bypasses the version change check, allowing the current package version to be re-published. This serves as a recovery mechanism for situations where an automatic deployment might have been silently skipped by GitHub (e.g., due to a CI-skip token in a merge commit).
    *   The concurrency group for the publish workflow has been updated to include the event name, preventing a manual dispatch from canceling an in-progress push-triggered release run on the same branch.

2.  **CI-Skip Merge Guard:**
    *   A new `guard-no-skip-ci` job has been added to the `publish.yml` workflow, configured to run on pull requests.
    *   This job executes a new script, `scripts/check-no-skip-ci.js`, which scans the pull request's title, body, and all commit messages for GitHub CI-skip directives (e.g., `[skip ci]`, `[ci skip]`).
    *   If any CI-skip directive is detected, the job fails, preventing the pull request from being merged into the `main` branch (assuming this job is a required status check). This prevents accidental suppression of automatic deployments that can occur when a squash merge incorporates a CI-skip token from an intermediate commit into the final merge commit.
    *   Comprehensive unit and integration tests have been added for the `check-no-skip-ci.js` script to ensure its accuracy and robustness in detecting skip tokens.
<!-- kody-pr-summary:end -->