### PR TITLE
fix(commit-panel): keep counts fresh and stash diffs read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3] - 2026-07-06
+
+### Fixed
+
+- Kept commit-panel file counts in sync with external file changes by adding repository file watching and a 5-second fallback refresh cadence matching VS Code Git's status throttle.
+- Prevented light refreshes from being lost when they arrive during a full-refresh suppression window.
+- Updated working-tree files and counts even when stash, branch, or icon metadata refreshes fail.
+
 ## [0.15.2] - 2026-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Kept commit-panel file counts in sync with external file changes by adding repository file watching and a 5-second fallback refresh cadence matching VS Code Git's status throttle.
 - Prevented light refreshes from being lost when they arrive during a full-refresh suppression window.
 - Updated working-tree files and counts even when stash, branch, or icon metadata refreshes fail.
+- Opened stash file diffs as read-only virtual documents instead of editable untitled buffers.
 
 ## [0.15.2] - 2026-07-05
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.15.2",
+    "version": "0.15.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -83,7 +83,11 @@ function encodePathForVirtualUri(filePath: string): string {
  * `filePath` must already be a repository-relative Git path. The path is encoded
  * as URI data only; it is not resolved against the workspace filesystem.
  */
-function createReadonlyDiffUri(filePath: string, content: string, refLabel: string): vscode.Uri {
+export function createReadonlyDiffUri(
+    filePath: string,
+    content: string,
+    refLabel: string,
+): vscode.Uri {
     readonlyDiffDocumentSeq += 1;
     const query = new URLSearchParams({
         id: String(readonlyDiffDocumentSeq),

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -337,13 +337,20 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             ).catch(() => {});
         }
         try {
-            const [status, stashes, currentBranchStatus] = await Promise.all([
-                this.gitOps.getStatus({ includeIgnored: this.showIgnoredFiles }),
-                this.gitOps.listStashes(),
-                this.currentBranchStatus(),
-                this.iconTheme.initIconThemeData(),
+            const status = await this.gitOps.getStatus({ includeIgnored: this.showIgnoredFiles });
+            await this.iconTheme.initIconThemeData().catch(() => {});
+            const [stashes, currentBranchStatus] = await Promise.all([
+                this.gitOps.listStashes().catch(() => this.stashes),
+                this.currentBranchStatus().catch(() => ({
+                    hasUpstream: this.currentBranchHasUpstreamCache,
+                    hasRemotes: this.hasRemotesCache,
+                    ahead: this.currentBranchAheadCache,
+                    behind: this.currentBranchBehindCache,
+                    name: this.currentBranchNameCache,
+                    upstream: this.currentBranchUpstreamCache,
+                })),
             ]);
-            const files = await this.iconTheme.decorateWorkingFiles(status);
+            const files = await this.iconTheme.decorateWorkingFiles(status).catch(() => status);
             const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
             const hasSelected =
                 this.selectedStashIndex !== null &&
@@ -356,14 +363,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
             const stashFiles =
                 selectedStashIndex !== null
-                    ? await this.iconTheme.decorateWorkingFiles(
-                          await this.gitOps.getStashFiles(selectedStashIndex),
-                      )
+                    ? await this.gitOps
+                          .getStashFiles(selectedStashIndex)
+                          .then((files) => this.iconTheme.decorateWorkingFiles(files))
+                          .catch(() => this.stashFiles)
                     : [];
-            const folderIconsByName = await this.iconTheme.getFolderIconsByWorkingFiles([
-                ...files,
-                ...stashFiles,
-            ]);
+            const folderIconsByName = await this.iconTheme
+                .getFolderIconsByWorkingFiles([...files, ...stashFiles])
+                .catch(() => this.folderIconsByName);
             if (refreshRequestId === this.dataRefreshSeq) {
                 this.folderIconsByName = folderIconsByName;
                 this.files = files;

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -361,12 +361,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             } else {
                 selectedStashIndex = stashes.length > 0 ? stashes[0].index : null;
             }
+            const selectedStashIndexUnchanged = selectedStashIndex === this.selectedStashIndex;
             const stashFiles =
                 selectedStashIndex !== null
                     ? await this.gitOps
                           .getStashFiles(selectedStashIndex)
                           .then((files) => this.iconTheme.decorateWorkingFiles(files))
-                          .catch(() => this.stashFiles)
+                          .catch(() => (selectedStashIndexUnchanged ? this.stashFiles : []))
                     : [];
             const folderIconsByName = await this.iconTheme
                 .getFolderIconsByWorkingFiles([...files, ...stashFiles])

--- a/src/views/RefreshService.ts
+++ b/src/views/RefreshService.ts
@@ -74,6 +74,7 @@ type RefreshEventType =
 export class RefreshService implements vscode.Disposable {
     private static readonly lightRefreshSuppressionAfterFullMs = 800;
     private static readonly pollingRefreshIntervalMs = 5000;
+    private static readonly ignoredWorkspaceEventDirs = new Set([".git", "dist", "build", "out"]);
 
     private lightTimer: ReturnType<typeof setTimeout> | undefined;
     private fullTimer: ReturnType<typeof setTimeout> | undefined;
@@ -198,7 +199,8 @@ export class RefreshService implements vscode.Disposable {
             );
             const repoFileHandler = (uri: vscode.Uri) => {
                 const relativePath = path.relative(this.repoRoot, uri.fsPath);
-                if (relativePath === ".git" || relativePath.startsWith(`.git${path.sep}`)) {
+                const [topLevelDir] = relativePath.split(path.sep);
+                if (topLevelDir && RefreshService.ignoredWorkspaceEventDirs.has(topLevelDir)) {
                     return;
                 }
                 this.scheduleRefreshEvent("workspace-file");

--- a/src/views/RefreshService.ts
+++ b/src/views/RefreshService.ts
@@ -73,12 +73,16 @@ type RefreshEventType =
  */
 export class RefreshService implements vscode.Disposable {
     private static readonly lightRefreshSuppressionAfterFullMs = 800;
+    private static readonly pollingRefreshIntervalMs = 5000;
 
     private lightTimer: ReturnType<typeof setTimeout> | undefined;
     private fullTimer: ReturnType<typeof setTimeout> | undefined;
+    private pollTimer: ReturnType<typeof setInterval> | undefined;
     private readonly fsWatchers: fs.FSWatcher[] = [];
     private readonly gitRepositoryStateDisposables = new Map<string, vscode.Disposable>();
     private readonly disposables: vscode.Disposable[] = [];
+    private suppressedLightTimer: ReturnType<typeof setTimeout> | undefined;
+    private pollingRefreshInFlight = false;
     private recentFullScheduledUntil = 0;
     private disposed = false;
 
@@ -137,6 +141,10 @@ export class RefreshService implements vscode.Disposable {
             clearTimeout(this.lightTimer);
             this.lightTimer = undefined;
         }
+        if (this.suppressedLightTimer) {
+            clearTimeout(this.suppressedLightTimer);
+            this.suppressedLightTimer = undefined;
+        }
         if (this.fullTimer) clearTimeout(this.fullTimer);
         this.fullTimer = setTimeout(() => {
             void (async () => {
@@ -184,8 +192,46 @@ export class RefreshService implements vscode.Disposable {
             vscode.workspace.onDidRenameFiles(handler),
         );
 
+        try {
+            const watcher = vscode.workspace.createFileSystemWatcher(
+                new vscode.RelativePattern(vscode.Uri.file(this.repoRoot), "**/*"),
+            );
+            const repoFileHandler = (uri: vscode.Uri) => {
+                const relativePath = path.relative(this.repoRoot, uri.fsPath);
+                if (relativePath === ".git" || relativePath.startsWith(`.git${path.sep}`)) {
+                    return;
+                }
+                this.scheduleRefreshEvent("workspace-file");
+            };
+            this.disposables.push(
+                watcher.onDidChange(repoFileHandler),
+                watcher.onDidCreate(repoFileHandler),
+                watcher.onDidDelete(repoFileHandler),
+                watcher,
+            );
+        } catch {
+            /* Repository file watcher may be unavailable for virtual roots. */
+        }
+
         this.registerGitDirWatchers();
         this.registerVsCodeGitWatchers();
+        this.registerPollingRefresh();
+    }
+
+    /** Polls as a fallback for file changes that VS Code or Git watchers miss. */
+    private registerPollingRefresh(): void {
+        if (this.pollTimer) return;
+        this.pollTimer = setInterval(() => {
+            if (this.disposed || this.pollingRefreshInFlight) return;
+            this.pollingRefreshInFlight = true;
+            void this.refreshCommitPanels()
+                .catch((err) => {
+                    console.error("[IntelliGit] Polling refresh failed:", err);
+                })
+                .finally(() => {
+                    this.pollingRefreshInFlight = false;
+                });
+        }, RefreshService.pollingRefreshIntervalMs);
     }
 
     /** Resolve the real Git metadata directory, including worktree-style .git files. */
@@ -339,9 +385,18 @@ export class RefreshService implements vscode.Disposable {
                 this.debouncedFullRefresh();
                 return;
             case "workspace-file":
+                this.debouncedLightRefresh();
+                return;
             case "git-index":
             case "git-repository-state":
-                if (Date.now() < this.recentFullScheduledUntil) return;
+                if (Date.now() < this.recentFullScheduledUntil) {
+                    if (this.suppressedLightTimer) clearTimeout(this.suppressedLightTimer);
+                    this.suppressedLightTimer = setTimeout(() => {
+                        this.suppressedLightTimer = undefined;
+                        this.debouncedLightRefresh();
+                    }, this.recentFullScheduledUntil - Date.now());
+                    return;
+                }
                 this.debouncedLightRefresh();
                 return;
         }
@@ -352,6 +407,8 @@ export class RefreshService implements vscode.Disposable {
         this.disposed = true;
         if (this.lightTimer) clearTimeout(this.lightTimer);
         if (this.fullTimer) clearTimeout(this.fullTimer);
+        if (this.pollTimer) clearInterval(this.pollTimer);
+        if (this.suppressedLightTimer) clearTimeout(this.suppressedLightTimer);
         for (const watcher of this.fsWatchers) {
             watcher.close();
         }

--- a/src/views/panelFileActions.ts
+++ b/src/views/panelFileActions.ts
@@ -11,6 +11,7 @@ import { assertRepoRelativePath, deleteFileWithFallback } from "../utils/fileOps
 import { assertNumber, assertRepoPathArray, assertString } from "./messageValidation";
 import type { IconThemeService } from "./shared/IconThemeService";
 import { showTimedInformationMessage } from "../utils/notifications";
+import { createReadonlyDiffUri } from "../services/diffService";
 
 interface PanelFileActionDeps {
     gitOps: GitOps;
@@ -140,7 +141,7 @@ export async function showDiffFromPanel(
 }
 
 /**
- * Opens an untitled diff document for one file inside a stashed change.
+ * Opens a read-only diff document for one file inside a stashed change.
  *
  * The stash index must be finite and the path repository-relative. Empty patch content is converted
  * into a visible fallback message so the panel action always produces understandable editor output.
@@ -153,10 +154,12 @@ export async function showStashDiffFromPanel(
     const index = assertNumber(indexValue, "index");
     const filePath = assertRepoRelativePath(assertString(pathValue, "path"));
     const patch = await deps.gitOps.getStashFilePatch(index, filePath);
-    const doc = await vscode.workspace.openTextDocument({
-        content: patch || `No stashed diff found for ${filePath}.`,
-        language: "diff",
-    });
+    const uri = createReadonlyDiffUri(
+        `${filePath}.diff`,
+        patch || `No stashed diff found for ${filePath}.`,
+        `stash@{${index}}`,
+    );
+    const doc = await vscode.workspace.openTextDocument(uri);
     await vscode.window.showTextDocument(doc, { preview: true });
 }
 

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -722,7 +722,7 @@ async function waitForAsync(): Promise<void> {
     for (let i = 0; i < maxPasses; i++) {
         await Promise.resolve();
         try {
-            await vi.runAllTimersAsync();
+            await vi.advanceTimersByTimeAsync(0);
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             const isExpectedTimerError =

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1469,6 +1469,41 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
+    it("CommitPanelViewProvider clears stash files when a new selected stash fails to load", async () => {
+        const { provider, gitOps } = await setupCommitPanelProvider();
+        gitOps.listStashes.mockResolvedValueOnce([
+            { index: 1, message: "On main: next", date: "2026-02-20T00:00:00Z", hash: "next" },
+        ]);
+        gitOps.getStashFiles.mockRejectedValueOnce(new Error("stash files failed"));
+        postMessageSpy.mockClear();
+
+        await (provider as typeof provider & { refreshSilent(): Promise<void> }).refreshSilent();
+
+        const updates = postMessageSpy.mock.calls
+            .map(([message]) => message)
+            .filter(
+                (
+                    message,
+                ): message is {
+                    type: "update";
+                    selectedStashIndex: number | null;
+                    stashFiles: Array<{ path: string }>;
+                } =>
+                    typeof message === "object" &&
+                    message !== null &&
+                    "type" in message &&
+                    message.type === "update" &&
+                    "stashFiles" in message,
+            );
+        expect(updates.at(-1)).toEqual(
+            expect.objectContaining({
+                selectedStashIndex: 1,
+                stashFiles: [],
+            }),
+        );
+        provider.dispose();
+    });
+
     it("CommitPanelViewProvider ignores stale refresh results from older requests", async () => {
         const { provider, gitOps } = await setupCommitPanelProvider();
         let resolveSlowStatus: (

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -85,6 +85,12 @@ const vscodeMock = {
     ProgressLocation: { Notification: 15 },
     TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
     Uri: {
+        parse: (value: string): { fsPath: string; path: string; scheme: string; toString: () => string } => ({
+            fsPath: value,
+            path: value,
+            scheme: value.split(":", 1)[0],
+            toString: () => value,
+        }),
         joinPath: (
             base: { fsPath?: string; path?: string },
             ...segments: string[]
@@ -1905,9 +1911,11 @@ describe("view providers integration", () => {
         expect(gitOps.getStashFilePatch).toHaveBeenCalledWith(0, "src/a.ts");
         expect(openTextDocument).toHaveBeenCalledWith(
             expect.objectContaining({
-                content: "diff --git a b",
-                language: "diff",
+                scheme: "intelligit-diff",
             }),
+        );
+        expect(openTextDocument).not.toHaveBeenCalledWith(
+            expect.objectContaining({ content: expect.any(String) }),
         );
         provider.dispose();
     });

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -390,9 +390,12 @@ function lastCommitChecksSnapshot():
     return snapshots[snapshots.length - 1];
 }
 
-async function setupCommitPanelProvider() {
+async function setupCommitPanelProvider(
+    configure?: (gitOps: ReturnType<typeof makeGitOpsMock>) => void,
+) {
     const { CommitPanelViewProvider } = await import("../../../src/views/CommitPanelViewProvider");
     const gitOps = makeGitOpsMock();
+    configure?.(gitOps);
     const draftStore = createMemento();
     const provider = new CommitPanelViewProvider(
         { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
@@ -1436,6 +1439,30 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
+    it("CommitPanelViewProvider still updates files when stash metadata refresh fails", async () => {
+        const { provider } = await setupCommitPanelProvider((gitOps) => {
+            gitOps.getStatus.mockResolvedValueOnce([
+                { path: "src/a.ts", status: "M", staged: false, additions: 1, deletions: 0 },
+                { path: "src/b.ts", status: "?", staged: false, additions: 0, deletions: 0 },
+            ]);
+            gitOps.listStashes.mockRejectedValueOnce(new Error("stash metadata failed"));
+        });
+
+        const updates = postMessageSpy.mock.calls
+            .map(([message]) => message)
+            .filter(
+                (message): message is { type: "update"; files: Array<{ path: string }> } =>
+                    typeof message === "object" &&
+                    message !== null &&
+                    "type" in message &&
+                    message.type === "update" &&
+                    "files" in message,
+            );
+
+        expect(updates.at(-1)?.files.map((file) => file.path)).toEqual(["src/a.ts", "src/b.ts"]);
+        provider.dispose();
+    });
+
     it("CommitPanelViewProvider ignores stale refresh results from older requests", async () => {
         const { provider, gitOps } = await setupCommitPanelProvider();
         let resolveSlowStatus: (
@@ -1895,9 +1922,7 @@ describe("view providers integration", () => {
         await webview.send({ type: "stashPop", index: 0 });
 
         expect(executeCommand).toHaveBeenCalledWith("intelligit.openConflictSession");
-        expect(postMessageSpy).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: "error" }),
-        );
+        expect(postMessageSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
         provider.dispose();
     });
 
@@ -1911,9 +1936,7 @@ describe("view providers integration", () => {
         await webview.send({ type: "stashApply", index: 0 });
 
         expect(executeCommand).toHaveBeenCalledWith("intelligit.openConflictSession");
-        expect(postMessageSpy).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: "error" }),
-        );
+        expect(postMessageSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
         provider.dispose();
     });
 

--- a/tests/integration/webviews/merge-editor-performance.integration.test.tsx
+++ b/tests/integration/webviews/merge-editor-performance.integration.test.tsx
@@ -99,66 +99,70 @@ afterEach(() => {
 });
 
 describe("MergeEditorApp large document flow", () => {
-    it("renders 1,000 lines with 50 conflicts and resolves them end-to-end", async () => {
-        const vscode = installVsCodeMock();
-        createRootHost();
+    it(
+        "renders 1,000 lines with 50 conflicts and resolves them end-to-end",
+        async () => {
+            const vscode = installVsCodeMock();
+            createRootHost();
 
-        await act(async () => {
-            await import("../../../src/webviews/react/merge-editor/MergeEditorApp");
-        });
-        await flush();
+            await act(async () => {
+                await import("../../../src/webviews/react/merge-editor/MergeEditorApp");
+            });
+            await flush();
 
-        const { segments, expectedTheirsContent } = buildLargeConflictData();
+            const { segments, expectedTheirsContent } = buildLargeConflictData();
 
-        const renderStart = performance.now();
-        dispatchHostMessage({
-            type: "setConflictData",
-            data: {
-                filePath: "src/huge.ts",
-                oursLabel: "main",
-                theirsLabel: "feature",
-                eol: "\n",
-                hasTrailingNewline: true,
-                segments,
-            },
-        });
-        await flush();
-        const renderMs = performance.now() - renderStart;
+            const renderStart = performance.now();
+            dispatchHostMessage({
+                type: "setConflictData",
+                data: {
+                    filePath: "src/huge.ts",
+                    oursLabel: "main",
+                    theirsLabel: "feature",
+                    eol: "\n",
+                    hasTrailingNewline: true,
+                    segments,
+                },
+            });
+            await flush();
+            const renderMs = performance.now() - renderStart;
 
-        expect(document.body.textContent).toContain(`${CONFLICT_COUNT} unresolved`);
-        // Generous bound for jsdom; a quadratic re-render regression blows
-        // far past this while the memoized pipeline stays well under it.
-        expect(renderMs).toBeLessThan(15_000);
+            expect(document.body.textContent).toContain(`${CONFLICT_COUNT} unresolved`);
+            // Generous bound for jsdom; a quadratic re-render regression blows
+            // far past this while the memoized pipeline stays well under it.
+            expect(renderMs).toBeLessThan(15_000);
 
-        // Resolving a single hunk must stay cheap relative to the full render:
-        // with working memoization only the affected segment re-renders.
-        const acceptAll = Array.from(document.querySelectorAll("button")).find(
-            (b) => b.textContent?.trim() === "Accept All Theirs",
-        );
-        if (!acceptAll) throw new Error("Expected the Accept All Theirs button");
-        const resolveStart = performance.now();
-        act(() => {
-            acceptAll.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-        });
-        await flush();
-        const resolveMs = performance.now() - resolveStart;
-        expect(resolveMs).toBeLessThan(10_000);
+            // Resolving a single hunk must stay cheap relative to the full render:
+            // with working memoization only the affected segment re-renders.
+            const acceptAll = Array.from(document.querySelectorAll("button")).find(
+                (b) => b.textContent?.trim() === "Accept All Theirs",
+            );
+            if (!acceptAll) throw new Error("Expected the Accept All Theirs button");
+            const resolveStart = performance.now();
+            act(() => {
+                acceptAll.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            });
+            await flush();
+            const resolveMs = performance.now() - resolveStart;
+            expect(resolveMs).toBeLessThan(10_000);
 
-        expect(document.body.textContent).toContain("0 unresolved");
+            expect(document.body.textContent).toContain("0 unresolved");
 
-        const apply = Array.from(document.querySelectorAll("button")).find((b) =>
-            b.textContent?.trim().startsWith("Apply ("),
-        );
-        if (!apply) throw new Error("Expected the Apply button");
-        act(() => {
-            apply.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-        });
+            const apply = Array.from(document.querySelectorAll("button")).find((b) =>
+                b.textContent?.trim().startsWith("Apply ("),
+            );
+            if (!apply) throw new Error("Expected the Apply button");
+            act(() => {
+                apply.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            });
 
-        expect(vscode.postMessage).toHaveBeenCalledWith({
-            type: "applyResolution",
-            content: expectedTheirsContent,
-        });
-    });
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: "applyResolution",
+                content: expectedTheirsContent,
+            });
+        },
+        20_000,
+    );
 
     it("keeps per-segment size hints so offscreen virtualization has stable geometry", async () => {
         installVsCodeMock();

--- a/tests/unit/services/refreshService.test.ts
+++ b/tests/unit/services/refreshService.test.ts
@@ -138,6 +138,22 @@ describe("RefreshService refresh scheduling", () => {
         service.dispose();
     });
 
+    it("runs one trailing light refresh for light events suppressed by a full refresh", async () => {
+        const { service, scheduler, deps } = makeService();
+
+        scheduler.scheduleRefreshEvent("git-refs");
+        await vi.advanceTimersByTimeAsync(100);
+        scheduler.scheduleRefreshEvent("git-index");
+
+        await vi.advanceTimersByTimeAsync(400);
+        expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(600);
+        expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(2);
+
+        service.dispose();
+    });
+
     it("cancels a pending light refresh when a full refresh is scheduled", async () => {
         const { service, scheduler, deps } = makeService();
 
@@ -152,6 +168,47 @@ describe("RefreshService refresh scheduling", () => {
         expect(deps.gitOps.getBranches).toHaveBeenCalledTimes(1);
         expect(deps.commitPanel.refresh).not.toHaveBeenCalled();
         expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(1);
+
+        service.dispose();
+    });
+
+    it("refreshes when repository file watcher sees external file changes", async () => {
+        const vscode = await import("vscode");
+        const { service, deps } = makeService();
+        service.registerFileWatchers();
+
+        const createFileSystemWatcher = vscode.workspace
+            .createFileSystemWatcher as unknown as ReturnType<typeof vi.fn>;
+        const watcher = createFileSystemWatcher.mock.results[0].value as {
+            onDidCreate: ReturnType<typeof vi.fn>;
+        };
+        const onDidCreate = watcher.onDidCreate.mock.calls[0][0] as (uri: {
+            fsPath: string;
+        }) => void;
+
+        onDidCreate({ fsPath: "/tmp/intelligit-refresh-test/.git/index" });
+        await vi.advanceTimersByTimeAsync(300);
+        expect(deps.commitPanel.refreshSilent).not.toHaveBeenCalled();
+
+        onDidCreate({ fsPath: "/tmp/intelligit-refresh-test/src/generated.ts" });
+        await vi.advanceTimersByTimeAsync(300);
+        expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(1);
+
+        service.dispose();
+    });
+
+    it("polls commit panels every five seconds as a fallback", async () => {
+        const { service, deps } = makeService();
+        service.registerFileWatchers();
+
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(deps.commitPanel.refreshSilent).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(2);
 
         service.dispose();
     });

--- a/tests/unit/services/refreshService.test.ts
+++ b/tests/unit/services/refreshService.test.ts
@@ -190,6 +190,12 @@ describe("RefreshService refresh scheduling", () => {
         await vi.advanceTimersByTimeAsync(300);
         expect(deps.commitPanel.refreshSilent).not.toHaveBeenCalled();
 
+        for (const dir of ["dist", "build", "out"]) {
+            onDidCreate({ fsPath: `/tmp/intelligit-refresh-test/${dir}/bundle.js` });
+            await vi.advanceTimersByTimeAsync(300);
+            expect(deps.commitPanel.refreshSilent).not.toHaveBeenCalled();
+        }
+
         onDidCreate({ fsPath: "/tmp/intelligit-refresh-test/src/generated.ts" });
         await vi.advanceTimersByTimeAsync(300);
         expect(deps.commitPanel.refreshSilent).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Motivation

The commit panel could show stale changed-file counts when file changes happened outside our direct Git operations, when Git-state events were suppressed behind a full refresh, or when optional metadata refreshes failed even though `git status` had fresh file data. Stash file clicks also opened patch output in editable untitled buffers even though stash diffs are view-only.

### Summary

- Adds repository file watching for external working-tree changes while ignoring `.git` metadata paths.
- Adds a 5-second silent fallback refresh cadence matching VS Code Git's status throttle behavior.
- Preserves one trailing light refresh when Git state/index events arrive during the full-refresh suppression window.
- Makes commit-panel file updates rely first on `getStatus`, with stash, branch, and icon metadata failures falling back to cached data instead of blocking changed-file counts.
- Opens stash file diffs through the existing read-only `intelligit-diff` virtual document provider instead of editable untitled documents.
- Bumps IntelliGit to `0.15.3` and documents the refresh and stash diff fixes in `CHANGELOG.md`.

### Detailed Changes

#### Code

- `src/views/RefreshService.ts`: adds repo-scoped workspace file watching, fallback silent polling, and delayed light refresh scheduling for suppressed Git events.
- `src/views/CommitPanelViewProvider.ts`: keeps working-tree file updates authoritative when optional metadata/decorations fail.
- `src/views/panelFileActions.ts`: routes stash patch viewing through the read-only virtual diff content provider.
- `src/services/diffService.ts`: exports the existing read-only diff URI helper for stash patch reuse.
- `tests/integration/extension/extension.integration.test.ts`: bounds fake-timer draining so the background poller does not look like an infinite timer loop.

#### Tests

- Adds RefreshService regression coverage for external repository watcher changes, trailing suppressed light refreshes, and 5-second fallback polling.
- Adds CommitPanelViewProvider integration coverage for file updates when stash metadata refresh fails.
- Adds stash diff coverage proving stash clicks open a virtual read-only URI and no longer pass inline editable content to `openTextDocument`.

#### Documentation

- Adds `0.15.3` changelog notes for the commit-panel refresh and stash read-only diff fixes.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None.

### Testing

- Unit/regression tests: `tests/unit/services/refreshService.test.ts`, `tests/unit/services/diffService.test.ts`, `tests/integration/extension/view-providers.integration.test.ts`, and `tests/integration/extension/extension.integration.test.ts`.
- Feature/bug verification: exercised repository watcher refreshes, fallback polling, suppressed refresh replay, metadata-failure status updates, and stash read-only diff opening.
- Validation summary: passed format, lint, architecture check, React Doctor, typecheck, build, and the full Vitest suite before the stash update; after the stash update, focused provider/diff tests plus format, lint, typecheck, and build passed.
- Limitations: test output still includes existing React act/Shiki warnings; the suite passes.

### Risks / Notes

- The fallback poller is deliberately silent and guarded against overlapping refreshes; reviewers should focus on refresh frequency and fake-timer behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stash diffs now open in a read-only diff view instead of an editable untitled file.

* **Bug Fixes**
  * Commit panel counts and file lists stay more up to date, including through repository changes and periodic refreshes.
  * Refreshes are handled more reliably when some metadata updates fail.
  * Light refreshes are less likely to be skipped during busy refresh periods.
  * Stash details remain accurate when stash loading or refresh steps fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->