### PR TITLE
Fix Commit panel input height and empty-message state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.9] - 2026-06-25
+
+### Fixed
+
+- Disabled the Commit action until a non-amend commit has both selected files and a non-empty commit message.
+- Increased the default Commit input area height and kept Commit before Push/Publish in the action row.
+
+### Tests
+
+- Added webview regression coverage for whitespace-only commit messages and Commit/Push action order.
+
 ## [0.13.8] - 2026-06-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.13.8",
+    "version": "0.13.9",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -466,7 +466,8 @@ function App(): React.ReactElement {
         }
     }, []);
 
-    const canCommit = cpState.isAmend || checkedPaths.size > 0;
+    const canCommit =
+        cpState.isAmend || (checkedPaths.size > 0 && cpState.commitMessage.trim().length > 0);
     const shouldPublishBranch = !cpState.currentBranchHasUpstream;
     const canPush = shouldPublishBranch
         ? cpState.currentBranchName !== null

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -15,6 +15,7 @@ import theme from "./commit-panel/theme";
 import { getSettings } from "./shared/settings";
 import { CommitPanelPane } from "./undocked/CommitPanelPane";
 import { commitPanelReducer, initialCommitPanelState } from "./undocked/commitPanelState";
+import { canRunCommitAction } from "./commit-panel/commitEligibility";
 import {
     computeEqualSectionWidths,
     migrateSectionWidths,
@@ -466,8 +467,7 @@ function App(): React.ReactElement {
         }
     }, []);
 
-    const canCommit =
-        cpState.isAmend || (checkedPaths.size > 0 && cpState.commitMessage.trim().length > 0);
+    const canCommit = canRunCommitAction(cpState.isAmend, checkedPaths.size, cpState.commitMessage);
     const shouldPublishBranch = !cpState.currentBranchHasUpstream;
     const canPush = shouldPublishBranch
         ? cpState.currentBranchName !== null

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -12,6 +12,7 @@ import { useExtensionMessages } from "./hooks/useExtensionMessages";
 import { useCheckedFiles } from "./hooks/useCheckedFiles";
 import { getVsCodeApi } from "./hooks/useVsCodeApi";
 import { ThemeIconFontFaces } from "../shared/components";
+import { canRunCommitAction } from "./commitEligibility";
 
 /**
  * Root commit-panel React app wired to the VS Code webview host.
@@ -60,8 +61,7 @@ function App(): React.ReactElement {
         [dispatch, vscode],
     );
 
-    const canCommit =
-        state.isAmend || (checkedPaths.size > 0 && state.commitMessage.trim().length > 0);
+    const canCommit = canRunCommitAction(state.isAmend, checkedPaths.size, state.commitMessage);
     const shouldPublishBranch = !state.currentBranchHasUpstream;
     const canPush = shouldPublishBranch
         ? state.currentBranchName !== null

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -60,7 +60,8 @@ function App(): React.ReactElement {
         [dispatch, vscode],
     );
 
-    const canCommit = state.isAmend || checkedPaths.size > 0;
+    const canCommit =
+        state.isAmend || (checkedPaths.size > 0 && state.commitMessage.trim().length > 0);
     const shouldPublishBranch = !state.currentBranchHasUpstream;
     const canPush = shouldPublishBranch
         ? state.currentBranchName !== null

--- a/src/webviews/react/commit-panel/commitEligibility.ts
+++ b/src/webviews/react/commit-panel/commitEligibility.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns whether the commit action can run for the current commit-panel state.
+ *
+ * Amend commits are allowed without staged file selection because the previous
+ * commit supplies the target, while normal commits require both a file selection
+ * and a non-blank commit message.
+ */
+export function canRunCommitAction(
+    isAmend: boolean,
+    checkedFileCount: number,
+    commitMessage: string,
+): boolean {
+    return isAmend || (checkedFileCount > 0 && commitMessage.trim().length > 0);
+}

--- a/src/webviews/react/commit-panel/components/CommitTab.tsx
+++ b/src/webviews/react/commit-panel/components/CommitTab.tsx
@@ -84,8 +84,8 @@ export function CommitTab({
 }: Props): React.ReactElement {
     const containerRef = useRef<HTMLDivElement>(null);
     const { height: bottomHeight, onMouseDown: onDragMouseDown } = useDragResize(
-        140,
-        80,
+        170,
+        110,
         containerRef,
     );
     const vscode = getVsCodeApi();

--- a/src/webviews/react/commit-panel/hooks/useDragResize.ts
+++ b/src/webviews/react/commit-panel/hooks/useDragResize.ts
@@ -14,6 +14,21 @@ export interface DragResizeOptions {
     onResize?: (height: number) => void;
 }
 
+const FALLBACK_MAX_HEIGHT = 500;
+
+function getMaxHeight(
+    containerRef: React.RefObject<HTMLDivElement | null>,
+    maxReservedHeight: number,
+): number {
+    return containerRef.current
+        ? containerRef.current.clientHeight - maxReservedHeight
+        : FALLBACK_MAX_HEIGHT;
+}
+
+function clampHeight(height: number, minHeight: number, maxHeight: number): number {
+    return Math.max(minHeight, Math.min(maxHeight, height));
+}
+
 /**
  * Provides vertical drag-to-resize state for the commit-panel bottom area.
  *
@@ -27,10 +42,12 @@ export function useDragResize(
     containerRef: React.RefObject<HTMLDivElement | null>,
     options: DragResizeOptions = {},
 ): DragResizeAPI {
-    const [height, setHeight] = useState(initialHeight);
+    const { maxReservedHeight = 60, onResize } = options;
+    const [height, setHeight] = useState(() =>
+        clampHeight(initialHeight, minHeight, getMaxHeight(containerRef, maxReservedHeight)),
+    );
     const dragging = useRef(false);
     const heightRef = useRef(height);
-    const { maxReservedHeight = 60, onResize } = options;
     const onResizeRef = useRef(onResize);
 
     useEffect(() => {
@@ -40,6 +57,17 @@ export function useDragResize(
     useEffect(() => {
         heightRef.current = height;
     }, [height]);
+
+    useEffect(() => {
+        const nextHeight = clampHeight(
+            heightRef.current,
+            minHeight,
+            getMaxHeight(containerRef, maxReservedHeight),
+        );
+        if (nextHeight !== heightRef.current) {
+            setHeight(nextHeight);
+        }
+    }, [containerRef, maxReservedHeight, minHeight]);
 
     const onMouseDown = useCallback(
         (e: React.MouseEvent) => {
@@ -51,10 +79,8 @@ export function useDragResize(
             const onMouseMove = (ev: MouseEvent) => {
                 if (!dragging.current) return;
                 const delta = startY - ev.clientY;
-                const maxH = containerRef.current
-                    ? containerRef.current.clientHeight - maxReservedHeight
-                    : 500;
-                const nextHeight = Math.max(minHeight, Math.min(maxH, startH + delta));
+                const maxH = getMaxHeight(containerRef, maxReservedHeight);
+                const nextHeight = clampHeight(startH + delta, minHeight, maxH);
                 setHeight(nextHeight);
                 onResizeRef.current?.(nextHeight);
             };

--- a/tests/webview/unit/app-logic.test.tsx
+++ b/tests/webview/unit/app-logic.test.tsx
@@ -508,7 +508,7 @@ describe("app logic coverage", () => {
         expect(capturedGroupByDir).toBe(true);
     });
 
-    it("CommitPanelApp disables commit when no files are checked", async () => {
+    it("CommitPanelApp disables commit when selected files have no commit message", async () => {
         const postMessage = vi.fn();
 
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useExtensionMessages", () => ({
@@ -545,7 +545,7 @@ describe("app logic coverage", () => {
         }));
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useCheckedFiles", () => ({
             useCheckedFiles: () => ({
-                checkedPaths: new Set<string>(),
+                checkedPaths: new Set(["src/a.ts"]),
                 toggleFile: vi.fn(),
                 toggleFolder: vi.fn(),
                 toggleSection: vi.fn(),

--- a/tests/webview/unit/low-coverage-components.test.tsx
+++ b/tests/webview/unit/low-coverage-components.test.tsx
@@ -34,6 +34,37 @@ beforeEach(() => {
 });
 
 describe("low coverage components", () => {
+    it("useDragResize clamps initial height to container bounds", () => {
+        function Harness(): React.ReactElement {
+            const ref = useRef<HTMLDivElement | null>(null);
+            const { height } = useDragResize(220, 80, ref, {
+                maxReservedHeight: 50,
+            });
+            return (
+                <div
+                    ref={(node) => {
+                        if (node) {
+                            Object.defineProperty(node, "clientHeight", {
+                                value: 140,
+                                configurable: true,
+                            });
+                        }
+                        ref.current = node;
+                    }}
+                    data-host="1"
+                >
+                    <span data-height>{height}</span>
+                </div>
+            );
+        }
+
+        const { root, container } = mount(<Harness />);
+        const heightText = container.querySelector("[data-height]")?.textContent ?? "";
+        expect(Number(heightText)).toBe(90);
+
+        unmount(root, container);
+    });
+
     it("useDragResize updates and clamps height", () => {
         const onResize = vi.fn();
         function Harness(): React.ReactElement {

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -415,7 +415,11 @@ describe("webview ui smoke", () => {
         expect(html).toContain("Refresh");
         expect(html).toContain("Branch: main -&gt; origin/main");
         expect(html).not.toContain("Commit and Push");
-        expect(html.indexOf("Commit")).toBeLessThan(html.indexOf("Push"));
+        const commitActionIndex = html.indexOf("Commit");
+        const pushActionIndex = html.indexOf("Push");
+        expect(commitActionIndex).toBeGreaterThanOrEqual(0);
+        expect(pushActionIndex).toBeGreaterThanOrEqual(0);
+        expect(commitActionIndex).toBeLessThan(pushActionIndex);
         expect(html).toContain("Stash (2)");
 
         const disabledCommitHtml = renderToStaticMarkup(

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -415,6 +415,7 @@ describe("webview ui smoke", () => {
         expect(html).toContain("Refresh");
         expect(html).toContain("Branch: main -&gt; origin/main");
         expect(html).not.toContain("Commit and Push");
+        expect(html.indexOf("Commit")).toBeLessThan(html.indexOf("Push"));
         expect(html).toContain("Stash (2)");
 
         const disabledCommitHtml = renderToStaticMarkup(


### PR DESCRIPTION
### Title

Fix Commit panel input height and empty-message action state

### Motivation

Issue #72 feedback called out that the Commit input area was too short, Commit could be active with an empty message, and the Commit action should remain available before Push/Publish instead of steering users toward pushing.

### Summary

- Increases the default Commit input area height.
- Disables Commit for non-amend commits until selected files have a non-empty trimmed message.
- Applies the same enablement rule in docked and undocked Commit panels.
- Keeps Commit rendered before Push/Publish in the action row.
- Adds webview regression coverage for the empty-message state and action order.

### Detailed Changes

#### Code

- Updated `CommitPanelApp` and `UndockedApp` Commit enablement logic.
- Raised `CommitTab` default commit area height from 140px to 170px and minimum height from 80px to 110px.

#### Tests

- Updated `app-logic.test.tsx` to cover selected files with a whitespace-only commit message.
- Updated `ui-smoke.test.tsx` to assert Commit renders before Push.

#### Documentation

- None.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None.

### Testing

- Unit/regression tests: `bun vitest run tests/webview/unit/app-logic.test.tsx tests/webview/unit/ui-smoke.test.tsx` passed, 12 tests.
- Feature/bug verification: Verified Commit stays disabled for selected files with a whitespace-only message and Commit renders before Push.
- Validation summary: `bun run format:check`, `bun run lint`, `bun run architecture:check`, `bun run react-doctor`, `bun run typecheck`, `bun run build`, and `bun run test` passed. Full suite: 828 passed.
- Limitations: `react-doctor` reports existing warnings but exits successfully.

### Risks / Notes

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit actions now require a non-empty commit message when not amending, preventing accidental empty commits.
  * The bottom commit area has been adjusted to allow a slightly larger resize range.

* **Tests**
  * Updated coverage to verify commits stay disabled when the message is blank or whitespace-only.
  * Strengthened layout checks to confirm the Commit area appears before Push.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->