### PR TITLE
fix(commit-checks): avoid automatic GitHub sign-in prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.10] - 2026-07-01
+
+### Fixed
+
+- Stopped automatic GitHub commit-check fetches from opening the VS Code GitHub sign-in prompt; IntelliGit now uses an existing GitHub session silently and refreshes commit-check badges when the GitHub session changes.
+
 ## [0.14.9] - 2026-06-30
 
 ### Changed

--- a/docs/commit-checks/README.md
+++ b/docs/commit-checks/README.md
@@ -32,7 +32,7 @@ enabled.
 
 | Provider | Credential | How to provide it | Scope / permission |
 |----------|------------|-------------------|--------------------|
-| GitHub (`github.com`) | Built-in VS Code GitHub session | Automatic — VS Code prompts for the GitHub sign-in on first use | `repo` |
+| GitHub (`github.com`) | Built-in VS Code GitHub session | Existing VS Code session only — automatic checks do not open a GitHub sign-in prompt | `repo` |
 | GitLab (`gitlab.com` + self-hosted) | Personal access token | `IntelliGit: Sign in to Commit Checks Provider` command | `read_api` |
 | Bitbucket Cloud (`bitbucket.org`) | Access token or OAuth Bearer token (app passwords are not supported) | `IntelliGit: Sign in to Commit Checks Provider` command | `repository` (read) |
 | Bitbucket Server / Data Center (self-hosted) | HTTP access token | `IntelliGit: Sign in to Commit Checks Provider` command | Repository read |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.14.9",
+    "version": "0.14.10",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -569,8 +569,9 @@ export async function activateRepositoryMode(
      *
      * Fired by the sign-in/sign-out commands after a credential change. A stored
      * "unavailable" snapshot is a terminal state the coordinator never re-fetches,
-     * so badges would stay stuck after the user signs in unless the cache is cleared
-     * and the graphs re-render (which makes the webview re-request checks).
+     * and GitHub's silent session lookup returns "none" when signed out. Badges would
+     * stay stuck after auth changes unless the cache is cleared and the graphs
+     * re-render, which makes the webview re-request checks.
      */
     const refreshCommitCheckBadges = async (): Promise<void> => {
         commitGraph.clearChecksCache();
@@ -586,6 +587,12 @@ export async function activateRepositoryMode(
             "intelligit.commitChecks.refreshBadges",
             refreshCommitCheckBadges,
         ),
+        vscode.authentication.onDidChangeSessions((event) => {
+            if (event.provider.id !== "github") return;
+            refreshCommitCheckBadges().catch((err) => {
+                console.error("[IntelliGit] GitHub commit-check refresh failed:", err);
+            });
+        }),
         commitPanel.onDidChangeWorkingTree(() => {
             undocked?.refreshSilent().catch((err) => {
                 console.error("[IntelliGit] Undocked commit panel refresh failed:", err);

--- a/src/services/commitChecks/githubProvider.ts
+++ b/src/services/commitChecks/githubProvider.ts
@@ -12,6 +12,7 @@ import {
     compactText,
     isCiCdCheckItem,
     readString,
+    summaryForState,
     summaryForItems,
     unavailableSnapshot,
 } from "./normalize";
@@ -101,10 +102,10 @@ export class GitHubProvider implements CommitChecksProvider {
     async getChecks(ref: ProviderRepoRef, hash: string): Promise<CommitChecksSnapshot> {
         const { owner, repo } = ref as GitHubRepoRef;
 
-        let session: vscode.AuthenticationSession;
+        let session: vscode.AuthenticationSession | undefined;
         try {
             session = await vscode.authentication.getSession("github", ["repo"], {
-                createIfNone: true,
+                silent: true,
             });
         } catch (err) {
             return unavailableSnapshot(
@@ -113,6 +114,9 @@ export class GitHubProvider implements CommitChecksProvider {
                     message: getErrorMessage(err),
                 }),
             );
+        }
+        if (!session) {
+            return { hash, state: "none", summary: summaryForState("none"), items: [] };
         }
 
         const headers = {

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -59,6 +59,7 @@ const saveDocListeners: Array<() => void> = [];
 const createFileListeners: Array<() => void> = [];
 const deleteFileListeners: Array<() => void> = [];
 const renameFileListeners: Array<() => void> = [];
+const authSessionListeners: Array<(event: { provider: { id: string } }) => void> = [];
 const configurationValues = new Map<string, unknown>();
 const configurationUpdate = vi.fn(async (key: string, value: unknown) => {
     configurationValues.set(key, value);
@@ -299,6 +300,7 @@ class MockCommitGraphViewProvider {
     onOpenCommitFileDiff = this.openCommitFileDiffEmitter.event;
     setBranches = vi.fn();
     refresh = vi.fn(async () => undefined);
+    clearChecksCache = vi.fn();
     filterByBranch = vi.fn(async () => undefined);
     setCommitDetail = vi.fn();
     clearCommitDetail = vi.fn();
@@ -450,6 +452,7 @@ class MockUndockedViewProvider {
     open = vi.fn(async () => undefined);
     refresh = vi.fn(async () => undefined);
     refreshSilent = vi.fn(async () => undefined);
+    clearChecksCache = vi.fn();
     reveal = vi.fn();
     dispose = vi.fn(() => {
         this.disposeEmitter.fire(undefined);
@@ -606,6 +609,12 @@ vi.mock("vscode", () => ({
         }),
         onDidRenameFiles: vi.fn((listener: () => void) => {
             renameFileListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
+    },
+    authentication: {
+        onDidChangeSessions: vi.fn((listener: (event: { provider: { id: string } }) => void) => {
+            authSessionListeners.push(listener);
             return { dispose: vi.fn() };
         }),
     },
@@ -817,6 +826,7 @@ describe("extension integration", () => {
         createFileListeners.length = 0;
         deleteFileListeners.length = 0;
         renameFileListeners.length = 0;
+        authSessionListeners.length = 0;
         fsWatchCallbacks.length = 0;
         createdTreeViews.clear();
         initialTreeViewBadges.clear();
@@ -1016,6 +1026,38 @@ describe("extension integration", () => {
         expect(latestCommitPanelProvider).toBeDefined();
         expect(latestCommitGraphProvider!.setRepositoryLabel).toHaveBeenCalledWith("repo");
         expect(latestCommitPanelProvider!.setRepositoryLabel).toHaveBeenCalledWith("repo");
+    });
+
+    it("refreshes commit-check badges when the GitHub auth session changes", async () => {
+        const { activate } = await import("../../../src/extension");
+        const context = {
+            extensionUri: { fsPath: "/ext", path: "/ext" },
+            subscriptions: [],
+        } as unknown as MockExtensionContext;
+
+        await activate(context);
+        expect(latestCommitGraphProvider).toBeDefined();
+        expect(latestSidebarGraphProvider).toBeDefined();
+        expect(authSessionListeners).toHaveLength(1);
+
+        latestCommitGraphProvider!.clearChecksCache.mockClear();
+        latestSidebarGraphProvider!.clearChecksCache.mockClear();
+        latestCommitGraphProvider!.refresh.mockClear();
+        latestSidebarGraphProvider!.refresh.mockClear();
+
+        authSessionListeners[0]({ provider: { id: "gitlab" } });
+        await Promise.resolve();
+
+        expect(latestCommitGraphProvider!.clearChecksCache).not.toHaveBeenCalled();
+        expect(latestSidebarGraphProvider!.clearChecksCache).not.toHaveBeenCalled();
+
+        authSessionListeners[0]({ provider: { id: "github" } });
+        await Promise.resolve();
+
+        expect(latestCommitGraphProvider!.clearChecksCache).toHaveBeenCalledTimes(1);
+        expect(latestSidebarGraphProvider!.clearChecksCache).toHaveBeenCalledTimes(1);
+        expect(latestCommitGraphProvider!.refresh).toHaveBeenCalledTimes(1);
+        expect(latestSidebarGraphProvider!.refresh).toHaveBeenCalledTimes(1);
     });
 
     it("clears the activity bar changed-files badge when the refreshed count reaches zero", async () => {

--- a/tests/unit/services/commitChecks/githubProvider.test.ts
+++ b/tests/unit/services/commitChecks/githubProvider.test.ts
@@ -200,7 +200,7 @@ describe("GitHubProvider", () => {
         const snapshot = await provider.getChecks(githubRef, "abc1234");
 
         expect(snapshot.state).toBe("none");
-        expect(mocks.getSession).toHaveBeenCalledWith("github", ["repo"], { createIfNone: true });
+        expect(mocks.getSession).toHaveBeenCalledWith("github", ["repo"], { silent: true });
         expect(fetchJson).toHaveBeenCalledTimes(2);
         const calledUrls = (fetchJson as ReturnType<typeof vi.fn>).mock.calls.map(
             (call) => call[0] as string,
@@ -215,6 +215,19 @@ describe("GitHubProvider", () => {
             const headers = call[1] as Record<string, string>;
             expect(headers.Authorization).toBe("Bearer gh-token");
         }
+    });
+
+    it("does not prompt or fetch when no GitHub session already exists", async () => {
+        mocks.getSession.mockResolvedValue(undefined);
+        const fetchJson = vi.fn();
+        const provider = new GitHubProvider(fetchJson);
+
+        const snapshot = await provider.getChecks(githubRef, "abc1234");
+
+        expect(snapshot.state).toBe("none");
+        expect(snapshot.items).toEqual([]);
+        expect(mocks.getSession).toHaveBeenCalledWith("github", ["repo"], { silent: true });
+        expect(fetchJson).not.toHaveBeenCalled();
     });
 
     it("treats unexpected API shapes (no check_runs / non-array statuses) as none", async () => {


### PR DESCRIPTION
### Title

fix(commit-checks): avoid automatic GitHub sign-in prompts

### Motivation

Issue #114 reports that opening IntelliGit repeatedly prompts users to sign into GitHub even when they do not want GitHub account access for commit checks.

Closes #114.

### Summary

- Stop automatic GitHub commit-check requests from creating a VS Code GitHub auth session.
- Return no GitHub commit-check badge when no existing GitHub session is available.
- Refresh commit-check caches when VS Code reports GitHub auth session changes.
- Keep GitHub checks automatic for users who are already signed into GitHub.
- Bump extension version to 0.14.10 and document the fix in the changelog.

### Detailed Changes

#### Code

- `GitHubProvider` now uses silent GitHub session lookup for automatic commit checks.
- Repository activation listens for GitHub auth session changes and refreshes commit-check badge caches.

#### Tests

- Added GitHub provider regression coverage for no-session/no-fetch behavior.
- Added extension integration coverage for GitHub auth-session refresh handling.

#### Documentation

- Updated commit-check docs to describe existing-session-only GitHub behavior.
- Added the `0.14.10` changelog entry.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- Updated `package.json` version to `0.14.10`.

### Testing

- Unit/regression tests: `tests/unit/services/commitChecks/githubProvider.test.ts`
- Feature/bug verification: `tests/integration/extension/extension.integration.test.ts -t "refreshes commit-check badges when the GitHub auth session changes"`
- Validation summary: `bun run format:check`, `bun run lint`, `bun run architecture:check`, `bun run react-doctor`, `bun run typecheck`, `bun run build`, `bun run test`, `bun run build:prod`, and `bun run package` passed.
- Limitations: Existing React SSR `useLayoutEffect` warnings appeared during tests; no test failures.

### Risks / Notes

- Users not signed into GitHub will see no GitHub commit-check badge until they sign in through VS Code; a GitHub auth-session event then refreshes badges automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub commit checks now use the existing VS Code sign-in session quietly, avoiding unexpected GitHub sign-in prompts.
  * Commit-check badges refresh automatically when your GitHub session changes, and cached results are cleared to keep status accurate.
  * If no GitHub session is available, commit checks now show a consistent “not available” state instead of trying to start authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->