### PR TITLE
[codex] fix issue 72 publish defaults and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved the branch `Create Worktree` context-menu action to the bottom of the branch menu.
 - Reused the commit-panel pull and push glyphs for branch update and push menu actions.
+- Documented the Undock workflow in the README feature gallery.
+
+### Fixed
+
+- Defaulted new remote publication from local `master` to remote `main`.
 
 ## [0.14.7] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,10 @@ guarded by context and confirmations.
 
 ![Undocked IntelliGit workbench with commit panel, branch tree, graph, changed files, and details](media/screenshots/intelligit-workbench.png)
 
-When you need room, IntelliGit can run as a unified workbench tab. The commit
-panel, branch tree, graph lanes, changed-file tree, and commit details stay in
-one layout, with dock/undock support for monitor-heavy workflows.
+When you need room, IntelliGit can run as a unified workbench tab. The `Undock`
+feature allows you to undock the Git window and move it to another screen. The
+commit panel, branch tree, graph lanes, changed-file tree, and commit details
+stay in one layout, with dock/undock support for monitor-heavy workflows.
 
 ### Publish Branch
 

--- a/src/services/publishService.ts
+++ b/src/services/publishService.ts
@@ -75,7 +75,7 @@ export async function runPublishBranchFlow(
     const remotePlan = await pickRemotePlan(remotes, branchName);
     if (!remotePlan) return;
 
-    let remoteBranchName = remotePlan.remoteBranchName ?? branchName;
+    let remoteBranchName = remotePlan.remoteBranchName ?? defaultPublishedBranchName(branchName);
     if (remotePlan.kind === "existing") {
         try {
             await vscode.window.withProgress(
@@ -246,6 +246,11 @@ export async function runPublishBranchFlow(
             vscode.l10n.t("Failed to publish branch: {message}", { message }),
         );
     }
+}
+
+/** Uses the modern default branch name when publishing a new remote from local master. */
+function defaultPublishedBranchName(branchName: string): string {
+    return branchName === "master" ? "main" : branchName;
 }
 
 function parseRemoteRefInput(

--- a/tests/unit/services/publishService.test.ts
+++ b/tests/unit/services/publishService.test.ts
@@ -381,7 +381,7 @@ describe("publishService phase 5", () => {
             2,
             expect.objectContaining({
                 prompt: "Published branch name",
-                value: "master",
+                value: "main",
             }),
         );
         expect(gitOps.addRemote).toHaveBeenCalledWith("origin", "https://github.com/user/repo.git");


### PR DESCRIPTION
## Summary

- Default new remote publication from local `master` to remote `main`.
- Document the Undock workflow in the README feature gallery using the existing workbench screenshot.
- Keep the 0.14.8 changelog aligned with the issue-comment fix.

## Issue Comment

Fixes follow-up from https://github.com/MaheshKok/IntelliGit/issues/72#issuecomment-4847732664.

## Notes

- Bitbucket Cloud and Bitbucket Server are already present in the publish provider picker and covered by `publishService.test.ts`.
- The local README publish screenshot already shows both Bitbucket choices.

## Validation

- bun vitest run tests/unit/services/publishService.test.ts
- bunx prettier --check README.md CHANGELOG.md src/services/publishService.ts tests/unit/services/publishService.test.ts
- bun run lint
- bun run typecheck
- bun run architecture:check
- bun run react-doctor
- bun run build
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New remote publications now use a better default branch name, switching from `master` to `main` when applicable.
* **Documentation**
  * Expanded the README to better explain the undock experience and how the workbench can be moved to another screen.
  * Added a changelog note about the updated default branch behavior and the documented Undock workflow.
* **Tests**
  * Updated the related test expectation to match the new default branch name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->