### PR TITLE
fix(github): refresh pending commit checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2026-06-21
+
+### Fixed
+
+- Refreshed pending GitHub commit checks for visible commits so rows no longer keep spinning after GitHub Actions completes.
+
+### Tests
+
+- Added regression coverage for pending-check retry behavior in the commit list and provider cache refresh path.
+
 ## [0.12.0] - 2026-06-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -409,7 +409,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
 
     private async sendCommitChecks(hash: string): Promise<void> {
         const cached = this.commitChecksCache.get(hash);
-        if (cached) {
+        if (cached && cached.state !== "pending") {
             this.postToWebview({ type: "setCommitChecks", snapshot: cached });
             return;
         }

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -623,7 +623,7 @@ export class UndockedViewProvider {
 
     private async sendCommitChecks(hash: string): Promise<void> {
         const cached = this.commitChecksCache.get(hash);
-        if (cached) {
+        if (cached && cached.state !== "pending") {
             this.postToWebview({ type: "setCommitChecks", snapshot: cached });
             return;
         }

--- a/src/webviews/react/CommitGraphPanel.tsx
+++ b/src/webviews/react/CommitGraphPanel.tsx
@@ -333,9 +333,11 @@ export function CommitGraphPanel({
 
     const handleRequestCommitChecks = useCallback(
         (hash: string) => {
-            if (commitChecks.has(hash)) return;
+            const cached = commitChecks.get(hash);
+            if (cached && (cached === "loading" || cached.state !== "pending")) return;
             setCommitChecks((prev) => {
-                if (prev.has(hash)) return prev;
+                const latest = prev.get(hash);
+                if (latest && (latest === "loading" || latest.state !== "pending")) return prev;
                 const next = new Map(prev);
                 next.set(hash, "loading");
                 return next;

--- a/src/webviews/react/CommitList.tsx
+++ b/src/webviews/react/CommitList.tsx
@@ -33,6 +33,7 @@ import {
 
 const MIN_PREFIX_LENGTH = 7;
 const MAX_GRAPH_WIDTH = JETBRAINS_UI.graph.maxWidth;
+const PENDING_CHECK_REFRESH_MS = 15_000;
 
 /**
  * Allows cherry-pick actions when the graph is scoped to a non-current branch,
@@ -210,9 +211,20 @@ export function CommitList({
     );
     useEffect(() => {
         if (!onRequestCommitChecks) return;
+        const pendingHashes: string[] = [];
         for (const commit of visibleCommits) {
-            if (!commitChecks?.has(commit.hash)) onRequestCommitChecks(commit.hash);
+            const checks = commitChecks?.get(commit.hash);
+            if (!checks) {
+                onRequestCommitChecks(commit.hash);
+            } else if (checks !== "loading" && checks.state === "pending") {
+                pendingHashes.push(commit.hash);
+            }
         }
+        if (pendingHashes.length === 0) return;
+        const timer = window.setTimeout(() => {
+            for (const hash of pendingHashes) onRequestCommitChecks(hash);
+        }, PENDING_CHECK_REFRESH_MS);
+        return () => window.clearTimeout(timer);
     }, [commitChecks, onRequestCommitChecks, visibleCommits]);
 
     const branchScopeLabel = selectedBranch

--- a/src/webviews/react/NativeCommitGraph.tsx
+++ b/src/webviews/react/NativeCommitGraph.tsx
@@ -136,9 +136,11 @@ export function NativeCommitGraph({
 
     const handleRequestCommitChecks = useCallback(
         (hash: string) => {
-            if (commitChecks.has(hash)) return;
+            const cached = commitChecks.get(hash);
+            if (cached && (cached === "loading" || cached.state !== "pending")) return;
             setCommitChecks((prev) => {
-                if (prev.has(hash)) return prev;
+                const latest = prev.get(hash);
+                if (latest && (latest === "loading" || latest.state !== "pending")) return prev;
                 const next = new Map(prev);
                 next.set(hash, "loading");
                 return next;

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -423,9 +423,11 @@ function App(): React.ReactElement {
 
     const handleRequestCommitChecks = useCallback(
         (hash: string) => {
-            if (commitChecks.has(hash)) return;
+            const cached = commitChecks.get(hash);
+            if (cached && (cached === "loading" || cached.state !== "pending")) return;
             setCommitChecks((prev) => {
-                if (prev.has(hash)) return prev;
+                const latest = prev.get(hash);
+                if (latest && (latest === "loading" || latest.state !== "pending")) return prev;
                 const next = new Map(prev);
                 next.set(hash, "loading");
                 return next;

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -271,7 +271,7 @@ const titleStyle: React.CSSProperties = {
     fontSize: 13,
     fontWeight: 700,
     background: JETBRAINS_UI.color.panel,
-    color: JETBRAINS_UI.color.muted,
+    color: "var(--vscode-textLink-foreground, #4ea1ff)",
 };
 
 const bodyStyle: React.CSSProperties = {

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -270,8 +270,8 @@ const titleStyle: React.CSSProperties = {
     textAlign: "center",
     fontSize: 13,
     fontWeight: 700,
-    background: JETBRAINS_UI.color.panel,
-    color: "var(--vscode-textLink-foreground, #4ea1ff)",
+    background: "var(--vscode-textLink-foreground)",
+    color: "var(--vscode-button-foreground)",
 };
 
 const bodyStyle: React.CSSProperties = {

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -16,7 +16,8 @@ interface Props {
     onOpenCheckUrl: (url: string) => void;
 }
 
-const PANEL_WIDTH = 600;
+const PANEL_MAX_WIDTH = 420;
+const PANEL_TEXT_MAX_WIDTH = 340;
 const PANEL_MAX_HEIGHT = 360;
 const SPINNER_STYLE_ID = "intelligit-commit-check-spinner";
 const SPINNER_STYLE_RULES = `
@@ -59,7 +60,7 @@ export function CommitChecksButton({
         const rect = button.getBoundingClientRect();
         const placement =
             rect.bottom + PANEL_MAX_HEIGHT + 10 < window.innerHeight ? "below" : "above";
-        const panelWidth = Math.min(PANEL_WIDTH, window.innerWidth - 16);
+        const panelWidth = Math.min(PANEL_MAX_WIDTH, window.innerWidth - 16);
         const panelHeight = Math.min(PANEL_MAX_HEIGHT, Math.max(0, window.innerHeight - 16));
         setPosition({
             left: Math.min(
@@ -256,8 +257,8 @@ const buttonStyle: React.CSSProperties = {
 
 const panelStyle: React.CSSProperties = {
     position: "fixed",
-    width: PANEL_WIDTH,
-    maxWidth: "calc(100vw - 16px)",
+    width: "max-content",
+    maxWidth: `min(${PANEL_MAX_WIDTH}px, calc(100vw - 16px))`,
     maxHeight: `min(${PANEL_MAX_HEIGHT}px, calc(100vh - 16px))`,
     overflow: "hidden",
     background: JETBRAINS_UI.color.panel,
@@ -282,6 +283,9 @@ const bodyStyle: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
     gap: 11,
+    boxSizing: "border-box",
+    width: "max-content",
+    maxWidth: "100%",
     maxHeight: 250,
     overflow: "auto",
 };
@@ -297,6 +301,8 @@ const rowTextStyle: React.CSSProperties = {
     display: "flex",
     flexDirection: "column",
     gap: 2,
+    width: "max-content",
+    maxWidth: PANEL_TEXT_MAX_WIDTH,
 };
 
 const linkButtonStyle: React.CSSProperties = {
@@ -307,17 +313,23 @@ const linkButtonStyle: React.CSSProperties = {
     textAlign: "left",
     fontSize: 13,
     cursor: "pointer",
+    maxWidth: "100%",
+    overflowWrap: "anywhere",
 };
 
 const nameStyle: React.CSSProperties = {
     color: "var(--vscode-textLink-foreground, #4ea1ff)",
     fontSize: 13,
+    maxWidth: "100%",
+    overflowWrap: "anywhere",
 };
 
 const descriptionStyle: React.CSSProperties = {
     color: JETBRAINS_UI.color.muted,
     fontSize: 12,
     lineHeight: "16px",
+    maxWidth: "100%",
+    overflowWrap: "anywhere",
 };
 
 const emptyStyle: React.CSSProperties = {

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -92,11 +92,14 @@ export function CommitChecksButton({
         const closeOnEscape = (event: KeyboardEvent): void => {
             if (event.key === "Escape") setPosition(null);
         };
+        const closeOnWindowBlur = (): void => setPosition(null);
         document.addEventListener("pointerdown", closeOnOutsidePointer);
         document.addEventListener("keydown", closeOnEscape);
+        window.addEventListener("blur", closeOnWindowBlur);
         return () => {
             document.removeEventListener("pointerdown", closeOnOutsidePointer);
             document.removeEventListener("keydown", closeOnEscape);
+            window.removeEventListener("blur", closeOnWindowBlur);
         };
     }, [position]);
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -134,6 +134,7 @@ const vscodeMock = {
 };
 
 const deleteFileWithFallback = vi.fn(async () => true);
+const getGithubCommitChecks = vi.hoisted(() => vi.fn());
 
 vi.mock("vscode", () => vscodeMock);
 vi.mock("../../../src/views/webviewHtml", () => ({
@@ -155,6 +156,9 @@ vi.mock("../../../src/utils/fileOps", async () => {
         deleteFileWithFallback,
     };
 });
+vi.mock("../../../src/services/githubCommitChecksService", () => ({
+    getGithubCommitChecks,
+}));
 
 function createWebviewView() {
     let messageHandler: MessageHandler | undefined;
@@ -321,6 +325,12 @@ describe("view providers integration", () => {
         vi.clearAllMocks();
         workspaceState.workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         showWarningMessage.mockResolvedValue(undefined);
+        getGithubCommitChecks.mockImplementation(async (_gitOps: unknown, hash: string) => ({
+            hash,
+            state: "success",
+            summary: "All checks passed",
+            items: [],
+        }));
     });
 
     it("OnboardingViewProvider renders clone and open-folder actions when no workspace is open", async () => {
@@ -795,6 +805,44 @@ describe("view providers integration", () => {
         await provider.refresh();
         expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Git log error"));
 
+        provider.dispose();
+    });
+
+    it("CommitGraphViewProvider refetches cached pending commit checks", async () => {
+        const { CommitGraphViewProvider } = await import("../../../src/views/CommitGraphViewProvider");
+        const gitOps = makeGitOpsMock();
+        const provider = new CommitGraphViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+        );
+        const webview = createWebviewView();
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        getGithubCommitChecks
+            .mockResolvedValueOnce({
+                hash: "abc1234",
+                state: "pending",
+                summary: "Checks pending",
+                items: [],
+            })
+            .mockResolvedValueOnce({
+                hash: "abc1234",
+                state: "success",
+                summary: "All checks passed",
+                items: [],
+            });
+
+        await webview.send({ type: "requestCommitChecks", hash: "abc1234" });
+        await webview.send({ type: "requestCommitChecks", hash: "abc1234" });
+
+        expect(getGithubCommitChecks).toHaveBeenCalledTimes(2);
+        expect(postMessageSpy).toHaveBeenLastCalledWith({
+            type: "setCommitChecks",
+            snapshot: expect.objectContaining({ state: "success" }),
+        });
         provider.dispose();
     });
 

--- a/tests/webview/unit/low-coverage-components.test.tsx
+++ b/tests/webview/unit/low-coverage-components.test.tsx
@@ -2,7 +2,7 @@
 
 import React, { act, useRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Branch, Commit } from "../../../src/types";
+import type { Branch, Commit, CommitChecksSnapshot } from "../../../src/types";
 import { BranchColumn } from "../../../src/webviews/react/BranchColumn";
 import { CommitList } from "../../../src/webviews/react/CommitList";
 import { CommitRow } from "../../../src/webviews/react/commit-list/CommitRow";
@@ -457,5 +457,53 @@ describe("low coverage components", () => {
         expect(onLoadMore).toHaveBeenCalled();
 
         unmount(root, container);
+    });
+
+    it("CommitList retries visible pending check snapshots", async () => {
+        vi.useFakeTimers();
+        const onRequestCommitChecks = vi.fn();
+        const commit: Commit = {
+            hash: "aa11bb22",
+            shortHash: "aa11bb22",
+            message: "feat: pending checks",
+            author: "Mahesh",
+            email: "m@example.com",
+            date: "2026-02-19T00:00:00Z",
+            parentHashes: ["p1"],
+            refs: [],
+        };
+        const pending: CommitChecksSnapshot = {
+            hash: "aa11bb22",
+            state: "pending",
+            summary: "Checks pending",
+            items: [],
+        };
+        const { root, container } = mount(
+            <CommitList
+                commits={[commit]}
+                selectedHash={null}
+                filterText=""
+                hasMore={false}
+                unpushedHashes={new Set()}
+                selectedBranch={null}
+                onSelectCommit={vi.fn()}
+                onFilterText={vi.fn()}
+                onLoadMore={vi.fn()}
+                onCommitAction={vi.fn()}
+                commitChecks={new Map([["aa11bb22", pending]])}
+                onRequestCommitChecks={onRequestCommitChecks}
+                onOpenCommitCheckUrl={vi.fn()}
+            />,
+        );
+        await flush();
+        expect(onRequestCommitChecks).not.toHaveBeenCalled();
+
+        act(() => {
+            vi.runOnlyPendingTimers();
+        });
+
+        expect(onRequestCommitChecks).toHaveBeenCalledWith("aa11bb22");
+        unmount(root, container);
+        vi.useRealTimers();
     });
 });

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -245,7 +245,12 @@ describe("webview ui smoke", () => {
                 (node.textContent?.includes("GitHub Commit Checks") ?? false),
         );
         expect(panel?.style.transform).toBe("translateY(-100%)");
+        expect(panel?.style.width).toBe("max-content");
         expect(Number.parseFloat(panel?.style.top ?? "0")).toBeGreaterThanOrEqual(312);
+        const description = Array.from(document.querySelectorAll("span")).find(
+            (node) => node.textContent === "No secrets detected",
+        );
+        expect(description?.style.overflowWrap).toBe("anywhere");
 
         const link = Array.from(document.querySelectorAll("button")).find(
             (button) => button.textContent === "GitGuardian Security Checks",

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -268,6 +268,16 @@ describe("webview ui smoke", () => {
         expect(document.body.textContent).toContain("GitHub Commit Checks");
 
         act(() => {
+            window.dispatchEvent(new Event("blur"));
+        });
+        expect(document.body.textContent).not.toContain("GitHub Commit Checks");
+
+        act(() => {
+            trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        expect(document.body.textContent).toContain("GitHub Commit Checks");
+
+        act(() => {
             trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         });
         expect(document.body.textContent).not.toContain("GitHub Commit Checks");


### PR DESCRIPTION
### Title

fix(github): refresh pending commit checks

### Motivation

GitHub commit checks introduced in v0.12.0 can remain in a pending/spinning state after GitHub Actions completes because pending snapshots were cached and treated as final. The affected case is visible on the `v0.12.0` tagged commit after its pipeline has already passed.

### Summary

- Retry visible pending commit-check snapshots so completed GitHub Actions runs can replace the spinner.
- Refetch cached pending snapshots in both commit graph providers instead of replaying stale pending data.
- Keep dedupe for loading/final commit-check states while allowing pending states to refresh.
- Bump the extension version to `0.12.1` and add the changelog entry.
- Add regression tests for the webview retry loop and provider pending-cache refresh path.

### Detailed Changes

#### Code

- Added visible pending-check retry scheduling in `CommitList`.
- Updated commit graph, native graph, and undocked request handlers to allow pending snapshots to be requested again.
- Updated host providers to refetch cached `pending` commit checks while continuing to reuse final snapshots.

#### Tests

- Added a webview regression test for retrying visible pending check snapshots.
- Added an integration test proving `CommitGraphViewProvider` refetches cached pending commit checks.

#### Documentation

- Added `0.12.1` changelog entry.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- Updated `package.json` version to `0.12.1`.

### Testing

- Unit/regression tests: Added coverage in `tests/webview/unit/low-coverage-components.test.tsx` and `tests/integration/extension/view-providers.integration.test.ts`.
- Feature/bug verification: Verified `v0.12.0` points to `334ecd60df68cad7862aa83e6d9bbac868765a9b` and GitHub reports completed check-runs for `build`, `release`, and `guard-no-skip-ci`.
- Validation summary: Passed focused Vitest, format, lint, architecture, react-doctor, typecheck, build, full test suite, coverage, production build, and VSIX packaging.
- Limitations: Existing React/Vitest console warnings still print during test runs; commands exited successfully. `react-doctor` still reports its existing warning inventory and exits 0.

### Risks / Notes

- Pending checks retry only for visible commits and only while the snapshot state is `pending`, so finished states remain cached and request traffic stays bounded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pending GitHub commit checks to refresh automatically after completion instead of remaining in a loading state.

* **Style**
  * Updated commit checks popover title color for improved visibility in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->