### PR TITLE
fix: discover git repository when workspace is a subdirectory of the git root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-06-18
+
+### Fixed
+
+- Fixed the extension entering no-repository mode when the workspace folder opened in the IDE is a subdirectory of the git root (e.g. opening `/root/client/project2` when `.git` lives at `/root/client`). Commits were blocked in this configuration even though IntelliJ IDE handled it correctly.
+
+### CI
+
+- Added a `workflow_dispatch` trigger to the publish workflow so a deploy silently skipped by GitHub can be re-triggered manually without a version bump (requires repo write access; a `force_publish` input bypasses only the version-change gate while the double-publish guard remains active).
+- Added a `guard-no-skip-ci` required status check that scans every PR commit message, PR title, and PR body for CI-skip directives and blocks the merge, preventing a squash merge from carrying a skip token into main and suppressing the push-to-main deploy.
+
 ## [0.11.1] - 2026-06-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/services/repositoryDiscovery.ts
+++ b/src/services/repositoryDiscovery.ts
@@ -96,7 +96,16 @@ async function addResolvedRoot(
     const resolved = await resolveGitRoot(candidateRoot).catch(() => null);
     if (!resolved) return;
     const root = await normalizeRoot(resolved);
-    if (!workspaceRoots.some((workspaceRoot) => isWithin(workspaceRoot, root))) return;
+    // Accept when the git root is inside the workspace (the common monorepo case) OR
+    // when the workspace is inside the git root (e.g. user opened a project subdirectory
+    // while the .git lives one level above). Reject roots that are completely outside to
+    // prevent a .git symlink from pulling in an unrelated external repository.
+    if (
+        !workspaceRoots.some(
+            (workspaceRoot) => isWithin(workspaceRoot, root) || isWithin(root, workspaceRoot),
+        )
+    )
+        return;
     if (seen.has(root)) return;
     seen.set(root, { root, label: labelForRoot(root, workspaceRoots) });
 }

--- a/tests/unit/git/repositoryDiscovery.test.ts
+++ b/tests/unit/git/repositoryDiscovery.test.ts
@@ -78,6 +78,33 @@ describe("discoverGitRepositories", () => {
         expect(repos).toEqual([{ root: path.resolve(app), label: "app" }]);
     });
 
+    it("discovers a git root that is a parent of the workspace (workspace opened as subdirectory)", async () => {
+        // /tmp/root/ is the git root (.git lives there); user opens /tmp/root/project2
+        const root = await makeTempWorkspace();
+        const project2 = path.join(root, "project2");
+        await fs.mkdir(project2, { recursive: true });
+        await makeGitMarker(root);
+        // Resolver simulates `git rev-parse --show-toplevel` returning the parent git root
+        const resolveGitRoot = vi.fn(async (candidateRoot: string) => {
+            if (candidateRoot === project2) return root;
+            return null;
+        });
+
+        const repos = await discoverGitRepositories([project2], { resolveGitRoot });
+
+        expect(repos).toEqual([{ root: path.resolve(root), label: path.basename(root) }]);
+    });
+
+    it("discovers the git root when workspace equals git root (no regression)", async () => {
+        const workspace = await makeTempWorkspace();
+        await makeGitMarker(workspace);
+        const resolveGitRoot = resolverFor([workspace]);
+
+        const repos = await discoverGitRepositories([workspace], { resolveGitRoot });
+
+        expect(repos).toEqual([{ root: path.resolve(workspace), label: path.basename(workspace) }]);
+    });
+
     it("drops resolved git roots outside the workspace real path", async () => {
         const workspace = await makeTempWorkspace();
         const outside = await makeTempWorkspace();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Enhances Git repository discovery to correctly identify repositories when the opened workspace is a subdirectory of the Git root.

Previously, the system would only recognize Git roots that were subdirectories of the workspace (e.g., in monorepo setups). This update modifies the discovery logic to also accept cases where the workspace itself is a subdirectory of the Git repository's root.

With this change, if a user opens a project subdirectory and the `.git` directory resides in a parent directory, the application will now correctly resolve and use that parent directory as the Git repository root. This ensures that commits and other Git operations are performed against the correct repository.

Includes new unit tests to validate this scenario and ensure no regressions for existing discovery patterns.
<!-- kody-pr-summary:end -->