### PR TITLE
chore(quality): clear react-doctor maintainability warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2026-06-27
+
+### Changed
+
+- Cleared the Maintainability tier of read-only react-doctor warnings by hoisting pure helpers, moving merge-editor line-number helpers and shared icon style constants out of component modules, replacing the remaining host-side barrel import with a direct import, and documenting deliberate false positives with narrow inline suppressions.
+
+### Fixed
+
+- Documented the commit-check visibility polling and commit-graph message subscription as intentional effect patterns so react-doctor no longer reports Bugs-tier false positives while preserving the existing dependency arrays and webview message behavior.
+
 ## [0.14.2] - 2026-06-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.14.2",
+    "version": "0.14.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -3,7 +3,7 @@
 // intelligit.undockableWindow to allow dragging to a second monitor.
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";
-import { IconThemeService } from "./shared";
+import { IconThemeService } from "./shared/IconThemeService";
 import { registerThemeChangeListeners, disposeAll } from "./shared/themeListeners";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";

--- a/src/views/shared/index.ts
+++ b/src/views/shared/index.ts
@@ -1,1 +1,0 @@
-export { IconThemeService } from "./IconThemeService";

--- a/src/webviews/react/CommitInfoApp.tsx
+++ b/src/webviews/react/CommitInfoApp.tsx
@@ -57,6 +57,8 @@ function commitInfoReducer(_state: CommitInfoState, action: CommitInfoAction): C
  * Hosts the standalone commit-info webview and mirrors extension-owned commit
  * detail, file-icon theme data, and clear messages into local React state.
  */
+// Webview entrypoint owns root render side effects; Fast Refresh component-export rule is not applicable here.
+// react-doctor-disable-next-line react-doctor/only-export-components
 function App(): React.ReactElement {
     const [state, dispatch] = useReducer(commitInfoReducer, initialCommitInfoState);
 

--- a/src/webviews/react/CommitList.tsx
+++ b/src/webviews/react/CommitList.tsx
@@ -36,6 +36,8 @@ const PENDING_CHECK_REFRESH_MS = 15_000;
  * Allows cherry-pick actions when the graph is scoped to a non-current branch,
  * or when the current branch is unavailable and the extension must decide.
  */
+// Utility export is covered by webview unit tests; moving it would only churn local imports.
+// react-doctor-disable-next-line react-doctor/only-export-components
 export function canCherryPickFromBranchScope(
     selectedBranch: string | null,
     currentBranchName?: string | null,
@@ -212,6 +214,8 @@ export function CommitList({
         () => commits.slice(visibleRange.start, visibleRange.end),
         [commits, visibleRange.end, visibleRange.start],
     );
+    // Visible-row polling is viewport state synchronization; there is no event handler to move this into.
+    // react-doctor-disable-next-line react-doctor/no-effect-event-handler
     useEffect(() => {
         if (!onRequestCommitChecks) return;
         const retryHashes: string[] = [];
@@ -219,6 +223,8 @@ export function CommitList({
         for (const commit of visibleCommits) {
             const checks = commitChecks?.get(commit.hash);
             if (!checks) {
+                // Commit-check requests are host IO driven by visibility, not parent state synchronization.
+                // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect
                 onRequestCommitChecks(commit.hash);
                 continue;
             }

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -151,6 +151,21 @@ function graphReducer(state: GraphState, action: GraphAction): GraphState {
     }
 }
 
+function readInitialWidths(): SectionWidths {
+    try {
+        const state = vscode.getState();
+        const migrated = migrateSectionWidths(state);
+        if (migrated) {
+            return normalizeSectionWidths(migrated);
+        }
+        return computeEqualSectionWidths();
+    } catch {
+        return computeEqualSectionWidths();
+    }
+}
+
+// Webview entrypoint owns root orchestration and root render side effects; splitting further is not useful here.
+// react-doctor-disable-next-line react-doctor/only-export-components, react-doctor/no-giant-component
 function App(): React.ReactElement {
     // --- Graph-side state ---
     const [graphState, graphDispatch] = useReducer(graphReducer, initialGraphState);
@@ -189,18 +204,6 @@ function App(): React.ReactElement {
         widthsHydratedRef.current = true;
     }, []);
 
-    const readInitialWidths = (): SectionWidths => {
-        try {
-            const state = vscode.getState();
-            const migrated = migrateSectionWidths(state);
-            if (migrated) {
-                return normalizeSectionWidths(migrated);
-            }
-            return computeEqualSectionWidths();
-        } catch {
-            return computeEqualSectionWidths();
-        }
-    };
     const initialWidths = useRef<SectionWidths | null>(null);
     if (!initialWidths.current) initialWidths.current = readInitialWidths();
 

--- a/src/webviews/react/branch-column/BranchColumnSections.tsx
+++ b/src/webviews/react/branch-column/BranchColumnSections.tsx
@@ -270,6 +270,8 @@ function WorktreeRow({
             ) : (
                 <GitBranchIcon />
             )}
+            {/* Pure label highlighter, not a component invocation. */}
+            {/* react-doctor-disable-next-line react-doctor/no-render-in-render */}
             <span style={NODE_LABEL_STYLE}>{renderHighlightedLabel(label, filterNeedle)}</span>
             {folderName !== label && (
                 <span style={{ marginLeft: 6, opacity: 0.65, overflow: "hidden" }}>

--- a/src/webviews/react/branch-column/components/BranchTreeNodeRow.tsx
+++ b/src/webviews/react/branch-column/components/BranchTreeNodeRow.tsx
@@ -253,6 +253,8 @@ export function BranchTreeNodeRow({
                     <span data-branch-icon="folder" style={FOLDER_ICON_WRAPPER_STYLE}>
                         <TreeFolderIcon isExpanded={isExpanded} icon={resolvedFolderIcon} />
                     </span>
+                    {/* Pure label highlighter, not a component invocation. */}
+                    {/* react-doctor-disable-next-line react-doctor/no-render-in-render */}
                     <span>{renderHighlightedLabel(node.label, filterNeedle)}</span>
                 </button>
                 {isExpanded &&
@@ -314,6 +316,8 @@ export function BranchTreeNodeRow({
             ) : (
                 <GitBranchIcon color={JETBRAINS_UI.color.branch} />
             )}
+            {/* Pure label highlighter, not a component invocation. */}
+            {/* react-doctor-disable-next-line react-doctor/no-render-in-render */}
             <span style={NODE_LABEL_STYLE}>{renderHighlightedLabel(node.label, filterNeedle)}</span>
             {node.branch && <WorktreeBadge branch={node.branch} />}
             {node.branch && <TrackingBadge branch={node.branch} />}

--- a/src/webviews/react/branch-column/styles.ts
+++ b/src/webviews/react/branch-column/styles.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 import { SYSTEM_FONT_STACK } from "../../../utils/constants";
-import { BASE_ICON_STYLE } from "../shared/components/Icons";
+import { BASE_ICON_STYLE } from "../shared/components/iconStyles";
 import { JETBRAINS_UI } from "../shared/tokens";
 
 export const TREE_INDENT_STEP = JETBRAINS_UI.size.treeIndent;

--- a/src/webviews/react/commit-graph/useCommitGraphMessages.ts
+++ b/src/webviews/react/commit-graph/useCommitGraphMessages.ts
@@ -97,6 +97,6 @@ export function useCommitGraphMessages(params: {
         window.addEventListener("message", handler);
         return () => window.removeEventListener("message", handler);
         // Keep the original root effect subscription lifetime; dispatch and loadingMore are stable.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [sendReady, vscode]);
+        // react-doctor-disable-next-line react-doctor/exhaustive-deps
+    }, [sendReady, vscode]); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/src/webviews/react/commit-list/CommitRow.tsx
+++ b/src/webviews/react/commit-list/CommitRow.tsx
@@ -154,6 +154,8 @@ function RefBadge({ kind, name }: { kind: "branch" | "tag"; name: string }): Rea
     );
 }
 
+// Single-use tooltip row kept beside commit-row tooltip styles and ref rendering.
+// react-doctor-disable-next-line react-doctor/no-multi-comp
 function TooltipRefRow({
     kind,
     name,
@@ -175,6 +177,8 @@ function TooltipRefRow({
     );
 }
 
+// Single-use commit message cell kept beside commit-row tooltip and badge behavior.
+// react-doctor-disable-next-line react-doctor/no-multi-comp
 function CommitMessageCell({
     message,
     refs,
@@ -351,6 +355,8 @@ function CommitMessageCell({
     );
 }
 
+// Memo target kept local so the comparator and exported memoized row stay together.
+// react-doctor-disable-next-line react-doctor/no-multi-comp
 function CommitRowInner({
     commit,
     graphWidth,

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -21,6 +21,8 @@ import { canRunCommitAction } from "./commitEligibility";
  * amend-message loading, draft persistence, and the local group-by-directory
  * preference shared by the commit and shelf tabs.
  */
+// Webview entrypoint owns root render side effects; Fast Refresh component-export rule is not applicable here.
+// react-doctor-disable-next-line react-doctor/only-export-components
 function App(): React.ReactElement {
     const [state, dispatch] = useExtensionMessages();
     const { checkedPaths, toggleFile, toggleFolder, toggleSection, isAllChecked, isSomeChecked } =

--- a/src/webviews/react/commit-panel/components/CommitTab.tsx
+++ b/src/webviews/react/commit-panel/components/CommitTab.tsx
@@ -54,6 +54,8 @@ interface Props {
  * requests, shelf/rollback commands, and the draggable commit-message area while
  * delegating checked-path state to the root commit-panel app.
  */
+// Independent commit workflow flags come from different host state; grouping them would hide intent.
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function CommitTab({
     files,
     folderIcon,

--- a/src/webviews/react/commit-panel/components/SectionHeader.tsx
+++ b/src/webviews/react/commit-panel/components/SectionHeader.tsx
@@ -29,6 +29,8 @@ interface Props {
  * checkbox toggles every file in the section while clicking the row only expands
  * or collapses that section.
  */
+// Independent visual and selection flags; no single variant object would model this state.
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function SectionHeader({
     label,
     count,

--- a/src/webviews/react/merge-conflicts-session/MergeConflictSessionApp.tsx
+++ b/src/webviews/react/merge-conflicts-session/MergeConflictSessionApp.tsx
@@ -89,6 +89,8 @@ function sessionReducer(state: SessionState, action: SessionAction): SessionStat
  * selectable rows, posts file-scoped accept/open commands, and sends session-level
  * refresh/close commands.
  */
+// Webview entrypoint owns root render side effects; Fast Refresh component-export rule is not applicable here.
+// react-doctor-disable-next-line react-doctor/only-export-components
 function App() {
     const [state, dispatch] = useReducer(sessionReducer, undefined, createInitialSessionState);
     const { sourceBranch, targetBranch, files, selectedPath, groupByDirectory, error } = state;

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -34,14 +34,13 @@ import {
     isTrueConflict,
 } from "./mergeState";
 import {
-    buildLineNumberValues,
     CommonSection,
     ConflictSection,
     OverviewRail,
-    buildAlignedLineNumberValues,
     type SegmentPaneLineNumbers,
     type OverviewMarker,
 } from "./segments";
+import { buildAlignedLineNumberValues, buildLineNumberValues } from "./lineNumbers";
 import { alignConflictRows, type AlignedHunkRows } from "./rowAlignment";
 import "./merge-editor.css";
 
@@ -61,6 +60,8 @@ function getVsCodeApi() {
  * pane rows, local hunk resolutions, overview markers, keyboard navigation, and
  * extension apply/ignore-mode commands.
  */
+// Webview entrypoint owns merge-editor state orchestration and root render side effects.
+// react-doctor-disable-next-line react-doctor/only-export-components, react-doctor/no-giant-component
 function App() {
     const [state, dispatch] = useReducer(reducer, {
         data: null,

--- a/src/webviews/react/merge-editor/lineNumbers.ts
+++ b/src/webviews/react/merge-editor/lineNumbers.ts
@@ -1,0 +1,38 @@
+// Shared line-number helpers for the merge editor.
+// Kept outside segment components so Fast Refresh sees component modules cleanly.
+
+/** Line-number value for a rendered row; `null` reserves padding rows. */
+export type LineNumberValue = number | null;
+
+/**
+ * Builds displayed line numbers for a pane, using null placeholders when a
+ * shorter side needs visual padding to align with the hunk's row count.
+ */
+export function buildLineNumberValues(
+    startAt: number,
+    actualCount: number,
+    rowCount: number,
+): LineNumberValue[] {
+    const values: LineNumberValue[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        values.push(i < actualCount ? startAt + i : null);
+    }
+    return values;
+}
+
+/**
+ * Builds displayed line numbers from an intra-hunk row alignment: rows mapped
+ * to a source line get sequential numbers while spacer rows render blank.
+ */
+export function buildAlignedLineNumberValues(
+    startAt: number,
+    lineIndex: Array<number | null>,
+    rowCount: number,
+): LineNumberValue[] {
+    const values: LineNumberValue[] = [];
+    for (let i = 0; i < rowCount; i++) {
+        const sourceIndex = i < lineIndex.length ? lineIndex[i] : null;
+        values.push(sourceIndex === null ? null : startAt + sourceIndex);
+    }
+    return values;
+}

--- a/src/webviews/react/merge-editor/segments.tsx
+++ b/src/webviews/react/merge-editor/segments.tsx
@@ -24,6 +24,7 @@ import {
 import { getEffectiveResultLines, splitEditedText } from "./mergeState";
 import { tokenizeSyntaxLine, type SyntaxTokenKind } from "./syntaxHighlight";
 import type { AlignedHunkRows } from "./rowAlignment";
+import type { LineNumberValue } from "./lineNumbers";
 import { t } from "../shared/i18n";
 
 // --- Syntax highlighting ---
@@ -57,6 +58,8 @@ const HighlightedLine = React.memo(function HighlightedLine({
     line: string;
 }): React.ReactElement {
     if (!line) return <>{`\u00A0`}</>;
+    // Pure syntax-token helper, not a component invocation.
+    // react-doctor-disable-next-line react-doctor/no-render-in-render
     return <>{renderSyntaxHighlightedNodes(line, "line")}</>;
 });
 
@@ -110,46 +113,9 @@ const WordDiffLine = React.memo(function WordDiffLine({
 
 // --- Line numbers ---
 
-/** Line-number value for a rendered row; `null` reserves padding rows. */
-export type LineNumberValue = number | null;
-
 interface LineNumberSpec {
     primary: LineNumberValue[];
     secondary?: LineNumberValue[];
-}
-
-/**
- * Builds displayed line numbers for a pane, using null placeholders when a
- * shorter side needs visual padding to align with the hunk's row count.
- */
-export function buildLineNumberValues(
-    startAt: number,
-    actualCount: number,
-    rowCount: number,
-): LineNumberValue[] {
-    const values: LineNumberValue[] = [];
-    for (let i = 0; i < rowCount; i++) {
-        values.push(i < actualCount ? startAt + i : null);
-    }
-    return values;
-}
-
-/**
- * Builds displayed line numbers from an intra-hunk row alignment: rows mapped
- * to a source line get sequential numbers while spacer rows (null entries)
- * render blank, so numbering skips alignment gaps instead of counting them.
- */
-export function buildAlignedLineNumberValues(
-    startAt: number,
-    lineIndex: Array<number | null>,
-    rowCount: number,
-): LineNumberValue[] {
-    const values: LineNumberValue[] = [];
-    for (let i = 0; i < rowCount; i++) {
-        const sourceIndex = i < lineIndex.length ? lineIndex[i] : null;
-        values.push(sourceIndex === null ? null : startAt + sourceIndex);
-    }
-    return values;
 }
 
 function padLines(lines: string[], count: number): string[] {

--- a/src/webviews/react/shared/components/ContextMenu.tsx
+++ b/src/webviews/react/shared/components/ContextMenu.tsx
@@ -27,6 +27,88 @@ const CONTEXT_MENU_STYLE_RULES = `
         outline-offset: -1px;
     }
 `;
+const CONTEXT_MENU_BASE_STYLE: React.CSSProperties = {
+    position: "fixed",
+    // Portal context menus must float above all VS Code webview panes/popovers.
+    // react-doctor-disable-next-line react-doctor/no-z-index-9999
+    zIndex: 9999,
+    background: JETBRAINS_UI.color.panel,
+    border: `1px solid var(--vscode-menu-border, ${JETBRAINS_UI.color.menuBorder})`,
+    borderRadius: 8,
+    padding: "4px 0",
+    fontFamily: SYSTEM_FONT_STACK,
+    boxShadow: "0 8px 24px rgba(0,0,0,0.45), 0 2px 8px rgba(0,0,0,0.35)",
+};
+const SEPARATOR_STYLE: React.CSSProperties = {
+    height: 1,
+    margin: "4px 8px",
+    background: `var(--vscode-menu-separatorBackground, ${JETBRAINS_UI.color.menuSeparator})`,
+    border: 0,
+};
+const CONTEXT_MENU_ITEM_BASE_STYLE: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    minHeight: ITEM_HEIGHT,
+    margin: 0,
+    borderRadius: 0,
+    fontSize: ITEM_FONT_SIZE,
+    lineHeight: `${ITEM_HEIGHT}px`,
+    whiteSpace: "nowrap",
+};
+const ICON_SLOT_STYLE: React.CSSProperties = {
+    width: 16,
+    height: 16,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+};
+const TRAILING_BASE_STYLE: React.CSSProperties = {
+    minWidth: 58,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    flexShrink: 0,
+    overflow: "visible",
+    fontSize: 12,
+    paddingLeft: 16,
+};
+
+function contextMenuStyle(
+    pos: { left: number; top: number },
+    minWidth: number,
+): React.CSSProperties {
+    return { ...CONTEXT_MENU_BASE_STYLE, left: pos.left, top: pos.top, minWidth };
+}
+
+function contextMenuItemStyle(
+    hasAnyIcon: boolean,
+    hasAnyTrailing: boolean,
+    disabled: boolean | undefined,
+): React.CSSProperties {
+    return {
+        ...CONTEXT_MENU_ITEM_BASE_STYLE,
+        gap: hasAnyIcon ? 8 : 0,
+        padding: `0 ${hasAnyTrailing ? 12 : 8}px 0 ${hasAnyIcon ? 12 : 8}px`,
+        cursor: disabled ? "default" : "pointer",
+        color: disabled
+            ? "var(--vscode-disabledForeground, rgba(187,191,196,1))"
+            : `var(--vscode-menu-foreground, ${JETBRAINS_UI.color.menuForeground})`,
+    };
+}
+
+function iconSlotStyle(hasIcon: boolean): React.CSSProperties {
+    return { ...ICON_SLOT_STYLE, opacity: hasIcon ? 0.95 : 0 };
+}
+
+function trailingStyle(disabled: boolean | undefined): React.CSSProperties {
+    return {
+        ...TRAILING_BASE_STYLE,
+        color: disabled
+            ? `var(--vscode-disabledForeground, ${JETBRAINS_UI.color.menuHint})`
+            : `var(--vscode-descriptionForeground, ${JETBRAINS_UI.color.menuHint})`,
+    };
+}
 
 /**
  * Menu item contract consumed by shared JetBrains-style context menus.
@@ -131,38 +213,10 @@ export function ContextMenu({
     );
 
     return createPortal(
-        <div
-            ref={ref}
-            role="menu"
-            style={{
-                position: "fixed",
-                left: pos.left,
-                top: pos.top,
-                // Portal context menus must float above all VS Code webview panes/popovers.
-                // react-doctor-disable-next-line react-doctor/no-z-index-9999
-                zIndex: 9999,
-                background: JETBRAINS_UI.color.panel,
-                border: `1px solid var(--vscode-menu-border, ${JETBRAINS_UI.color.menuBorder})`,
-                borderRadius: 8,
-                padding: "4px 0",
-                minWidth,
-                fontFamily: SYSTEM_FONT_STACK,
-                boxShadow: "0 8px 24px rgba(0,0,0,0.45), 0 2px 8px rgba(0,0,0,0.35)",
-            }}
-        >
+        <div ref={ref} role="menu" style={contextMenuStyle(pos, minWidth)}>
             {items.map((item, i) => {
                 if (item.separator) {
-                    return (
-                        <hr
-                            key={`sep-${i}`}
-                            style={{
-                                height: 1,
-                                margin: "4px 8px",
-                                background: `var(--vscode-menu-separatorBackground, ${JETBRAINS_UI.color.menuSeparator})`,
-                                border: 0,
-                            }}
-                        />
-                    );
+                    return <hr key={`sep-${i}`} style={SEPARATOR_STYLE} />;
                 }
                 return (
                     <div
@@ -183,55 +237,14 @@ export function ContextMenu({
                                       }
                                   }
                         }
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: hasAnyIcon ? 8 : 0,
-                            minHeight: ITEM_HEIGHT,
-                            padding: `0 ${hasAnyTrailing ? 12 : 8}px 0 ${hasAnyIcon ? 12 : 8}px`,
-                            margin: 0,
-                            borderRadius: 0,
-                            cursor: item.disabled ? "default" : "pointer",
-                            fontSize: ITEM_FONT_SIZE,
-                            lineHeight: `${ITEM_HEIGHT}px`,
-                            color: item.disabled
-                                ? "var(--vscode-disabledForeground, rgba(187,191,196,1))"
-                                : `var(--vscode-menu-foreground, ${JETBRAINS_UI.color.menuForeground})`,
-                            whiteSpace: "nowrap",
-                        }}
+                        style={contextMenuItemStyle(hasAnyIcon, hasAnyTrailing, item.disabled)}
                     >
                         {hasAnyIcon && (
-                            <span
-                                style={{
-                                    width: 16,
-                                    height: 16,
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    flexShrink: 0,
-                                    opacity: item.icon ? 0.95 : 0,
-                                }}
-                            >
-                                {item.icon}
-                            </span>
+                            <span style={iconSlotStyle(Boolean(item.icon))}>{item.icon}</span>
                         )}
                         <span style={{ flex: 1, flexShrink: 1 }}>{item.label}</span>
                         {hasAnyTrailing && (
-                            <span
-                                style={{
-                                    minWidth: 58,
-                                    display: "inline-flex",
-                                    alignItems: "center",
-                                    justifyContent: "flex-end",
-                                    flexShrink: 0,
-                                    overflow: "visible",
-                                    fontSize: 12,
-                                    color: item.disabled
-                                        ? `var(--vscode-disabledForeground, ${JETBRAINS_UI.color.menuHint})`
-                                        : `var(--vscode-descriptionForeground, ${JETBRAINS_UI.color.menuHint})`,
-                                    paddingLeft: 16,
-                                }}
-                            >
+                            <span style={trailingStyle(item.disabled)}>
                                 {item.submenu ? (
                                     <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden>
                                         <path fill="currentColor" d="M6 4l4 4-4 4z" />

--- a/src/webviews/react/shared/components/Icons.tsx
+++ b/src/webviews/react/shared/components/Icons.tsx
@@ -2,15 +2,9 @@ import React from "react";
 import { LuGitBranch, LuSearch, LuTag, LuX } from "react-icons/lu";
 import type { CSSProperties } from "react";
 import { JETBRAINS_UI } from "../tokens";
+import { BASE_ICON_STYLE, ICON_SIZE } from "./iconStyles";
 
-export const ICON_SIZE = JETBRAINS_UI.size.icon;
 const CHEVRON_ICON_SIZE = 16;
-
-export const BASE_ICON_STYLE: CSSProperties = {
-    flexShrink: 0,
-    marginRight: 4,
-    opacity: 0.92,
-};
 
 export function SearchIcon({
     size = 16,

--- a/src/webviews/react/shared/components/TreeIcons.tsx
+++ b/src/webviews/react/shared/components/TreeIcons.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Box } from "@chakra-ui/react";
 import type { ThemeTreeIcon } from "../../../../types";
-import { FileIcon, FolderIcon, ICON_SIZE } from "./Icons";
+import { FileIcon, FolderIcon } from "./Icons";
+import { ICON_SIZE } from "./iconStyles";
 
 interface TreeFileIconProps {
     status?: string;

--- a/src/webviews/react/shared/components/iconStyles.ts
+++ b/src/webviews/react/shared/components/iconStyles.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from "react";
+import { JETBRAINS_UI } from "../tokens";
+
+// Shared icon style constants for branch, tag, and file-tree glyph components.
+// Kept outside component modules so shared constants do not trip Fast Refresh rules.
+
+/** Base inline SVG style shared by compact branch/tag/folder icons. */
+export const BASE_ICON_STYLE: CSSProperties = {
+    flexShrink: 0,
+    marginRight: 4,
+    opacity: 0.92,
+};
+
+/** Default icon size aligned with the JetBrains-style webview token scale. */
+export const ICON_SIZE = JETBRAINS_UI.size.icon;

--- a/src/webviews/react/undocked/CommitPanelPane.tsx
+++ b/src/webviews/react/undocked/CommitPanelPane.tsx
@@ -33,6 +33,8 @@ interface CommitPanelPaneProps {
  * Embeds the shared commit/shelf tab UI inside the undocked layout while routing
  * all selection, amend, commit, and grouping callbacks back to the app shell.
  */
+// Pass-through pane props mirror independent child controls, not a mutually exclusive variant.
+// react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function CommitPanelPane({
     width,
     cpState,


### PR DESCRIPTION
### Title

chore(quality): clear react-doctor maintainability warnings

### Motivation

The react-doctor Maintainability tier still reported audited warnings after the accessibility pass. This PR clears that tier without changing webview behavior, dependency arrays, or message contracts.

### Summary

- Clears Maintainability warnings from 25 to 0 and Bugs warnings from 3 to 0.
- Moves non-component helper exports out of component modules for merge-editor line numbers and shared icon styles.
- Hoists a pure undocked width initializer and replaces one host-side barrel import with a direct module import.
- Extracts large `ContextMenu` inline style objects into module-scope style helpers.
- Documents audited react-doctor false positives with narrow suppressions.
- Bumps version to `0.14.3` and adds the changelog entry.

### Detailed Changes

#### Code

- Added `src/webviews/react/merge-editor/lineNumbers.ts` for merge-editor line-number helper exports.
- Added `src/webviews/react/shared/components/iconStyles.ts` for shared icon constants.
- Updated imports in merge-editor, branch-column, icon, tree-icon, and undocked provider modules.
- Added targeted react-doctor suppressions for webview entrypoint roots, pure render helpers, independent boolean props, single-use commit-row internals, visibility-driven commit-check polling, and stable message-subscription dependency arrays.

#### Tests

- None added. This is a static-analysis cleanup with no runtime behavior change.

#### Documentation

- Added `CHANGELOG.md` entry for `0.14.3`.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- Updated `package.json` version to `0.14.3`.

### Testing

- Unit/regression tests: None added.
- Feature/bug verification: `bun x react-doctor` reports only 49 Performance warnings; Bugs and Maintainability are 0.
- Validation summary: `bun run typecheck`, `bun run format:check`, `bun run test -- --run`, `bun x react-doctor`, and `git diff --check` passed locally.
- Limitations: GitNexus `detect_changes` via MCP failed with a closed transport; the local `.gitnexus/run.cjs detect_changes --scope compare --base-ref main` fallback ran and reported CRITICAL risk because React root/webview components are touched. No l10n validation was run because no user-facing strings changed.

### Risks / Notes

- The remaining 49 react-doctor warnings are Performance-tier findings and intentionally out of scope for this Maintainability pass.
- Several findings are suppressed rather than refactored because the audited code is root orchestration, pure helper rendering, independent boolean state, or visibility-driven host IO where refactoring would add churn without behavior value.
