### PR TITLE
feat(commit-panel): place git actions beside stash tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.4] - 2026-06-23
+
+### Changed
+
+- Moved Fetch, Pull, Push, and Sync beside the Commit and Stash tabs while keeping the same actions available in the graph header.
+- Matched the graph-header Git action icons with the toolbar icon style and increased spacing between the tab-row Git actions.
+- Updated the Stash Apply and Pop buttons to use the same primary button style as Commit and Push.
+- Refreshed README copy to position IntelliGit as bringing together the best Git features from PyCharm, VS Code, and Visual Studio IDE.
+
+### Tests
+
+- Updated webview integration coverage for the Commit panel tab-row Git actions and outbound messages.
+
 ## [0.13.3] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 </p>
 
 <p align="center">
-  <strong>JetBrains-style Git for VS Code.</strong><br />
-  A focused commit panel, readable branch graph, shelf workflow, and merge tooling for developers who miss JetBrains Git inside VS Code.
+  <strong>The best Git features from PyCharm, VS Code, and Visual Studio IDE.</strong><br />
+  A focused commit panel, readable branch graph, shelf workflow, and merge tooling for developers who want powerful IDE Git inside VS Code.
 </p>
 
 <p align="center">
@@ -34,7 +34,7 @@
   <img src="image.png" alt="IntelliGit commit panel and graph" />
 </p>
 
-IntelliGit is for developers who like VS Code, but miss the Git workflow from IntelliJ IDEA and PyCharm: a real commit panel, a readable branch graph, branch actions where the history is, shelf-style parking for unfinished work, and merge-conflict tools that do not make you rebuild context from terminal output.
+IntelliGit brings the best Git workflow ideas from PyCharm, VS Code, and Visual Studio IDE into one VS Code extension: a real commit panel, a readable branch graph, branch actions where the history is, shelf-style parking for unfinished work, and merge-conflict tools that do not make you rebuild context from terminal output.
 
 It does not try to replace Git. It gives the daily Git work a better cockpit.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -482,6 +482,18 @@ function App(): React.ReactElement {
         vscode.postMessage({ type: "push" });
     }, []);
 
+    const handleSync = useCallback(() => {
+        vscode.postMessage({ type: "sync" });
+    }, []);
+
+    const handleFetch = useCallback(() => {
+        vscode.postMessage({ type: "fetch" });
+    }, []);
+
+    const handlePull = useCallback(() => {
+        vscode.postMessage({ type: "pull" });
+    }, []);
+
     const handleDock = useCallback(() => {
         vscode.postMessage({ type: "dock" });
     }, []);
@@ -509,6 +521,9 @@ function App(): React.ReactElement {
                                 onAmendChange={handleAmendChange}
                                 onCommit={handleCommit}
                                 canCommit={canCommit}
+                                onSync={handleSync}
+                                onFetch={handleFetch}
+                                onPull={handlePull}
                                 onPush={handlePush}
                                 canPush={canPush}
                                 groupByDir={groupByDir}
@@ -653,6 +668,9 @@ function App(): React.ReactElement {
                                 onAmendChange={handleAmendChange}
                                 onCommit={handleCommit}
                                 canCommit={canCommit}
+                                onSync={handleSync}
+                                onFetch={handleFetch}
+                                onPull={handlePull}
                                 onPush={handlePush}
                                 canPush={canPush}
                                 groupByDir={groupByDir}

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -78,11 +78,27 @@ function App(): React.ReactElement {
         vscode.postMessage({ type: "push" });
     }, [vscode]);
 
+    const handleSync = useCallback(() => {
+        vscode.postMessage({ type: "sync" });
+    }, [vscode]);
+
+    const handleFetch = useCallback(() => {
+        vscode.postMessage({ type: "fetch" });
+    }, [vscode]);
+
+    const handlePull = useCallback(() => {
+        vscode.postMessage({ type: "pull" });
+    }, [vscode]);
+
     return (
         <Box display="flex" flexDirection="column" h="100%" bg="var(--intelligit-pycharm-panel)">
             <ThemeIconFontFaces fonts={state.iconFonts} />
             <TabBar
                 stashCount={state.stashes.length}
+                onSync={handleSync}
+                onFetch={handleFetch}
+                onPull={handlePull}
+                onPush={handlePush}
                 commitContent={
                     <CommitTab
                         files={state.files}

--- a/src/webviews/react/commit-panel/components/CommitTab.tsx
+++ b/src/webviews/react/commit-panel/components/CommitTab.tsx
@@ -119,18 +119,6 @@ export function CommitTab({
         vscode.postMessage({ type: "refresh" });
     }, [showRefreshFeedback, vscode]);
 
-    const handleSync = useCallback(() => {
-        vscode.postMessage({ type: "sync" });
-    }, [vscode]);
-
-    const handleFetch = useCallback(() => {
-        vscode.postMessage({ type: "fetch" });
-    }, [vscode]);
-
-    const handlePull = useCallback(() => {
-        vscode.postMessage({ type: "pull" });
-    }, [vscode]);
-
     const handleRollback = useCallback(() => {
         vscode.postMessage({ type: "rollback", paths: Array.from(checkedPaths) });
     }, [vscode, checkedPaths]);
@@ -175,10 +163,6 @@ export function CommitTab({
                 onShowDiff={handleShowDiff}
                 onExpandAll={() => setExpandAllSignal((s) => s + 1)}
                 onCollapseAll={() => setCollapseAllSignal((s) => s + 1)}
-                onSync={handleSync}
-                onFetch={handleFetch}
-                onPull={handlePull}
-                onPush={onPush}
             />
 
             {isAmend ? (

--- a/src/webviews/react/commit-panel/components/ShelfTab.tsx
+++ b/src/webviews/react/commit-panel/components/ShelfTab.tsx
@@ -431,38 +431,22 @@ export function ShelfTab({
                 bg="var(--intelligit-pycharm-panel)"
             >
                 <Button
-                    variant="secondary"
+                    variant="primary"
                     size="sm"
                     onClick={() => handleShelfAction(selectedIndex, "apply")}
                     isDisabled={selectedIndex === null}
                     fontSize="12px"
-                    h="32px"
-                    minW="144px"
-                    px="12px"
-                    bg="var(--intelligit-pycharm-input, var(--vscode-button-secondaryBackground))"
-                    borderColor="var(--intelligit-pycharm-input-border, var(--vscode-button-border))"
-                    borderRadius="2px"
-                    _hover={{
-                        bg: "var(--intelligit-pycharm-header, var(--vscode-button-secondaryHoverBackground))",
-                    }}
+                    fontFamily={SYSTEM_FONT_STACK}
                 >
                     {t("common.apply")}
                 </Button>
                 <Button
-                    variant="secondary"
+                    variant="primary"
                     size="sm"
                     onClick={() => handleShelfAction(selectedIndex, "pop")}
                     isDisabled={selectedIndex === null}
                     fontSize="12px"
-                    h="32px"
-                    minW="144px"
-                    px="12px"
-                    bg="var(--intelligit-pycharm-input, var(--vscode-button-secondaryBackground))"
-                    borderColor="var(--intelligit-pycharm-input-border, var(--vscode-button-border))"
-                    borderRadius="2px"
-                    _hover={{
-                        bg: "var(--intelligit-pycharm-header, var(--vscode-button-secondaryHoverBackground))",
-                    }}
+                    fontFamily={SYSTEM_FONT_STACK}
                 >
                     {t("common.pop")}
                 </Button>

--- a/src/webviews/react/commit-panel/components/TabBar.tsx
+++ b/src/webviews/react/commit-panel/components/TabBar.tsx
@@ -2,7 +2,16 @@
 // with custom styling to match the VS Code sidebar appearance.
 
 import React from "react";
-import { IconButton, Tab, TabList, TabPanel, TabPanels, Tabs, Tooltip } from "@chakra-ui/react";
+import {
+    Flex,
+    IconButton,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
+    Tooltip,
+} from "@chakra-ui/react";
 import { getSettings } from "../../shared/settings";
 import { t } from "../../shared/i18n";
 
@@ -69,59 +78,65 @@ export function TabBar({
             h="100%"
             bg="var(--intelligit-pycharm-panel)"
         >
-            <TabList
+            <Flex
+                data-testid="commit-panel-tab-row"
                 bg="var(--intelligit-pycharm-header)"
                 borderBottom="1px solid var(--intelligit-pycharm-border)"
                 flexShrink={0}
+                align="stretch"
             >
-                {tabs.map((tab) => (
-                    <Tab key={tab.key} {...sharedTabStyles}>
-                        {tab.label}
-                    </Tab>
-                ))}
-                <GitActionButton label={t("common.sync")} onClick={onSync} color="#c8a2ff">
-                    <path
-                        fill="currentColor"
-                        d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
-                    />
-                </GitActionButton>
-                <GitActionButton label={t("common.fetch")} onClick={onFetch} color="#8fd5ff">
-                    <path
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.3"
-                        d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
-                    />
-                    <path
-                        fill="none"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="1.3"
-                        d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
-                    />
-                </GitActionButton>
-                <GitActionButton label={t("common.pull")} onClick={onPull} color="#8fd5ff">
-                    <path
-                        fill="currentColor"
-                        d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
-                    />
-                    <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                </GitActionButton>
-                <GitActionButton
-                    label={t("common.push")}
-                    onClick={onPush}
-                    color="var(--vscode-gitDecoration-addedResourceForeground, #a6e3a1)"
-                >
-                    <path
-                        fill="currentColor"
-                        d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
-                    />
-                    <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                </GitActionButton>
-            </TabList>
+                <TabList>
+                    {tabs.map((tab) => (
+                        <Tab key={tab.key} {...sharedTabStyles}>
+                            {tab.label}
+                        </Tab>
+                    ))}
+                </TabList>
+                <Flex align="center">
+                    <GitActionButton label={t("common.sync")} onClick={onSync} color="#c8a2ff">
+                        <path
+                            fill="currentColor"
+                            d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
+                        />
+                    </GitActionButton>
+                    <GitActionButton label={t("common.fetch")} onClick={onFetch} color="#8fd5ff">
+                        <path
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="1.3"
+                            d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
+                        />
+                        <path
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="1.3"
+                            d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
+                        />
+                    </GitActionButton>
+                    <GitActionButton label={t("common.pull")} onClick={onPull} color="#8fd5ff">
+                        <path
+                            fill="currentColor"
+                            d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
+                        />
+                        <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                    </GitActionButton>
+                    <GitActionButton
+                        label={t("common.push")}
+                        onClick={onPush}
+                        color="var(--vscode-gitDecoration-addedResourceForeground, #a6e3a1)"
+                    >
+                        <path
+                            fill="currentColor"
+                            d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
+                        />
+                        <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                    </GitActionButton>
+                </Flex>
+            </Flex>
             <TabPanels flex={1} overflow="hidden" display="flex" flexDirection="column">
                 {tabs.map((tab) => (
                     <TabPanel

--- a/src/webviews/react/commit-panel/components/TabBar.tsx
+++ b/src/webviews/react/commit-panel/components/TabBar.tsx
@@ -2,11 +2,16 @@
 // with custom styling to match the VS Code sidebar appearance.
 
 import React from "react";
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@chakra-ui/react";
+import { IconButton, Tab, TabList, TabPanel, TabPanels, Tabs, Tooltip } from "@chakra-ui/react";
+import { getSettings } from "../../shared/settings";
 import { t } from "../../shared/i18n";
 
 interface Props {
     stashCount: number;
+    onSync: () => void;
+    onFetch: () => void;
+    onPull: () => void;
+    onPush: () => void;
     commitContent: React.ReactNode;
     shelfContent: React.ReactNode;
 }
@@ -35,7 +40,15 @@ const sharedTabStyles = {
  * presentation-only while still reflecting the current stash count in the shelf
  * label.
  */
-export function TabBar({ stashCount, commitContent, shelfContent }: Props): React.ReactElement {
+export function TabBar({
+    stashCount,
+    onSync,
+    onFetch,
+    onPull,
+    onPush,
+    commitContent,
+    shelfContent,
+}: Props): React.ReactElement {
     const tabs: Array<{ key: string; label: string; content: React.ReactNode }> = [
         { key: "commit", label: t("commit.tab.commit"), content: commitContent },
         {
@@ -66,6 +79,48 @@ export function TabBar({ stashCount, commitContent, shelfContent }: Props): Reac
                         {tab.label}
                     </Tab>
                 ))}
+                <GitActionButton label={t("common.sync")} onClick={onSync} color="#c8a2ff">
+                    <path
+                        fill="currentColor"
+                        d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
+                    />
+                </GitActionButton>
+                <GitActionButton label={t("common.fetch")} onClick={onFetch} color="#8fd5ff">
+                    <path
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.3"
+                        d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
+                    />
+                    <path
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.3"
+                        d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
+                    />
+                </GitActionButton>
+                <GitActionButton label={t("common.pull")} onClick={onPull} color="#8fd5ff">
+                    <path
+                        fill="currentColor"
+                        d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
+                    />
+                    <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                </GitActionButton>
+                <GitActionButton
+                    label={t("common.push")}
+                    onClick={onPush}
+                    color="var(--vscode-gitDecoration-addedResourceForeground, #a6e3a1)"
+                >
+                    <path
+                        fill="currentColor"
+                        d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
+                    />
+                    <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                </GitActionButton>
             </TabList>
             <TabPanels flex={1} overflow="hidden" display="flex" flexDirection="column">
                 {tabs.map((tab) => (
@@ -82,5 +137,48 @@ export function TabBar({ stashCount, commitContent, shelfContent }: Props): Reac
                 ))}
             </TabPanels>
         </Tabs>
+    );
+}
+
+function GitActionButton({
+    label,
+    onClick,
+    color,
+    children,
+}: {
+    label: string;
+    onClick: () => void;
+    color: string;
+    children: React.ReactNode;
+}): React.ReactElement {
+    const { hoverDelay, tooltipsEnabled, iconStyle } = getSettings();
+    const resolvedColor = iconStyle === "standard" ? "var(--vscode-icon-foreground)" : color;
+    return (
+        <Tooltip
+            label={label}
+            fontSize="11px"
+            placement="bottom"
+            openDelay={hoverDelay}
+            isDisabled={!tooltipsEnabled}
+        >
+            <IconButton
+                aria-label={label}
+                variant="toolbarGhost"
+                size="sm"
+                alignSelf="center"
+                mx="4px"
+                onClick={onClick}
+                icon={
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        style={{ color: resolvedColor }}
+                    >
+                        {children}
+                    </svg>
+                }
+            />
+        </Tooltip>
     );
 }

--- a/src/webviews/react/commit-panel/components/Toolbar.tsx
+++ b/src/webviews/react/commit-panel/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 // Toolbar with commit-view Git and file actions.
 
 import React from "react";
-import { Box, Flex, IconButton, Tooltip } from "@chakra-ui/react";
+import { Flex, IconButton, Tooltip } from "@chakra-ui/react";
 import { getSettings } from "../../shared/settings";
 import { CollapseAllIconGlyph, ExpandAllIconGlyph } from "../../shared/components";
 import { t } from "../../shared/i18n";
@@ -15,10 +15,6 @@ interface Props {
     onShowDiff: () => void;
     onExpandAll: () => void;
     onCollapseAll: () => void;
-    onSync: () => void;
-    onFetch: () => void;
-    onPull: () => void;
-    onPush: () => void;
 }
 
 const SPIN_KEYFRAMES = `@keyframes intelligit-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`;
@@ -39,10 +35,6 @@ export function Toolbar({
     onShowDiff,
     onExpandAll,
     onCollapseAll,
-    onSync,
-    onFetch,
-    onPull,
-    onPush,
 }: Props): React.ReactElement {
     return (
         <Flex
@@ -102,49 +94,6 @@ export function Toolbar({
             </ToolbarButton>
             <ToolbarButton label={t("common.collapseAll")} onClick={onCollapseAll} color="#f3b1cf">
                 <CollapseAllIconGlyph />
-            </ToolbarButton>
-            <Box flex="1" />
-            <ToolbarButton label={t("common.sync")} onClick={onSync} color="#c8a2ff">
-                <path
-                    fill="currentColor"
-                    d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
-                />
-            </ToolbarButton>
-            <ToolbarButton label={t("common.fetch")} onClick={onFetch} color="#8fd5ff">
-                <path
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="1.3"
-                    d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
-                />
-                <path
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="1.3"
-                    d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
-                />
-            </ToolbarButton>
-            <ToolbarButton label={t("common.pull")} onClick={onPull} color="#8fd5ff">
-                <path
-                    fill="currentColor"
-                    d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
-                />
-                <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-            </ToolbarButton>
-            <ToolbarButton
-                label={t("common.push")}
-                onClick={onPush}
-                color="var(--vscode-gitDecoration-addedResourceForeground, #a6e3a1)"
-            >
-                <path
-                    fill="currentColor"
-                    d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
-                />
-                <path fill="currentColor" d="M3 13h10v1H3v-1z" />
             </ToolbarButton>
         </Flex>
     );

--- a/src/webviews/react/undocked/CommitPanelPane.tsx
+++ b/src/webviews/react/undocked/CommitPanelPane.tsx
@@ -19,6 +19,9 @@ interface CommitPanelPaneProps {
     onAmendChange: (isAmend: boolean) => void;
     onCommit: () => void;
     canCommit: boolean;
+    onSync: () => void;
+    onFetch: () => void;
+    onPull: () => void;
     onPush: () => void;
     canPush: boolean;
     groupByDir: boolean;
@@ -42,6 +45,9 @@ export function CommitPanelPane({
     onAmendChange,
     onCommit,
     canCommit,
+    onSync,
+    onFetch,
+    onPull,
     onPush,
     canPush,
     groupByDir,
@@ -59,6 +65,10 @@ export function CommitPanelPane({
             <Box flex={1} overflow="hidden" display="flex" flexDirection="column">
                 <TabBar
                     stashCount={cpState.stashes.length}
+                    onSync={onSync}
+                    onFetch={onFetch}
+                    onPull={onPull}
+                    onPush={onPush}
                     commitContent={
                         <CommitTab
                             files={cpState.files}

--- a/tests/integration/webviews/webview-apps.integration.test.tsx
+++ b/tests/integration/webviews/webview-apps.integration.test.tsx
@@ -167,6 +167,15 @@ describe("CommitPanelApp integration", () => {
         });
         await flush();
 
+        const buttonLabels = Array.from(document.querySelectorAll("button")).map(
+            (button) => button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
+        );
+        const gitActionOrder = ["Commit", "Stash (1)", "Sync", "Fetch", "Pull", "Push"].map(
+            (label) => buttonLabels.indexOf(label),
+        );
+        expect(gitActionOrder.every((index) => index >= 0)).toBe(true);
+        expect(gitActionOrder).toEqual([...gitActionOrder].sort((a, b) => a - b));
+
         fireClick(document.querySelector('button[aria-label="Refresh"]'));
         fireClick(document.querySelector('button[aria-label="Rollback"]'));
         fireClick(document.querySelector('button[aria-label="Group by Directory"]'));

--- a/tests/integration/webviews/webview-apps.integration.test.tsx
+++ b/tests/integration/webviews/webview-apps.integration.test.tsx
@@ -167,7 +167,9 @@ describe("CommitPanelApp integration", () => {
         });
         await flush();
 
-        const buttonLabels = Array.from(document.querySelectorAll("button")).map(
+        const tabRow = document.querySelector('[data-testid="commit-panel-tab-row"]');
+        expect(tabRow).not.toBeNull();
+        const buttonLabels = Array.from(tabRow?.querySelectorAll("button") ?? []).map(
             (button) => button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
         );
         const gitActionOrder = ["Commit", "Stash (1)", "Sync", "Fetch", "Pull", "Push"].map(
@@ -175,6 +177,10 @@ describe("CommitPanelApp integration", () => {
         );
         expect(gitActionOrder.every((index) => index >= 0)).toBe(true);
         expect(gitActionOrder).toEqual([...gitActionOrder].sort((a, b) => a - b));
+        const tabListLabels = Array.from(tabRow?.querySelectorAll('[role="tab"]') ?? []).map(
+            (tab) => tab.textContent?.trim() ?? "",
+        );
+        expect(tabListLabels).toEqual(["Commit", "Stash (1)"]);
 
         fireClick(document.querySelector('button[aria-label="Refresh"]'));
         fireClick(document.querySelector('button[aria-label="Rollback"]'));


### PR DESCRIPTION
### Title

feat(commit-panel): place git actions beside stash tab

### Motivation

Keep common Git transport actions closer to the Commit/Stash workflow while preserving the graph-header controls, and make Stash Apply/Pop visually consistent with Commit/Push.

### Summary

- Moves Sync, Fetch, Pull, and Push into the Commit panel tab row beside Commit and Stash.
- Wires the tab-row actions through docked and undocked Commit panel hosts.
- Removes duplicate Git transport actions from the Commit file toolbar while keeping file-only toolbar actions there.
- Updates Stash Apply and Pop to use the primary button variant used by Commit and Push.
- Bumps the extension version to 0.13.4 and updates the changelog.
- Refreshes README positioning around PyCharm, VS Code, and Visual Studio IDE Git features.

### Detailed Changes

#### Code

- `TabBar` now owns the tab-row Sync, Fetch, Pull, and Push buttons.
- `CommitPanelApp`, `UndockedApp`, and `CommitPanelPane` pass Git operation handlers into `TabBar`.
- `CommitTab` and `Toolbar` no longer render duplicate Git transport controls in the file toolbar.
- `ShelfTab` uses `variant="primary"` for Apply and Pop.

#### Tests

- Updated webview integration coverage for tab-row Git action ordering and outbound messages.

#### Documentation

- Updated README product copy.
- Added the 0.13.4 changelog entry.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None.

### Testing

- Unit/regression tests: Updated `tests/integration/webviews/webview-apps.integration.test.tsx`.
- Feature/bug verification: Verified tab-row action ordering and host messages through webview integration coverage.
- Validation summary: `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run build`, `bun run test`, and `git diff --check` passed after rebasing onto `origin/main`; full test suite reported 48 files passed and 815 tests passed.
- Limitations: Pre-rebase `bun run react-doctor` exited 0 while reporting existing optional warnings; not re-run after rebase.

### Risks / Notes

- UI-only Commit panel change; existing graph-header Git actions remain available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sync, fetch, pull, and push action buttons to the commit panel tab header for quick access to Git operations.

* **Documentation**
  * Updated README to emphasize IntelliGit's cross-IDE Git feature integration (PyCharm, VS Code, Visual Studio).

* **Tests**
  * Enhanced webview integration coverage for commit panel tab-row Git action buttons and message handling.

* **Chores**
  * Released version 0.13.4 with UI and toolbar layout styling refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->