### PR TITLE
feat(commit-panel): support multi-repository views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-07-08
+
+### Added
+
+- Added multi-repository workspace support with per-repository commit accordions and an undocked repository selector.
+
+### Changed
+
+- Scoped IntelliGit graph views to the active repository selected from the active editor or undocked repository list.
+
 ## [0.15.4] - 2026-07-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.15.4",
+    "version": "0.16.0",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,24 @@
                 }
             },
             {
+                "command": "intelligit.sidebarRepositoryIndicator",
+                "title": "%command.selectRepository%",
+                "category": "%intelligit%",
+                "icon": {
+                    "light": "media/icons/select-repository-white.svg",
+                    "dark": "media/icons/select-repository-white.svg"
+                }
+            },
+            {
+                "command": "intelligit.sidebarRepositoryIndicator.color",
+                "title": "%command.selectRepository%",
+                "category": "%intelligit%",
+                "icon": {
+                    "light": "media/icons/select-repository-color.svg",
+                    "dark": "media/icons/select-repository-color.svg"
+                }
+            },
+            {
                 "command": "intelligit.checkout",
                 "title": "%command.checkout%",
                 "category": "%intelligit%"
@@ -509,6 +527,14 @@
                     "when": "false"
                 },
                 {
+                    "command": "intelligit.sidebarRepositoryIndicator",
+                    "when": "false"
+                },
+                {
+                    "command": "intelligit.sidebarRepositoryIndicator.color",
+                    "when": "false"
+                },
+                {
                     "command": "intelligit.graph.sync",
                     "when": "false"
                 },
@@ -590,6 +616,16 @@
                     "command": "intelligit.openUndocked.color",
                     "when": "view == intelligit.commitGraph && config.intelligit.undockableWindowButtonVisability && config.intelligit.icons == color",
                     "group": "navigation"
+                },
+                {
+                    "command": "intelligit.sidebarRepositoryIndicator",
+                    "when": "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons != color",
+                    "group": "navigation@0"
+                },
+                {
+                    "command": "intelligit.sidebarRepositoryIndicator.color",
+                    "when": "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons == color",
+                    "group": "navigation@0"
                 },
                 {
                     "command": "intelligit.graph.sync",

--- a/package.json
+++ b/package.json
@@ -618,16 +618,6 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "intelligit.sidebarRepositoryIndicator",
-                    "when": "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons != color",
-                    "group": "navigation@0"
-                },
-                {
-                    "command": "intelligit.sidebarRepositoryIndicator.color",
-                    "when": "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons == color",
-                    "group": "navigation@0"
-                },
-                {
                     "command": "intelligit.graph.sync",
                     "when": "view == intelligit.sidebarGraph && config.intelligit.icons != color",
                     "group": "navigation@1"

--- a/src/activation/common.ts
+++ b/src/activation/common.ts
@@ -24,6 +24,11 @@ export const NO_REPOSITORY_MESSAGE = "No Git repositories found in this workspac
 export const HAS_MERGE_CONFLICTS_CONTEXT = "intelligit.hasMergeConflicts";
 
 /**
+ * VS Code when-clause key that enables UI for multi-repository workspaces.
+ */
+export const HAS_MULTIPLE_REPOSITORIES_CONTEXT = "intelligit.hasMultipleRepositories";
+
+/**
  * Updates a VS Code when-clause context key for IntelliGit views and commands.
  *
  * This is a host-wide side effect and does not create a disposable. Callers may

--- a/src/activation/noRepositoryMode.ts
+++ b/src/activation/noRepositoryMode.ts
@@ -7,6 +7,7 @@ import { CommitPanelViewProvider } from "../views/CommitPanelViewProvider";
 import { OnboardingViewProvider } from "../views/OnboardingViewProvider";
 import {
     HAS_MERGE_CONFLICTS_CONTEXT,
+    HAS_MULTIPLE_REPOSITORIES_CONTEXT,
     initializeRepository,
     NO_REPOSITORY_MESSAGE,
     type RepositoryViewProviders,
@@ -44,6 +45,7 @@ export function activateNoRepositoryMode(
     deps: NoRepositoryModeDeps,
 ): void {
     let repositories: DiscoveredRepository[] = [];
+    void setViewContext(HAS_MULTIPLE_REPOSITORIES_CONTEXT, false);
     const noRepositoryDisposables: vscode.Disposable[] = [];
     let repositoryModeActivated = false;
     let repositoryModeActivationPromise: Promise<void> | undefined;

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -39,6 +39,26 @@ function getBranchSelectionName(branch: Branch | string): string {
 }
 
 /**
+ * Returns the deepest discovered repository that contains a file URI.
+ *
+ * Non-file editors and files outside known repositories are ignored so
+ * transient editor switches do not disturb the active IntelliGit root.
+ */
+function repositoryForFileUri(
+    uri: vscode.Uri | undefined,
+    knownRepositories: DiscoveredRepository[],
+): DiscoveredRepository | undefined {
+    if (!uri || uri.scheme !== "file") return undefined;
+    const filePath = path.resolve(uri.fsPath);
+    return knownRepositories
+        .filter((repo) => {
+            const root = path.resolve(repo.root);
+            return filePath === root || filePath.startsWith(root + path.sep);
+        })
+        .sort((a, b) => b.root.length - a.root.length)[0];
+}
+
+/**
  * Activates IntelliGit's repository-backed mode for discovered Git roots.
  *
  * This path runs after startup discovery finds repositories or after
@@ -254,6 +274,21 @@ export async function activateRepositoryMode(
         clearSelection();
         await refreshActiveRepository();
     };
+
+    const updateActiveRepositoryFromEditor = async (editor?: vscode.TextEditor): Promise<void> => {
+        const repository = repositoryForFileUri(editor?.document.uri, repositories);
+        if (!repository || repository.root === activeRepository.root) return;
+        await setActiveRepository(repository);
+    };
+
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            void updateActiveRepositoryFromEditor(editor).catch((err) => {
+                console.error("[IntelliGit] Failed to update active repository from editor:", err);
+            });
+        }),
+    );
+    await updateActiveRepositoryFromEditor(vscode.window.activeTextEditor);
 
     /**
      * Opens IntelliGit's native three-way merge editor for a repository-relative conflict file.

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -218,7 +218,10 @@ export async function activateRepositoryMode(
      * Repository switches clear selection before calling this. Failures propagate to
      * the caller; background initial refreshes attach their own logging handlers.
      */
-    const refreshActiveRepository = async (): Promise<void> => {
+    const refreshActiveRepositoryWithGuard = async (
+        shouldContinue: () => boolean = () => true,
+        afterBranchDataApplied?: () => Promise<void>,
+    ): Promise<boolean> => {
         const [branches, refreshedWorktrees] = await Promise.all([
             gitOps.getBranches(),
             worktreeService.refresh().catch((err) => {
@@ -226,11 +229,16 @@ export async function activateRepositoryMode(
                 return [] as GitWorktree[];
             }),
         ]);
+        if (!shouldContinue()) return false;
         currentWorktrees = refreshedWorktrees;
         currentBranches = worktreeService.decorateBranches(branches);
         commitGraph.setBranches(currentBranches, currentWorktrees);
         sidebarGraph.setBranches(currentBranches, currentWorktrees);
         commitPanel.setBranches(currentBranches);
+        if (afterBranchDataApplied) {
+            await afterBranchDataApplied();
+            if (!shouldContinue()) return false;
+        }
         const refreshes: Array<Promise<void>> = [
             commitGraph.refresh(),
             sidebarGraph.refresh(),
@@ -242,6 +250,18 @@ export async function activateRepositoryMode(
             refreshes.push(undocked.refresh());
         }
         await Promise.all(refreshes);
+        return shouldContinue();
+    };
+
+    const refreshActiveRepository = async (): Promise<void> => {
+        await refreshActiveRepositoryWithGuard();
+    };
+
+    let activeEditorSwitchSeq = 0;
+    type ActiveRepositorySwitchOptions = {
+        fromActiveEditor?: boolean;
+        persistSelectionAfterBranchData?: boolean;
+        shouldContinue?: () => boolean;
     };
 
     /**
@@ -251,7 +271,14 @@ export async function activateRepositoryMode(
      * badge state, persisted workspace selection, and refresh service watchers
      * before loading fresh data for the selected repository.
      */
-    const setActiveRepository = async (repository: DiscoveredRepository): Promise<void> => {
+    const setActiveRepository = async (
+        repository: DiscoveredRepository,
+        options: ActiveRepositorySwitchOptions = {},
+    ): Promise<void> => {
+        if (!options.fromActiveEditor) activeEditorSwitchSeq++;
+        const shouldContinue = options.shouldContinue ?? (() => true);
+        if (!shouldContinue()) return;
+
         activeRepository = repository;
         repoRoot = repository.root;
         repoRootUri = vscode.Uri.file(repoRoot);
@@ -270,15 +297,38 @@ export async function activateRepositoryMode(
         refreshService.dispose();
         refreshService = createRefreshService(repoRoot);
         refreshService.registerFileWatchers();
-        await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
+        if (!options.persistSelectionAfterBranchData) {
+            await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
+            if (!shouldContinue()) return;
+        }
         clearSelection();
-        await refreshActiveRepository();
+        const persistSelectionAfterBranchDataApplied = options.persistSelectionAfterBranchData
+            ? async (): Promise<void> => {
+                  if (shouldContinue()) {
+                      await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
+                  }
+              }
+            : undefined;
+        if (
+            !(await refreshActiveRepositoryWithGuard(
+                shouldContinue,
+                persistSelectionAfterBranchDataApplied,
+            ))
+        ) {
+            return;
+        }
     };
 
     const updateActiveRepositoryFromEditor = async (editor?: vscode.TextEditor): Promise<void> => {
         const repository = repositoryForFileUri(editor?.document.uri, repositories);
         if (!repository || repository.root === activeRepository.root) return;
-        await setActiveRepository(repository);
+        const switchSeq = ++activeEditorSwitchSeq;
+        const isLatestEditorSwitch = (): boolean => switchSeq === activeEditorSwitchSeq;
+        await setActiveRepository(repository, {
+            fromActiveEditor: true,
+            persistSelectionAfterBranchData: true,
+            shouldContinue: isLatestEditorSwitch,
+        });
     };
 
     context.subscriptions.push(

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -36,6 +36,7 @@ import {
 import { showTimedWarningMessage } from "../utils/notifications";
 
 type BranchDeleteSelection = Array<Branch | string>;
+const UNDOCKED_SELECTED_REPOSITORY_KEY = "intelligit.undockedSelectedRepositoryRoot";
 
 /** Extracts a branch name from current and legacy bulk-delete event payloads. */
 function getBranchSelectionName(branch: Branch | string): string {
@@ -115,6 +116,21 @@ export async function activateRepositoryMode(
     let undockedCommitDetailRequestSeq = 0;
     let repoRootUri = vscode.Uri.file(repoRoot);
     let undocked: UndockedViewProvider | undefined;
+    let undockedSelectedRepositoryRoot =
+        repositories.find(
+            (repository) =>
+                repository.root ===
+                context.workspaceState?.get<string>(UNDOCKED_SELECTED_REPOSITORY_KEY),
+        )?.root ?? activeRepository.root;
+    let undockedBranches: Branch[] = [];
+    let undockedWorktrees: GitWorktree[] = [];
+    let undockedRuntime:
+        | {
+              executor: GitExecutor;
+              gitOps: GitOps;
+              worktreeService: WorktreeService;
+          }
+        | undefined;
 
     const commitGraph = new CommitGraphViewProvider(context.extensionUri, gitOps, credentialStore, {
         hostMap: commitCheckHostMap,
@@ -153,6 +169,18 @@ export async function activateRepositoryMode(
     ): void => {
         repositories = nextRepositories;
         commitPanel.setRepositories(nextRepositories, activeRoot ?? undefined);
+        if (
+            !repositories.some((repository) => repository.root === undockedSelectedRepositoryRoot)
+        ) {
+            undockedSelectedRepositoryRoot = resolveUndockedRepository(
+                activeRoot ?? undefined,
+            ).root;
+            void context.workspaceState?.update(
+                UNDOCKED_SELECTED_REPOSITORY_KEY,
+                undockedSelectedRepositoryRoot,
+            );
+        }
+        undocked?.setRepositories(repositories, undockedSelectedRepositoryRoot);
     };
 
     const mergeConflictsView = vscode.window.createTreeView("intelligit.mergeConflicts", {
@@ -223,6 +251,32 @@ export async function activateRepositoryMode(
     /** Returns the active branch name from the latest refreshed branch snapshot. */
     const getCurrentBranchName = (): string | undefined =>
         currentBranches.find((b) => b.isCurrent)?.name;
+    /** Returns the repository root currently selected by the independent undocked runtime. */
+    const getUndockedSelectedRepositoryRoot = (): string => undockedSelectedRepositoryRoot;
+
+    const resolveUndockedRepository = (root: string | undefined): DiscoveredRepository =>
+        repositories.find((repository) => repository.root === root) ??
+        repositories.find((repository) => repository.root === activeRepository.root) ??
+        activeRepository;
+
+    const loadCurrentUndockedRepositoryData = async (): Promise<{
+        branches: Branch[];
+        worktrees: GitWorktree[];
+    }> => {
+        if (!undockedRuntime) {
+            return { branches: [], worktrees: [] };
+        }
+        const [branches, refreshedWorktrees] = await Promise.all([
+            undockedRuntime.gitOps.getBranches(),
+            undockedRuntime.worktreeService.refresh().catch((err) => {
+                console.error("[IntelliGit] Undocked worktrees refresh failed:", err);
+                return [] as GitWorktree[];
+            }),
+        ]);
+        undockedWorktrees = refreshedWorktrees;
+        undockedBranches = undockedRuntime.worktreeService.decorateBranches(branches);
+        return { branches: undockedBranches, worktrees: undockedWorktrees };
+    };
 
     /** Clears selected commit state from every visible IntelliGit surface at once. */
     const clearSelection = (options?: { loading?: boolean }): void => {
@@ -265,7 +319,9 @@ export async function activateRepositoryMode(
             commitPanel.refresh(),
             refreshService.refreshMergeConflicts(),
         ];
-        if (undocked) {
+        if (undocked && undockedSelectedRepositoryRoot === repoRoot) {
+            undockedBranches = currentBranches;
+            undockedWorktrees = currentWorktrees;
             undocked.setBranches(currentBranches, currentWorktrees);
             refreshes.push(undocked.refresh());
         }
@@ -328,10 +384,7 @@ export async function activateRepositoryMode(
         sidebarGraph.setRepositoryLabel(repository.label);
         commitPanel.setRepositoryRootUri(repoRootUri);
         commitPanel.setRepositoryLabel(repository.label);
-        if (undocked) {
-            undocked.setRepositoryRootUri(repoRootUri);
-            undocked.setRepositoryLabel(repository.label);
-        }
+        undocked?.setRepositories(repositories, undockedSelectedRepositoryRoot);
         mergeConflicts.setWorkspaceRoot(repoRootUri);
         resetFileCountBadge();
         refreshService.dispose();
@@ -493,21 +546,55 @@ export async function activateRepositoryMode(
     const ensureUndockedPanel = (): UndockedViewProvider => {
         if (undocked) return undocked;
 
+        const initialUndockedRepository = resolveUndockedRepository(undockedSelectedRepositoryRoot);
+        undockedSelectedRepositoryRoot = initialUndockedRepository.root;
+        const undockedExecutor = new GitExecutor(initialUndockedRepository.root);
+        const undockedGitOps = new GitOps(undockedExecutor);
+        const undockedWorktreeService = new WorktreeService(
+            undockedExecutor,
+            getUndockedSelectedRepositoryRoot,
+        );
+        undockedRuntime = {
+            executor: undockedExecutor,
+            gitOps: undockedGitOps,
+            worktreeService: undockedWorktreeService,
+        };
+        const handleOpenUndockedCommitFileDiff = createOpenCommitFileDiffHandler({
+            executor: undockedExecutor,
+            gitOps: undockedGitOps,
+            getRepoRoot: getUndockedSelectedRepositoryRoot,
+        });
+
         undocked = new UndockedViewProvider(
             context.extensionUri,
-            gitOps,
-            repoRootUri,
+            undockedGitOps,
+            vscode.Uri.file(initialUndockedRepository.root),
             credentialStore,
             context.workspaceState,
             commitCheckHostMap,
             commitCheckSettings,
+            {
+                executor: undockedExecutor,
+                repositories,
+                selectedRepositoryRoot: initialUndockedRepository.root,
+                loadRepositoryData: loadCurrentUndockedRepositoryData,
+                onSelectedRepositoryRootChanged: async (root) => {
+                    undockedSelectedRepositoryRoot = root;
+                    await context.workspaceState?.update(UNDOCKED_SELECTED_REPOSITORY_KEY, root);
+                },
+            },
         );
-        undocked.setRepositoryLabel(activeRepository.label);
+        undocked.setRepositoryLabel(initialUndockedRepository.label);
+        undocked.setRepositories(repositories, initialUndockedRepository.root);
         context.subscriptions.push(undocked);
 
         context.subscriptions.push(
             undocked.onDidDispose(() => {
                 undocked = undefined;
+                undockedRuntime?.worktreeService.dispose();
+                undockedRuntime = undefined;
+                undockedBranches = [];
+                undockedWorktrees = [];
             }),
             undocked.onDockRequested(async () => {
                 await dockIntelliGit();
@@ -515,7 +602,7 @@ export async function activateRepositoryMode(
             undocked.onCommitSelected(async (hash) => {
                 const requestId = ++undockedCommitDetailRequestSeq;
                 try {
-                    const detail = await gitOps.getCommitDetail(hash);
+                    const detail = await undockedGitOps.getCommitDetail(hash);
                     if (requestId === undockedCommitDetailRequestSeq) {
                         undocked?.setCommitDetail(detail);
                     }
@@ -527,12 +614,12 @@ export async function activateRepositoryMode(
                 }
             }),
             undocked.onBranchAction(({ action, branchName }) => {
-                const branch = currentBranches.find((b) => b.name === branchName);
+                const branch = undockedBranches.find((b) => b.name === branchName);
                 if (!branch) return;
                 void vscode.commands.executeCommand(`intelligit.${action}`, { branch });
             }),
             undocked.onWorktreeAction?.(({ action, path: worktreePath }) => {
-                const worktree = currentWorktrees.find(
+                const worktree = undockedWorktrees.find(
                     (candidate) => candidate.path === worktreePath,
                 );
                 if (!worktree) return;
@@ -552,7 +639,7 @@ export async function activateRepositoryMode(
                     new Set(branchSelection.map(getBranchSelectionName)),
                 );
                 const branches = requestedNames
-                    .map((name) => getCurrentBranches().find((branch) => branch.name === name))
+                    .map((name) => undockedBranches.find((branch) => branch.name === name))
                     .filter((branch): branch is Branch => Boolean(branch));
                 if (branches.length !== requestedNames.length) {
                     const found = new Set(branches.map((branch) => branch.name));
@@ -571,11 +658,17 @@ export async function activateRepositoryMode(
                     await handleCommitContextAction({
                         action,
                         hash,
-                        executor,
-                        gitOps,
-                        repoRoot,
-                        currentBranches,
-                        refreshAll: () => refreshService.refreshAll(),
+                        executor: undockedExecutor,
+                        gitOps: undockedGitOps,
+                        repoRoot: getUndockedSelectedRepositoryRoot(),
+                        currentBranches: undockedBranches,
+                        refreshAll: async () => {
+                            if (getUndockedSelectedRepositoryRoot() === repoRoot) {
+                                await refreshService.refreshAll();
+                                return;
+                            }
+                            await loadUndockedData();
+                        },
                     });
                 } catch (error) {
                     const message = getErrorMessage(error);
@@ -585,7 +678,7 @@ export async function activateRepositoryMode(
                     );
                 }
             }),
-            undocked.onOpenCommitFileDiff(handleOpenCommitFileDiff),
+            undocked.onOpenCommitFileDiff(handleOpenUndockedCommitFileDiff),
             undocked.onDidChangeWorkingTree(() => {
                 commitPanel.refreshSilent().catch((err) => {
                     console.error("[IntelliGit] Docked commit panel refresh failed:", err);
@@ -608,9 +701,9 @@ export async function activateRepositoryMode(
      */
     const loadUndockedData = async (): Promise<void> => {
         if (!undocked) return;
-        currentBranches = worktreeService.decorateBranches(await gitOps.getBranches());
+        const { branches, worktrees } = await loadCurrentUndockedRepositoryData();
         if (!undocked) return;
-        undocked.setBranches(currentBranches, currentWorktrees);
+        undocked.setBranches(branches, worktrees);
         await undocked.refresh();
     };
 

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -386,6 +386,8 @@ export async function activateRepositoryMode(
         executor.setRoot(repoRoot);
         commitGraph.setRepositoryLabel(repository.label);
         sidebarGraph.setRepositoryLabel(repository.label);
+        commitGraph.resetFilters();
+        sidebarGraph.resetFilters();
         commitPanel.setRepositoryRootUri(repoRootUri);
         commitPanel.setRepositoryLabel(repository.label);
         undocked?.setRepositories(repositories, undockedSelectedRepositoryRoot);

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -127,6 +127,7 @@ export async function activateRepositoryMode(
         )?.root ?? activeRepository.root;
     let undockedBranches: Branch[] = [];
     let undockedWorktrees: GitWorktree[] = [];
+    let undockedSelectionWrite = Promise.resolve();
     let undockedRuntime:
         | {
               executor: GitExecutor;
@@ -166,12 +167,15 @@ export async function activateRepositoryMode(
     sidebarGraph.setRepositoryLabel(activeRepository.label);
     commitPanel.setRepositoryLabel(activeRepository.label);
     commitPanel.setRepositories(repositories, activeRepository.root);
+    sidebarGraph.setShowRepositoryLabel(repositories.length > 1);
 
     const setKnownRepositories = (
         nextRepositories: DiscoveredRepository[],
         activeRoot: string | null = activeRepository.root,
     ): void => {
         repositories = nextRepositories;
+        void setViewContext(HAS_MULTIPLE_REPOSITORIES_CONTEXT, repositories.length > 1);
+        sidebarGraph.setShowRepositoryLabel(repositories.length > 1);
         commitPanel.setRepositories(nextRepositories, activeRoot ?? undefined);
         if (
             !repositories.some((repository) => repository.root === undockedSelectedRepositoryRoot)
@@ -338,6 +342,7 @@ export async function activateRepositoryMode(
     };
 
     let activeEditorSwitchSeq = 0;
+    let repositorySwitchSeq = 0;
     let activeEditorSelectionWrite = Promise.resolve();
     type ActiveRepositorySwitchOptions = {
         fromActiveEditor?: boolean;
@@ -375,8 +380,11 @@ export async function activateRepositoryMode(
         repository: DiscoveredRepository,
         options: ActiveRepositorySwitchOptions = {},
     ): Promise<void> => {
+        const switchSeq = ++repositorySwitchSeq;
         if (!options.fromActiveEditor) activeEditorSwitchSeq++;
-        const shouldContinue = options.shouldContinue ?? (() => true);
+        const callerShouldContinue = options.shouldContinue ?? (() => true);
+        const shouldContinue = (): boolean =>
+            switchSeq === repositorySwitchSeq && callerShouldContinue();
         if (!shouldContinue()) return;
 
         activeRepository = repository;
@@ -586,7 +594,16 @@ export async function activateRepositoryMode(
                 loadRepositoryData: loadCurrentUndockedRepositoryData,
                 onSelectedRepositoryRootChanged: async (root) => {
                     undockedSelectedRepositoryRoot = root;
-                    await context.workspaceState?.update(UNDOCKED_SELECTED_REPOSITORY_KEY, root);
+                    undockedSelectionWrite = undockedSelectionWrite
+                        .catch(() => undefined)
+                        .then(async () => {
+                            if (undockedSelectedRepositoryRoot !== root) return;
+                            await context.workspaceState?.update(
+                                UNDOCKED_SELECTED_REPOSITORY_KEY,
+                                root,
+                            );
+                        });
+                    await undockedSelectionWrite;
                 },
             },
         );

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -7,7 +7,10 @@ import type { Branch, GitWorktree } from "../types";
 import { getErrorMessage } from "../utils/errors";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { WorktreeService } from "../services/worktreeService";
-import type { DiscoveredRepository } from "../services/repositoryDiscovery";
+import {
+    discoverGitRepositories,
+    type DiscoveredRepository,
+} from "../services/repositoryDiscovery";
 import { CredentialStore } from "../services/commitChecks/credentialStore";
 import { normalizeHostMap } from "../services/commitChecks/hostConfig";
 import { normalizeCommitChecksSettings } from "../services/commitChecks/settingsConfig";
@@ -23,6 +26,7 @@ import {
     type RepositoryViewProviders,
     SELECTED_REPOSITORY_KEY,
     selectInitialRepository,
+    workspaceRoots,
 } from "./common";
 import { registerRepositoryCommands } from "./repositoryCommands";
 import {
@@ -142,6 +146,14 @@ export async function activateRepositoryMode(
     sidebarGraph.setRepositoryLabel(activeRepository.label);
     commitPanel.setRepositoryLabel(activeRepository.label);
     commitPanel.setRepositories(repositories, activeRepository.root);
+
+    const setKnownRepositories = (
+        nextRepositories: DiscoveredRepository[],
+        activeRoot: string | null = activeRepository.root,
+    ): void => {
+        repositories = nextRepositories;
+        commitPanel.setRepositories(nextRepositories, activeRoot ?? undefined);
+    };
 
     const mergeConflictsView = vscode.window.createTreeView("intelligit.mergeConflicts", {
         treeDataProvider: mergeConflicts,
@@ -358,10 +370,29 @@ export async function activateRepositoryMode(
         });
     };
 
+    const refreshDiscoveredRepositories = async (): Promise<void> => {
+        const nextRepositories = await discoverGitRepositories(workspaceRoots());
+        const currentActive = nextRepositories.find(
+            (repository) => repository.root === activeRepository.root,
+        );
+        if (currentActive || nextRepositories.length === 0) {
+            setKnownRepositories(nextRepositories, currentActive?.root ?? activeRepository.root);
+            return;
+        }
+        const fallbackRepository = nextRepositories[0];
+        setKnownRepositories(nextRepositories, fallbackRepository.root);
+        await setActiveRepository(fallbackRepository);
+    };
+
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor((editor) => {
             void updateActiveRepositoryFromEditor(editor).catch((err) => {
                 console.error("[IntelliGit] Failed to update active repository from editor:", err);
+            });
+        }),
+        vscode.workspace.onDidChangeWorkspaceFolders(async () => {
+            await refreshDiscoveredRepositories().catch((err) => {
+                console.error("[IntelliGit] Failed to refresh repositories:", err);
             });
         }),
     );
@@ -766,8 +797,7 @@ export async function activateRepositoryMode(
         worktreeService,
         getRepoRoot,
         setRepositories: (nextRepositories) => {
-            repositories = nextRepositories;
-            commitPanel.setRepositories(nextRepositories, activeRepository.root);
+            setKnownRepositories(nextRepositories);
         },
         getCurrentBranches,
         getCurrentBranchName,

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -23,9 +23,11 @@ import { MergeEditorPanel } from "../views/MergeEditorPanel";
 import { RefreshService } from "../views/RefreshService";
 import { UndockedViewProvider } from "../views/UndockedViewProvider";
 import {
+    HAS_MULTIPLE_REPOSITORIES_CONTEXT,
     type RepositoryViewProviders,
     SELECTED_REPOSITORY_KEY,
     selectInitialRepository,
+    setViewContext,
     workspaceRoots,
 } from "./common";
 import { registerRepositoryCommands } from "./repositoryCommands";
@@ -83,6 +85,7 @@ export async function activateRepositoryMode(
     viewProviders: RepositoryViewProviders = {},
 ): Promise<void> {
     let repositories = repositoriesForActivation;
+    void setViewContext(HAS_MULTIPLE_REPOSITORIES_CONTEXT, repositories.length > 1);
     let activeRepository = selectInitialRepository(
         repositories,
         context.workspaceState?.get<string>(SELECTED_REPOSITORY_KEY),
@@ -143,6 +146,7 @@ export async function activateRepositoryMode(
         {
             scriptFile: "webview-compactcommitgraph.js",
             title: vscode.l10n.t("Graph"),
+            showRepositoryLabel: repositories.length > 1,
             hostMap: commitCheckHostMap,
             settings: commitCheckSettings,
         },
@@ -817,6 +821,11 @@ export async function activateRepositoryMode(
 
     context.subscriptions.push(
         mergeConflictsView,
+        vscode.commands.registerCommand("intelligit.sidebarRepositoryIndicator", () => undefined),
+        vscode.commands.registerCommand(
+            "intelligit.sidebarRepositoryIndicator.color",
+            () => undefined,
+        ),
         vscode.commands.registerCommand(
             "intelligit.commitChecks.refreshBadges",
             refreshCommitCheckBadges,

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -192,8 +192,14 @@ export async function activateRepositoryMode(
         );
 
     let refreshService = createRefreshService(repoRoot);
+    let refreshServiceWatchersRegistered = false;
     /** Returns the currently active refresh coordinator after repository switches replace it. */
     const getRefreshService = (): RefreshService => refreshService;
+    const registerRefreshServiceWatchers = (): void => {
+        if (refreshServiceWatchersRegistered) return;
+        refreshService.registerFileWatchers();
+        refreshServiceWatchersRegistered = true;
+    };
     /** Returns the repository root currently bound to command handlers. */
     const getRepoRoot = (): string => repoRoot;
     /** Returns the latest decorated branch snapshot shared by host command handlers. */
@@ -258,10 +264,30 @@ export async function activateRepositoryMode(
     };
 
     let activeEditorSwitchSeq = 0;
+    let activeEditorSelectionWrite = Promise.resolve();
     type ActiveRepositorySwitchOptions = {
         fromActiveEditor?: boolean;
         persistSelectionAfterBranchData?: boolean;
         shouldContinue?: () => boolean;
+    };
+    const persistActiveEditorSelection = async (
+        root: string,
+        shouldContinue: () => boolean,
+    ): Promise<void> => {
+        const write = activeEditorSelectionWrite
+            .catch(() => undefined)
+            .then(async () => {
+                if (!shouldContinue()) return;
+                await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, root);
+                if (!shouldContinue()) {
+                    await context.workspaceState?.update(
+                        SELECTED_REPOSITORY_KEY,
+                        activeRepository.root,
+                    );
+                }
+            });
+        activeEditorSelectionWrite = write;
+        await write;
     };
 
     /**
@@ -296,7 +322,8 @@ export async function activateRepositoryMode(
         resetFileCountBadge();
         refreshService.dispose();
         refreshService = createRefreshService(repoRoot);
-        refreshService.registerFileWatchers();
+        refreshServiceWatchersRegistered = false;
+        registerRefreshServiceWatchers();
         if (!options.persistSelectionAfterBranchData) {
             await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
             if (!shouldContinue()) return;
@@ -304,9 +331,7 @@ export async function activateRepositoryMode(
         clearSelection();
         const persistSelectionAfterBranchDataApplied = options.persistSelectionAfterBranchData
             ? async (): Promise<void> => {
-                  if (shouldContinue()) {
-                      await context.workspaceState?.update(SELECTED_REPOSITORY_KEY, repoRoot);
-                  }
+                  await persistActiveEditorSelection(repoRoot, shouldContinue);
               }
             : undefined;
         if (
@@ -773,7 +798,7 @@ export async function activateRepositoryMode(
     refreshService.refreshMergeConflicts().catch((err) => {
         console.error("Initial merge conflicts refresh failed:", err);
     });
-    refreshService.registerFileWatchers();
+    registerRefreshServiceWatchers();
 
     context.subscriptions.push(
         fileCountBadgeSubscription,

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -133,6 +133,7 @@ export async function activateRepositoryMode(
         gitOps,
         repoRootUri,
         context.workspaceState,
+        context.secrets,
     );
     const mergeConflicts = new MergeConflictsTreeProvider(gitOps, repoRootUri);
     const worktreeService = new WorktreeService(executor, () => repoRoot);

--- a/src/activation/repositoryMode.ts
+++ b/src/activation/repositoryMode.ts
@@ -141,6 +141,7 @@ export async function activateRepositoryMode(
     commitGraph.setRepositoryLabel(activeRepository.label);
     sidebarGraph.setRepositoryLabel(activeRepository.label);
     commitPanel.setRepositoryLabel(activeRepository.label);
+    commitPanel.setRepositories(repositories, activeRepository.root);
 
     const mergeConflictsView = vscode.window.createTreeView("intelligit.mergeConflicts", {
         treeDataProvider: mergeConflicts,
@@ -766,6 +767,7 @@ export async function activateRepositoryMode(
         getRepoRoot,
         setRepositories: (nextRepositories) => {
             repositories = nextRepositories;
+            commitPanel.setRepositories(nextRepositories, activeRepository.root);
         },
         getCurrentBranches,
         getCurrentBranchName,

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -389,11 +389,17 @@ export class GitOps {
      * than blocking the status view. Ignored files are included only when callers opt in because Git
      * can return large ignored directories.
      */
-    async getStatus(options: { includeIgnored?: boolean } = {}): Promise<WorkingFile[]> {
+    async getStatus(
+        options: { includeIgnored?: boolean; withStats?: boolean } = {},
+    ): Promise<WorkingFile[]> {
         const statusArgs = ["status", "--porcelain=v1", "-z", "-uall"];
         if (options.includeIgnored) statusArgs.push("--ignored");
         const result = await this.executor.run(statusArgs);
         const files = parseWorkingTreeStatus(result);
+        // Callers that only need the changed-file set (e.g. collapsed multi-repository
+        // row counts) pass `withStats: false` to skip the two numstat subprocesses,
+        // turning a three-process status into a single one per repository.
+        if (options.withStats === false) return files;
         const applyNumstat = (
             output: string,
             staged: boolean,

--- a/src/services/repositoryDiscovery.ts
+++ b/src/services/repositoryDiscovery.ts
@@ -2,6 +2,12 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { GitExecutor } from "../git/executor";
 import { GitOps } from "../git/operations";
+import { mapWithConcurrency } from "../utils/concurrency";
+
+// Bound on concurrent `git rev-parse` resolutions during discovery. High enough to
+// hide subprocess latency across many repositories, low enough not to swamp the OS.
+// ponytail: fixed cap; tie to os.cpus() only if a profiler says it matters.
+const GIT_RESOLVE_CONCURRENCY = 8;
 
 const IGNORED_DIRS = new Set([
     ".git",
@@ -52,8 +58,16 @@ export interface DiscoverGitRepositoriesOptions {
  */
 async function defaultResolveGitRoot(candidateRoot: string): Promise<string | null> {
     const gitOps = new GitOps(new GitExecutor(candidateRoot));
-    if (!(await gitOps.isRepository())) return null;
-    return gitOps.getRepositoryRoot();
+    // A single `git rev-parse --show-toplevel` both validates that the candidate is
+    // inside a work tree and returns its canonical root: non-repositories reject and
+    // resolve to `null`. This replaces the former is-repository + show-toplevel pair,
+    // halving Git subprocesses per candidate during discovery.
+    try {
+        const root = await gitOps.getRepositoryRoot();
+        return root || null;
+    } catch {
+        return null;
+    }
 }
 
 async function normalizeRoot(root: string): Promise<string> {
@@ -111,17 +125,13 @@ async function addResolvedRoot(
 }
 
 /**
- * Recursively scans a workspace folder for `.git` markers while skipping heavy dependency dirs.
+ * Recursively collects directories containing a `.git` marker while skipping heavy dependency dirs.
  *
- * Inaccessible directories are ignored so discovery remains best-effort during
- * activation and no-repository onboarding flows.
+ * Only the cheap filesystem walk happens here; Git resolution of each candidate is
+ * deferred so it can run bounded-parallel. Inaccessible directories are ignored so
+ * discovery stays best-effort during activation and no-repository onboarding flows.
  */
-async function scanForGitMarkers(
-    directory: string,
-    workspaceRoots: string[],
-    seen: Map<string, DiscoveredRepository>,
-    resolveGitRoot: ResolveGitRoot,
-): Promise<void> {
+async function collectGitMarkerDirs(directory: string, candidates: string[]): Promise<void> {
     let entries: import("fs").Dirent[];
     try {
         entries = await fs.readdir(directory, { withFileTypes: true });
@@ -131,22 +141,15 @@ async function scanForGitMarkers(
 
     for (const entry of entries) {
         if (IGNORED_DIRS.has(entry.name)) {
-            if (entry.name === ".git") {
-                // Discovery is sequential to keep recursive filesystem IO bounded and ordered.
-                // react-doctor-disable-next-line react-doctor/async-await-in-loop
-                await addResolvedRoot(directory, workspaceRoots, seen, resolveGitRoot);
-            }
+            // A `.git` marker makes `directory` a repository/worktree/submodule root
+            // candidate; the actual Git resolution runs later, in parallel.
+            if (entry.name === ".git") candidates.push(directory);
             continue;
         }
         if (!entry.isDirectory()) continue;
-        // Discovery is sequential to keep recursive filesystem IO bounded and ordered.
+        // The walk stays sequential to keep recursive filesystem IO bounded and ordered.
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
-        await scanForGitMarkers(
-            path.join(directory, entry.name),
-            workspaceRoots,
-            seen,
-            resolveGitRoot,
-        );
+        await collectGitMarkerDirs(path.join(directory, entry.name), candidates);
     }
 }
 
@@ -165,12 +168,24 @@ export async function discoverGitRepositories(
     const seen = new Map<string, DiscoveredRepository>();
     const resolveGitRoot = options.resolveGitRoot ?? defaultResolveGitRoot;
 
+    // Phase 1 — cheap filesystem walk that only collects candidate directories. Each
+    // workspace root is itself a candidate (the user may have opened a repository or a
+    // subdirectory of one) alongside every nested `.git` marker.
+    const candidates: string[] = [...roots];
     for (const workspaceRoot of roots) {
-        // Each root is added before its children so repository de-duplication stays deterministic.
+        // Sequential walk keeps recursive filesystem IO bounded.
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
-        await addResolvedRoot(workspaceRoot, roots, seen, resolveGitRoot);
-        await scanForGitMarkers(workspaceRoot, roots, seen, resolveGitRoot);
+        await collectGitMarkerDirs(workspaceRoot, candidates);
     }
+
+    // Phase 2 — resolve candidates through Git concurrently. Git resolution (one
+    // subprocess per candidate) dominated activation time with many repositories, so it
+    // runs bounded-parallel instead of one-at-a-time. De-duplicating candidate paths
+    // first, then keying `seen` by canonical root and sorting by label at the end, keeps
+    // results deterministic regardless of the order resolutions complete in.
+    await mapWithConcurrency([...new Set(candidates)], GIT_RESOLVE_CONCURRENCY, (candidate) =>
+        addResolvedRoot(candidate, roots, seen, resolveGitRoot),
+    );
 
     // Spread already isolates the map values before sorting; no shared array is mutated.
     // react-doctor-disable-next-line react-doctor/js-tosorted-immutable

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,39 @@
+// Small async concurrency helper used to bound how many Git subprocesses run at
+// once during multi-repository operations (repository discovery, collapsed-row
+// count scans). Keeping a fixed worker pool avoids the thundering herd of one
+// subprocess per repository that made activation slow with many repositories.
+
+/**
+ * Maps `items` through `mapper` while running at most `limit` calls concurrently.
+ *
+ * Results are returned in the original item order regardless of completion order.
+ * A rejected mapper call rejects the returned promise, mirroring `Promise.all`;
+ * callers that must not abort the batch should catch inside `mapper`.
+ *
+ * @param items - Items to process; an empty list resolves to an empty array.
+ * @param limit - Maximum number of concurrent `mapper` executions (floored at 1).
+ * @param mapper - Async transform invoked with each item and its original index.
+ * @returns Mapper results in the same order as `items`.
+ */
+export async function mapWithConcurrency<T, R>(
+    items: readonly T[],
+    limit: number,
+    mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+    if (items.length === 0) return [];
+    const bound = Math.max(1, Math.min(Math.floor(limit), items.length));
+    const results = new Array<R>(items.length);
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+        // `nextIndex++` is atomic between awaits on the single-threaded event loop,
+        // so each index is claimed by exactly one worker.
+        while (nextIndex < items.length) {
+            const index = nextIndex++;
+            results[index] = await mapper(items[index], index);
+        }
+    };
+
+    await Promise.all(Array.from({ length: bound }, runWorker));
+    return results;
+}

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -321,7 +321,18 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this.currentBranch = branch;
         this.filterText = "";
         this.postToWebview({ type: "setSelectedBranch", branch });
+        this.postToWebview({ type: "setFilterText", text: "" });
         await this.loadInitial();
+    }
+
+    /**
+     * Clears repository-scoped filters before a different repository root is loaded.
+     */
+    resetFilters(): void {
+        this.currentBranch = null;
+        this.filterText = "";
+        this.postToWebview({ type: "setSelectedBranch", branch: null });
+        this.postToWebview({ type: "setFilterText", text: "" });
     }
 
     /**

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -667,7 +667,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         if (!this.view) return;
         this.view.description =
             this.options.showRepositoryLabel && this.repositoryLabel
-                ? this.repositoryLabel
+                ? `(${this.repositoryLabel})`
                 : undefined;
     }
 

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -68,6 +68,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     private branchFolderIconsByName: ThemeFolderIconMap = {};
     private commitDetailSeq = 0;
     private themeChangeDisposables: vscode.Disposable[] = [];
+    private repositoryLabel: string | null = null;
     private readonly iconTheme: IconThemeService;
     private readonly _onCommitSelected = new vscode.EventEmitter<string>();
     readonly onCommitSelected = this._onCommitSelected.event;
@@ -115,6 +116,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         private readonly options: {
             scriptFile?: string;
             title?: string;
+            showRepositoryLabel?: boolean;
             hostMap?: HostMap;
             settings?: CommitChecksSettings;
         } = {},
@@ -150,13 +152,11 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     }
 
     /**
-     * Accepts repository label updates while keeping the graph view description available.
-     *
-     * The commit graph does not render the repository name in the VS Code title area; clearing the
-     * description prevents stale labels when activation switches repositories underneath the view.
+     * Stores the active repository label for compact multi-repository graph chrome.
      */
-    setRepositoryLabel(_label: string): void {
-        if (this.view) this.view.description = undefined;
+    setRepositoryLabel(label: string): void {
+        this.repositoryLabel = label.trim() || null;
+        this.applyRepositoryDescription();
     }
 
     /**
@@ -176,7 +176,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
         this.disposeThemeChangeDisposables();
         this.iconTheme.dispose();
         this.view = webviewView;
-        webviewView.description = undefined;
+        this.applyRepositoryDescription();
 
         webviewView.webview.options = {
             enableScripts: true,
@@ -658,6 +658,17 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
             title: this.options.title ?? "Commit Graph",
             backgroundVar: "var(--vscode-editor-background)",
         });
+    }
+
+    /**
+     * Mirrors the active repository name into the VS Code-owned view header suffix.
+     */
+    private applyRepositoryDescription(): void {
+        if (!this.view) return;
+        this.view.description =
+            this.options.showRepositoryLabel && this.repositoryLabel
+                ? this.repositoryLabel
+                : undefined;
     }
 
     /**

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -160,6 +160,14 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
     }
 
     /**
+     * Toggles whether the compact graph view should show the active repository label.
+     */
+    setShowRepositoryLabel(showRepositoryLabel: boolean): void {
+        this.options.showRepositoryLabel = showRepositoryLabel;
+        this.applyRepositoryDescription();
+    }
+
+    /**
      * Attaches a freshly resolved VS Code webview view to the commit graph protocol.
      *
      * Each resolution replaces the previous webview, re-registers theme listeners,
@@ -221,6 +229,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
                             type: "setSelectedBranch",
                             branch: this.currentBranch,
                         });
+                        this.postToWebview({ type: "setFilterText", text: "" });
                         await this.loadInitial();
                         break;
                     case "branchAction":

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -2,6 +2,7 @@
 // Shows working tree changes with checkboxes, commit message input,
 // commit/push buttons, amend toggle, and stash management.
 // Frontend is a React + Chakra UI app loaded from dist/webview-commitpanel.js.
+import * as path from "path";
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";
 import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
@@ -9,7 +10,10 @@ import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { abortMergeWithConfirmation } from "./mergeAbort";
-import type { InboundMessage } from "../webviews/protocol/commitPanelMessages";
+import type {
+    CommitPanelRepositorySnapshot,
+    InboundMessage,
+} from "../webviews/protocol/commitPanelMessages";
 import type { DiscoveredRepository } from "../services/repositoryDiscovery";
 import { CommitPanelRepositoryRuntime } from "./commitPanelRepositoryRuntime";
 import { runPublishBranchFlow } from "../services/publishService";
@@ -62,10 +66,13 @@ const MIN_VISIBLE_REFRESH_MS = 600;
 export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = "intelligit.commitPanel";
     private static readonly COMMIT_DRAFT_KEY_PREFIX = "commitDraft:";
+    private static readonly ignoredWatcherDirs = new Set([".git", "dist", "build", "out"]);
     private view?: vscode.WebviewView;
     private lastFileCount = 0;
     private repositories: DiscoveredRepository[] = [];
     private readonly runtimes = new Map<string, CommitPanelRepositoryRuntime>();
+    private readonly expandedRepositoryRoots = new Set<string>();
+    private readonly runtimeWatchers = new Map<string, vscode.Disposable>();
     private activeRepositoryRoot: string | null = null;
     private themeChangeDisposables: vscode.Disposable[] = [];
     private readonly iconTheme: IconThemeService;
@@ -150,6 +157,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         for (const runtime of this.runtimes.values()) {
             this.invalidateRuntime(runtime);
         }
+        this.disposeAllRuntimeWatchers();
+        this.expandedRepositoryRoots.clear();
         this.runtimes.clear();
         this.setRepositoriesInternal(
             [this.repositoryFromUri(repoRootUri)],
@@ -181,6 +190,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
 
         for (const [root, runtime] of this.runtimes) {
             if (nextRoots.has(root)) continue;
+            this.expandedRepositoryRoots.delete(root);
+            this.disposeRuntimeWatcher(root);
             this.invalidateRuntime(runtime);
             this.runtimes.delete(root);
         }
@@ -216,7 +227,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             this.commitDetailFolderIconsByName = {};
             this.branchFolderIconsByName = {};
             this.commitDetailSeq += 1;
-            this.updateViewCount(activeRuntime ? this.countChangedFiles(activeRuntime) : 0);
+            this.updateAggregateChangedFileCount();
             if (activeRuntime) {
                 this.postToWebview({
                     type: "restoreCommitDraft",
@@ -226,12 +237,20 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
         }
         this.postRepositoryListHydration();
+        this.syncRuntimeWatchers();
+        this.scanInitialCollapsedCounts();
+        if (activeChanged && previousActiveRoot !== null && activeRuntime) {
+            this.scanRepositoryFileCount(activeRuntime);
+        }
     }
 
     private postRepositoryListHydration(): void {
         this.postToWebview({
             type: "setRepositories",
-            repositories: this.repositories,
+            repositories: this.repositories.map((repository) => ({
+                ...repository,
+                changedFileCount: this.countChangedFiles(this.runtimes.get(repository.root)),
+            })),
             activeRepositoryRoot: this.activeRepositoryRoot,
         });
     }
@@ -273,14 +292,207 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private invalidateRuntime(runtime: CommitPanelRepositoryRuntime): void {
         runtime.requestSeq += 1;
         runtime.dataRefreshSeq += 1;
+        runtime.countRefreshSeq += 1;
     }
 
-    private countChangedFiles(runtime: CommitPanelRepositoryRuntime): number {
+    private countChangedFiles(runtime: CommitPanelRepositoryRuntime | undefined): number {
+        if (!runtime) return 0;
         const uniquePaths = new Set<string>();
         for (const file of runtime.files) {
             if (file.status !== "!") uniquePaths.add(file.path);
         }
         return uniquePaths.size;
+    }
+
+    /** Sums non-ignored unique changed paths per repository from cached runtime snapshots. */
+    private aggregateChangedFileCount(): number {
+        let count = 0;
+        for (const runtime of this.runtimes.values()) {
+            count += this.countChangedFiles(runtime);
+        }
+        return count;
+    }
+
+    /** Emits the native badge count using every repository runtime's last-known file snapshot. */
+    private updateAggregateChangedFileCount(): void {
+        const count = this.aggregateChangedFileCount();
+        this._onDidChangeFileCount.fire(count);
+        this.updateViewCount(count);
+    }
+
+    /**
+     * Builds the host-owned snapshot for one repository runtime.
+     *
+     * The active single-repository UI still consumes this as an `update` message; Task 4 can reuse
+     * the same payload for per-row accordion state without re-querying Git.
+     */
+    private snapshotForRuntime(
+        runtime: CommitPanelRepositoryRuntime,
+    ): CommitPanelRepositorySnapshot {
+        const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
+        return {
+            repositoryRoot: runtime.repository.root,
+            repositoryLabel: runtime.repository.label,
+            changedFileCount: this.countChangedFiles(runtime),
+            files: runtime.files,
+            stashes: runtime.stashes,
+            stashFiles: runtime.stashFiles,
+            selectedStashIndex: runtime.selectedStashIndex,
+            folderIcon: folderIcons.folderIcon,
+            folderExpandedIcon: folderIcons.folderExpandedIcon,
+            folderIconsByName: runtime.folderIconsByName,
+            iconFonts,
+            currentBranchHasUpstream: runtime.currentBranchHasUpstreamCache,
+            hasRemotes: runtime.hasRemotesCache,
+            currentBranchAhead: runtime.currentBranchAheadCache,
+            currentBranchBehind: runtime.currentBranchBehindCache,
+            currentBranchName: runtime.currentBranchNameCache,
+            currentBranchUpstream: runtime.currentBranchUpstreamCache,
+            refreshing: false,
+            error: null,
+        };
+    }
+
+    /**
+     * Applies webview-expanded repository roots after validating them against host runtimes.
+     *
+     * Newly expanded rows become watched immediately and receive a full runtime refresh; collapsed
+     * rows retain their last scanned count until they are active or expanded again.
+     */
+    private async setExpandedRepositories(value: unknown): Promise<void> {
+        if (!Array.isArray(value)) {
+            throw new Error(`Expected string[] for 'repositoryRoots', got ${typeof value}`);
+        }
+        const nextRoots = new Set<string>();
+        for (const item of value) {
+            const root = assertString(item, "repositoryRoots");
+            if (!this.runtimes.has(root)) {
+                throw new Error("Unknown repository root received from webview.");
+            }
+            nextRoots.add(root);
+        }
+
+        const newlyExpanded = Array.from(nextRoots).filter(
+            (root) => !this.expandedRepositoryRoots.has(root),
+        );
+        this.expandedRepositoryRoots.clear();
+        for (const root of nextRoots) this.expandedRepositoryRoots.add(root);
+        this.syncRuntimeWatchers();
+        await Promise.all(
+            newlyExpanded
+                .map((root) => this.runtimes.get(root))
+                .filter((runtime): runtime is CommitPanelRepositoryRuntime => runtime !== undefined)
+                .map((runtime) => this.refreshRepositoryData(runtime, true)),
+        );
+        this.postRepositoryListHydration();
+    }
+
+    /** Starts one-time status scans for collapsed rows whose count has not been hydrated yet. */
+    private scanInitialCollapsedCounts(): void {
+        for (const runtime of this.runtimes.values()) {
+            if (runtime.hasScannedFileCount) continue;
+            if (runtime.repository.root === this.activeRepositoryRoot) continue;
+            if (this.expandedRepositoryRoots.has(runtime.repository.root)) continue;
+            this.scanRepositoryFileCount(runtime);
+        }
+    }
+
+    /**
+     * Refreshes only the lightweight changed-file count for a collapsed or newly active row.
+     *
+     * The scan is discarded if a full runtime refresh starts before the status result resolves.
+     */
+    private scanRepositoryFileCount(runtime: CommitPanelRepositoryRuntime): void {
+        const dataSeq = runtime.dataRefreshSeq;
+        const countRequestId = ++runtime.countRefreshSeq;
+        void runtime.gitOps
+            .getStatus({ includeIgnored: runtime.showIgnoredFiles })
+            .then((files) => {
+                if (
+                    dataSeq !== runtime.dataRefreshSeq ||
+                    countRequestId !== runtime.countRefreshSeq
+                ) {
+                    return;
+                }
+                runtime.files = files;
+                runtime.hasScannedFileCount = true;
+                this.updateAggregateChangedFileCount();
+                this.postRepositoryListHydration();
+            })
+            .catch(() => {});
+    }
+
+    /** Keeps provider-owned file watchers aligned with the active repository plus expanded rows. */
+    private syncRuntimeWatchers(): void {
+        const desiredRoots = new Set(this.expandedRepositoryRoots);
+        if (this.activeRepositoryRoot !== null) desiredRoots.add(this.activeRepositoryRoot);
+
+        for (const root of Array.from(this.runtimeWatchers.keys())) {
+            if (desiredRoots.has(root)) continue;
+            this.disposeRuntimeWatcher(root);
+        }
+
+        for (const root of desiredRoots) {
+            const runtime = this.runtimes.get(root);
+            if (!runtime || this.runtimeWatchers.has(root)) continue;
+            this.registerRuntimeWatcher(runtime);
+        }
+    }
+
+    /** Registers a repository-scoped filesystem watcher that refreshes only its owning runtime. */
+    private registerRuntimeWatcher(runtime: CommitPanelRepositoryRuntime): void {
+        try {
+            const watcher = vscode.workspace.createFileSystemWatcher(
+                new vscode.RelativePattern(runtime.repoRootUri, "**/*"),
+            );
+            const refresh = (uri: vscode.Uri) => {
+                if (!this.shouldRefreshForWatcherUri(runtime, uri)) return;
+                this.refreshDataWithErrorHandling(true, runtime);
+            };
+            const disposables = [
+                watcher.onDidChange(refresh),
+                watcher.onDidCreate(refresh),
+                watcher.onDidDelete(refresh),
+                watcher,
+            ];
+            this.runtimeWatchers.set(runtime.repository.root, {
+                dispose: () => {
+                    for (const disposable of disposables) {
+                        disposable.dispose();
+                    }
+                },
+            });
+        } catch {
+            /* File watching may be unavailable for virtual or test roots. */
+        }
+    }
+
+    /** Filters watcher events to real working-tree paths and skips noisy generated/Git folders. */
+    private shouldRefreshForWatcherUri(
+        runtime: CommitPanelRepositoryRuntime,
+        uri: vscode.Uri,
+    ): boolean {
+        const relativePath = path.relative(runtime.repository.root, uri.fsPath);
+        if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+            return false;
+        }
+        const [topLevelDir] = relativePath.split(/[\\/]/);
+        return !CommitPanelViewProvider.ignoredWatcherDirs.has(topLevelDir ?? "");
+    }
+
+    /** Disposes the provider-owned watcher for one repository root if it is currently registered. */
+    private disposeRuntimeWatcher(root: string): void {
+        const watcher = this.runtimeWatchers.get(root);
+        if (!watcher) return;
+        watcher.dispose();
+        this.runtimeWatchers.delete(root);
+    }
+
+    /** Disposes every provider-owned repository watcher during root resets and provider teardown. */
+    private disposeAllRuntimeWatchers(): void {
+        for (const root of Array.from(this.runtimeWatchers.keys())) {
+            this.disposeRuntimeWatcher(root);
+        }
     }
 
     private actionDepsForRuntime(runtime?: CommitPanelRepositoryRuntime) {
@@ -409,7 +621,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             if (!webviewView.visible) return;
             const runtime = this.requireActiveRuntime();
             this.postWorkingTreeSnapshot(runtime);
-            this.refreshDataWithErrorHandling(true, runtime);
+            this.refreshAllRepositoriesWithErrorHandling(true);
         });
         this.postRepositoryListHydration();
         this.updateViewCount(this.lastFileCount);
@@ -419,12 +631,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      */
     async refresh(): Promise<void> {
         const runtime = this.requireActiveRuntime();
-        await this.refreshData(false, runtime);
+        await this.refreshAllRepositories(false);
         await this.refreshGraphData(runtime);
     }
     /** Refreshes working-tree data without showing webview or context-key spinner state. */
     async refreshSilent(): Promise<void> {
-        await this.refreshData(true, this.requireActiveRuntime());
+        await this.refreshAllRepositories(true);
     }
     /**
      * Runs a visible refresh for explicit user requests in the Changes view.
@@ -452,24 +664,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * the webview was hidden or loading.
      */
     private postWorkingTreeSnapshot(runtime: CommitPanelRepositoryRuntime): void {
-        const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         this.postToWebview({
             type: "update",
-            repositoryRoot: runtime.repository.root,
-            files: runtime.files,
-            stashes: runtime.stashes,
-            selectedStashIndex: runtime.selectedStashIndex,
-            stashFiles: runtime.stashFiles,
-            folderIcon: folderIcons.folderIcon,
-            folderExpandedIcon: folderIcons.folderExpandedIcon,
-            folderIconsByName: runtime.folderIconsByName,
-            iconFonts,
-            currentBranchHasUpstream: runtime.currentBranchHasUpstreamCache,
-            hasRemotes: runtime.hasRemotesCache,
-            currentBranchAhead: runtime.currentBranchAheadCache,
-            currentBranchBehind: runtime.currentBranchBehindCache,
-            currentBranchName: runtime.currentBranchNameCache,
-            currentBranchUpstream: runtime.currentBranchUpstreamCache,
+            ...this.snapshotForRuntime(runtime),
         });
     }
 
@@ -483,6 +680,35 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private async refreshData(
         silent = false,
         runtime: CommitPanelRepositoryRuntime = this.requireActiveRuntime(),
+    ): Promise<void> {
+        await this.refreshRepositoryData(runtime, silent);
+    }
+
+    /** Refreshes the active runtime plus any expanded rows in parallel. */
+    private async refreshAllRepositories(silent: boolean): Promise<void> {
+        const runtimes = this.watchedRuntimes();
+        await Promise.all(runtimes.map((runtime) => this.refreshRepositoryData(runtime, silent)));
+    }
+
+    /** Returns the unique runtime set that should stay fresh in the docked commit panel. */
+    private watchedRuntimes(): CommitPanelRepositoryRuntime[] {
+        const roots = new Set<string>();
+        if (this.activeRepositoryRoot !== null) roots.add(this.activeRepositoryRoot);
+        for (const root of this.expandedRepositoryRoots) roots.add(root);
+        return Array.from(roots)
+            .map((root) => this.runtimes.get(root))
+            .filter((runtime): runtime is CommitPanelRepositoryRuntime => runtime !== undefined);
+    }
+
+    /**
+     * Reloads full working-tree, stash, icon, and branch metadata for exactly one runtime.
+     *
+     * Request sequencing prevents stale async responses from overwriting a later refresh for the
+     * same repository while leaving other repository rows untouched.
+     */
+    private async refreshRepositoryData(
+        runtime: CommitPanelRepositoryRuntime,
+        silent: boolean,
     ): Promise<void> {
         const refreshStartedAt = Date.now();
         const refreshRequestId = ++runtime.dataRefreshSeq;
@@ -519,7 +745,6 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 })),
             ]);
             const files = await this.iconTheme.decorateWorkingFiles(status).catch(() => status);
-            const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
             const hasSelected =
                 runtime.selectedStashIndex !== null &&
                 stashes.some((entry) => entry.index === runtime.selectedStashIndex);
@@ -552,29 +777,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 runtime.currentBranchBehindCache = currentBranchStatus.behind;
                 runtime.currentBranchNameCache = currentBranchStatus.name;
                 runtime.currentBranchUpstreamCache = currentBranchStatus.upstream;
-                const count = this.countChangedFiles(runtime);
-                if (runtime === this.getActiveRuntime()) {
-                    this._onDidChangeFileCount.fire(count);
-                    this.updateViewCount(count);
-                }
+                runtime.hasScannedFileCount = true;
+                this.updateAggregateChangedFileCount();
                 this.postToWebview({
                     type: "update",
-                    repositoryRoot: runtime.repository.root,
-                    files,
-                    stashes,
-                    stashFiles,
-                    selectedStashIndex,
-                    folderIcon: folderIcons.folderIcon,
-                    folderExpandedIcon: folderIcons.folderExpandedIcon,
-                    folderIconsByName: runtime.folderIconsByName,
-                    iconFonts,
-                    currentBranchHasUpstream: currentBranchStatus.hasUpstream,
-                    hasRemotes: currentBranchStatus.hasRemotes,
-                    currentBranchAhead: currentBranchStatus.ahead,
-                    currentBranchBehind: currentBranchStatus.behind,
-                    currentBranchName: currentBranchStatus.name,
-                    currentBranchUpstream: currentBranchStatus.upstream,
+                    ...this.snapshotForRuntime(runtime),
                 });
+                this.postRepositoryListHydration();
             }
         } finally {
             if (!silent) {
@@ -742,7 +951,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 this.postRepositoryListHydration();
                 if (runtime) {
                     this.postWorkingTreeSnapshot(runtime);
-                    await this.refreshData(true, runtime);
+                    await this.refreshAllRepositories(true);
                     await this.refreshGraphData(runtime);
                 }
                 this.postToWebview({
@@ -754,6 +963,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
             case "refresh":
                 await this.refreshFromUserAction(scopedRuntime());
+                break;
+            case "setExpandedRepositories":
+                await this.setExpandedRepositories(msg.repositoryRoots);
                 break;
             case "abortMerge":
                 await this.abortMerge(scopedRuntime());
@@ -1114,6 +1326,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * Releases theme listeners, icon resources, and event emitters owned by the Changes provider.
      */
     dispose(): void {
+        this.disposeAllRuntimeWatchers();
         this.iconTheme.dispose();
         this.disposeThemeChangeDisposables();
         this._onDidChangeFileCount.dispose();
@@ -1215,10 +1428,18 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             this.postToWebview({ type: "error", message });
         });
     }
+    /** Runs aggregate docked-row refreshes from listeners without leaking rejected promises. */
+    private refreshAllRepositoriesWithErrorHandling(silent = false): void {
+        this.refreshAllRepositories(silent).catch((err) => {
+            const message = getErrorMessage(err);
+            vscode.window.showErrorMessage(message);
+            this.postToWebview({ type: "error", message });
+        });
+    }
     private registerThemeChangeListeners(): void {
         this.themeChangeDisposables.push(
             ...registerThemeChangeListeners(() =>
-                this.refreshDataWithErrorHandling(false, this.getActiveRuntime()),
+                this.refreshAllRepositoriesWithErrorHandling(false),
             ),
         );
     }

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -262,6 +262,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         return this.getActiveRuntime();
     }
 
+    private validateKnownRepositoryRoot(msg: { [key: string]: unknown }): void {
+        if (msg.repositoryRoot === undefined) return;
+        const repositoryRoot = assertString(msg.repositoryRoot, "repositoryRoot");
+        if (!this.runtimes.has(repositoryRoot)) {
+            throw new Error("Unknown repository root received from webview.");
+        }
+    }
+
     private invalidateRuntime(runtime: CommitPanelRepositoryRuntime): void {
         runtime.requestSeq += 1;
         runtime.dataRefreshSeq += 1;
@@ -725,6 +733,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      */
     private async handleMessage(raw: unknown): Promise<void> {
         const msg = assertMessage(raw);
+        this.validateKnownRepositoryRoot(msg);
         const activeRuntime = () => this.requireActiveRuntime();
         const scopedRuntime = () => this.runtimeForMessage(msg);
         switch (msg.type) {

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -187,9 +187,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         const previousActiveRuntime =
             previousActiveRoot !== null ? this.runtimes.get(previousActiveRoot) : undefined;
         const nextRoots = new Set(repositories.map((repository) => repository.root));
+        let repositoryRemoved = false;
 
         for (const [root, runtime] of this.runtimes) {
             if (nextRoots.has(root)) continue;
+            repositoryRemoved = true;
             this.expandedRepositoryRoots.delete(root);
             this.disposeRuntimeWatcher(root);
             this.invalidateRuntime(runtime);
@@ -235,6 +237,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     message: this.getStoredCommitDraft(activeRuntime),
                 });
             }
+        }
+        if (repositoryRemoved && !activeChanged && !options.resetActiveState) {
+            this.updateAggregateChangedFileCount();
         }
         this.postRepositoryListHydration();
         this.syncRuntimeWatchers();

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -12,6 +12,8 @@ import { abortMergeWithConfirmation } from "./mergeAbort";
 import type { InboundMessage } from "../webviews/protocol/commitPanelMessages";
 import type { DiscoveredRepository } from "../services/repositoryDiscovery";
 import { CommitPanelRepositoryRuntime } from "./commitPanelRepositoryRuntime";
+import { runPublishBranchFlow } from "../services/publishService";
+import { showTimedWarningMessage } from "../utils/notifications";
 import type {
     BranchAction,
     CommitAction,
@@ -274,6 +276,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             postCommitted: () => this.postToWebview({ type: "committed" }),
             maybeOfferPublishBranch: () =>
                 runtime ? this.maybeOfferPublishBranch(runtime) : Promise.resolve(),
+            publishBranch: runtime ? () => this.publishBranch(runtime) : undefined,
         };
     }
 
@@ -919,7 +922,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 break;
             }
             case "publishBranch":
-                await publishBranchFromPanel(this.fileActionDepsForRuntime(scopedRuntime()));
+                {
+                    const runtime = scopedRuntime();
+                    if (runtime) {
+                        await this.publishBranch(runtime);
+                    } else {
+                        await publishBranchFromPanel(this.fileActionDepsForRuntime());
+                    }
+                }
                 break;
             case "showStashDiff":
                 await showStashDiffFromPanel(
@@ -1086,11 +1096,28 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 publishBranchAction,
             );
             if (publish === publishBranchAction) {
-                await vscode.commands.executeCommand("intelligit.publishBranch");
+                await this.publishBranch(runtime);
             }
         } catch {
             // Silently ignore — publish is optional, don't block the user
         }
+    }
+
+    private async publishBranch(runtime: CommitPanelRepositoryRuntime): Promise<void> {
+        const hasCommits = await runtime.gitOps.hasAnyCommits();
+        if (!hasCommits) {
+            showTimedWarningMessage(
+                vscode.l10n.t("Create a commit before publishing this branch."),
+            );
+            return;
+        }
+        const branches = await runtime.gitOps.getBranches();
+        const currentBranch = branches.find((branch) => branch.isCurrent && !branch.isRemote);
+        if (!currentBranch) {
+            vscode.window.showErrorMessage(vscode.l10n.t("No current branch found."));
+            return;
+        }
+        await runPublishBranchFlow(runtime.gitOps, currentBranch.name, runtime.repository.root);
     }
     /**
      * Reads current-branch upstream, ahead/behind, and remote availability for toolbar state.

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -635,15 +635,20 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             try {
                 await this.handleMessage(message);
             } catch (err) {
-                const message = getErrorMessage(err);
-                vscode.window.showErrorMessage(message);
-                this.postToWebview({ type: "error", message });
+                const errorMessage = getErrorMessage(err);
+                vscode.window.showErrorMessage(errorMessage);
+                this.postToWebview({
+                    type: "error",
+                    ...this.repositoryScopeForError(message),
+                    message: errorMessage,
+                });
             }
         });
         webviewView.webview.html = this.getHtml(webviewView.webview);
         webviewView.onDidChangeVisibility(() => {
             if (!webviewView.visible) return;
-            const runtime = this.requireActiveRuntime();
+            const runtime = this.getActiveRuntime();
+            if (!runtime) return;
             this.postWorkingTreeSnapshot(runtime);
             this.refreshAllRepositoriesWithErrorHandling(true);
         });
@@ -817,11 +822,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 if (remainingMs > 0) {
                     await new Promise<void>((resolve) => setTimeout(resolve, remainingMs));
                 }
-                this.postToWebview({
-                    type: "refreshing",
-                    repositoryRoot: runtime.repository.root,
-                    active: false,
-                });
+                if (refreshRequestId === runtime.dataRefreshSeq) {
+                    this.postToWebview({
+                        type: "refreshing",
+                        repositoryRoot: runtime.repository.root,
+                        active: false,
+                    });
+                }
                 this.visibleRefreshCount = Math.max(0, this.visibleRefreshCount - 1);
                 void Promise.resolve(
                     this.visibleRefreshCount === 0
@@ -960,6 +967,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         text: string,
     ): Promise<void> {
         runtime.filterText = text;
+        this.postToWebview({ type: "setFilterText", text });
         await this.loadInitialGraphCommits(runtime);
     }
     /**
@@ -1038,6 +1046,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     type: "setSelectedBranch",
                     branch: runtime.currentBranch,
                 });
+                this.postToWebview({ type: "setFilterText", text: "" });
                 await this.loadInitialGraphCommits(runtime);
                 break;
             }
@@ -1455,7 +1464,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.refreshData(silent, runtime).catch((err) => {
             const message = getErrorMessage(err);
             vscode.window.showErrorMessage(message);
-            this.postToWebview({ type: "error", message });
+            this.postToWebview({ type: "error", repositoryRoot: runtime.repository.root, message });
         });
     }
     /** Runs aggregate docked-row refreshes from listeners without leaking rejected promises. */
@@ -1475,5 +1484,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     }
     private disposeThemeChangeDisposables(): void {
         disposeAll(this.themeChangeDisposables);
+    }
+
+    /**
+     * Returns repository identity for trusted repository-scoped error payloads.
+     */
+    private repositoryScopeForError(raw: unknown): { repositoryRoot?: string } {
+        if (!raw || typeof raw !== "object") return {};
+        const repositoryRoot = (raw as { repositoryRoot?: unknown }).repositoryRoot;
+        if (typeof repositoryRoot !== "string") return {};
+        return this.runtimes.has(repositoryRoot) ? { repositoryRoot } : {};
     }
 }

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -74,6 +74,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private readonly expandedRepositoryRoots = new Set<string>();
     private readonly runtimeWatchers = new Map<string, vscode.Disposable>();
     private activeRepositoryRoot: string | null = null;
+    private visibleRefreshCount = 0;
     private themeChangeDisposables: vscode.Disposable[] = [];
     private readonly iconTheme: IconThemeService;
     private readonly PAGE_SIZE = 500;
@@ -427,10 +428,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             .catch(() => {});
     }
 
-    /** Keeps provider-owned file watchers aligned with the active repository plus expanded rows. */
+    /** Keeps provider-owned file watchers aligned with expanded non-active rows. */
     private syncRuntimeWatchers(): void {
-        const desiredRoots = new Set(this.expandedRepositoryRoots);
-        if (this.activeRepositoryRoot !== null) desiredRoots.add(this.activeRepositoryRoot);
+        const desiredRoots = new Set(
+            Array.from(this.expandedRepositoryRoots).filter(
+                (root) => root !== this.activeRepositoryRoot,
+            ),
+        );
 
         for (const root of Array.from(this.runtimeWatchers.keys())) {
             if (desiredRoots.has(root)) continue;
@@ -726,11 +730,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         }
         if (!silent) {
             void Promise.resolve(
-                vscode.commands.executeCommand(
-                    "setContext",
-                    "intelligit.commitPanel.refreshing",
-                    true,
-                ),
+                ++this.visibleRefreshCount === 1
+                    ? vscode.commands.executeCommand(
+                          "setContext",
+                          "intelligit.commitPanel.refreshing",
+                          true,
+                      )
+                    : undefined,
             ).catch(() => {});
         }
         try {
@@ -801,12 +807,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     repositoryRoot: runtime.repository.root,
                     active: false,
                 });
+                this.visibleRefreshCount = Math.max(0, this.visibleRefreshCount - 1);
                 void Promise.resolve(
-                    vscode.commands.executeCommand(
-                        "setContext",
-                        "intelligit.commitPanel.refreshing",
-                        false,
-                    ),
+                    this.visibleRefreshCount === 0
+                        ? vscode.commands.executeCommand(
+                              "setContext",
+                              "intelligit.commitPanel.refreshing",
+                              false,
+                          )
+                        : undefined,
                 ).catch(() => {});
             }
         }

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -1003,7 +1003,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             onConflictStateChanged: async () => {
                 if (runtime) {
                     await this.refreshData(false, runtime);
-                    await this.refreshGraphData(runtime);
+                    if (runtime === this.getActiveRuntime()) {
+                        await this.refreshGraphData(runtime);
+                    }
                 }
                 this._onDidChangeWorkingTree.fire();
                 await vscode.commands.executeCommand("intelligit.mergeConflictsRefresh");

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -842,6 +842,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.postToWebview({
             type: "setBranches",
             branches: this.branches,
+            repositoryLabel: runtime.repository.label,
             folderIcon: folderIcons.folderIcon,
             folderExpandedIcon: folderIcons.folderExpandedIcon,
             folderIconsByName: this.branchFolderIconsByName,

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -8,6 +8,7 @@ import { GitOps } from "../git/operations";
 import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
+import { mapWithConcurrency } from "../utils/concurrency";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { abortMergeWithConfirmation } from "./mergeAbort";
 import type {
@@ -55,6 +56,11 @@ import {
     unstageFilesFromPanel,
 } from "./panelFileActions";
 const MIN_VISIBLE_REFRESH_MS = 600;
+
+// Bound on concurrent collapsed-row count scans at activation. Each scan spawns one
+// `git status`; with many repositories, firing them all at once starved the active
+// repository's first render. ponytail: fixed cap, revisit only if a profiler asks.
+const COLLAPSED_COUNT_SCAN_CONCURRENCY = 6;
 
 /**
  * Hosts the sidebar Changes webview and its embedded commit graph protocol.
@@ -246,7 +252,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.syncRuntimeWatchers();
         this.scanInitialCollapsedCounts();
         if (activeChanged && previousActiveRoot !== null && activeRuntime) {
-            this.scanRepositoryFileCount(activeRuntime);
+            void this.scanRepositoryFileCount(activeRuntime);
         }
     }
 
@@ -395,24 +401,33 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
 
     /** Starts one-time status scans for collapsed rows whose count has not been hydrated yet. */
     private scanInitialCollapsedCounts(): void {
+        const pending: CommitPanelRepositoryRuntime[] = [];
         for (const runtime of this.runtimes.values()) {
             if (runtime.hasScannedFileCount) continue;
             if (runtime.repository.root === this.activeRepositoryRoot) continue;
             if (this.expandedRepositoryRoots.has(runtime.repository.root)) continue;
-            this.scanRepositoryFileCount(runtime);
+            pending.push(runtime);
         }
+        // Bounded so opening a workspace with many repositories does not launch one
+        // `git status` per repository simultaneously and stall the active row's render.
+        void mapWithConcurrency(pending, COLLAPSED_COUNT_SCAN_CONCURRENCY, (runtime) =>
+            this.scanRepositoryFileCount(runtime),
+        );
     }
 
     /**
      * Refreshes only the lightweight changed-file count for a collapsed or newly active row.
      *
-     * The scan is discarded if a full runtime refresh starts before the status result resolves.
+     * Uses a status-only Git call (no numstat) since the count needs paths and statuses
+     * only; full stats arrive later when the row is activated or expanded. The scan is
+     * discarded if a full runtime refresh starts before the status result resolves. The
+     * returned promise resolves when the scan settles so callers can bound concurrency.
      */
-    private scanRepositoryFileCount(runtime: CommitPanelRepositoryRuntime): void {
+    private scanRepositoryFileCount(runtime: CommitPanelRepositoryRuntime): Promise<void> {
         const dataSeq = runtime.dataRefreshSeq;
         const countRequestId = ++runtime.countRefreshSeq;
-        void runtime.gitOps
-            .getStatus({ includeIgnored: runtime.showIgnoredFiles })
+        return runtime.gitOps
+            .getStatus({ includeIgnored: runtime.showIgnoredFiles, withStats: false })
             .then((files) => {
                 if (
                     dataSeq !== runtime.dataRefreshSeq ||

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -4,12 +4,14 @@
 // Frontend is a React + Chakra UI app loaded from dist/webview-commitpanel.js.
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";
-import type { Branch, CommitDetail, ThemeFolderIconMap, WorkingFile, StashEntry } from "../types";
+import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { abortMergeWithConfirmation } from "./mergeAbort";
 import type { InboundMessage } from "../webviews/protocol/commitPanelMessages";
+import type { DiscoveredRepository } from "../services/repositoryDiscovery";
+import { CommitPanelRepositoryRuntime } from "./commitPanelRepositoryRuntime";
 import type {
     BranchAction,
     CommitAction,
@@ -59,28 +61,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = "intelligit.commitPanel";
     private static readonly COMMIT_DRAFT_KEY_PREFIX = "commitDraft:";
     private view?: vscode.WebviewView;
-    private files: WorkingFile[] = [];
-    private stashes: StashEntry[] = [];
-    private selectedStashIndex: number | null = null;
-    private stashFiles: WorkingFile[] = [];
-    private folderIconsByName: ThemeFolderIconMap = {};
     private lastFileCount = 0;
-    private showIgnoredFiles = false;
+    private repositories: DiscoveredRepository[] = [];
+    private readonly runtimes = new Map<string, CommitPanelRepositoryRuntime>();
+    private activeRepositoryRoot: string | null = null;
     private themeChangeDisposables: vscode.Disposable[] = [];
     private readonly iconTheme: IconThemeService;
-    // Embedded commit graph state
-    private currentBranch: string | null = null;
-    private currentBranchHasUpstreamCache = false;
-    private hasRemotesCache = false;
-    private currentBranchAheadCache = 0;
-    private currentBranchBehindCache = 0;
-    private currentBranchNameCache: string | null = null;
-    private currentBranchUpstreamCache: string | null = null;
-    private filterText = "";
-    private offset = 0;
-    private loadingMore = false;
-    private requestSeq = 0;
-    private dataRefreshSeq = 0;
     private readonly PAGE_SIZE = 500;
     private branches: Branch[] = [];
     private selectedCommitDetail: CommitDetail | null = null;
@@ -125,7 +111,25 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         private readonly workspaceState?: vscode.Memento,
     ) {
         this.iconTheme = new IconThemeService(this.extensionUri);
+        if (repoRootUri) {
+            this.setRepositoriesInternal(
+                [this.repositoryFromUri(repoRootUri)],
+                repoRootUri.fsPath,
+                this.gitOps,
+            );
+        }
     }
+
+    /**
+     * Replaces the repository set known to the commit panel while preserving unchanged runtimes.
+     *
+     * Roots are matched exactly against host-discovered absolute paths. Removed runtimes are
+     * invalidated so late async refreshes cannot post stale state after the repository list changes.
+     */
+    setRepositories(repositories: DiscoveredRepository[], activeRoot?: string): void {
+        this.setRepositoriesInternal(repositories, activeRoot);
+    }
+
     /**
      * Switches the panel to a new active repository and invalidates repository-scoped caches.
      *
@@ -134,34 +138,155 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * so the webview receives a fresh draft restore message after the root changes.
      */
     setRepositoryRootUri(repoRootUri: vscode.Uri): void {
-        this.repoRootUri = repoRootUri;
-        this.selectedStashIndex = null;
-        this.files = [];
-        this.stashes = [];
-        this.stashFiles = [];
-        this.currentBranch = null;
-        this.currentBranchHasUpstreamCache = false;
-        this.hasRemotesCache = false;
-        this.currentBranchAheadCache = 0;
-        this.currentBranchBehindCache = 0;
-        this.currentBranchNameCache = null;
-        this.currentBranchUpstreamCache = null;
-        this.filterText = "";
-        this.offset = 0;
-        this.loadingMore = false;
-        this.selectedCommitDetail = null;
-        this.commitDetailFolderIconsByName = {};
-        this.branchFolderIconsByName = {};
-        // Bump request sequences so in-flight async responses from the old repo are ignored.
-        this.requestSeq += 1;
-        this.dataRefreshSeq += 1;
-        this.commitDetailSeq += 1;
-        this.updateViewCount(0);
+        for (const runtime of this.runtimes.values()) {
+            this.invalidateRuntime(runtime);
+        }
+        this.runtimes.clear();
+        this.setRepositoriesInternal(
+            [this.repositoryFromUri(repoRootUri)],
+            repoRootUri.fsPath,
+            this.gitOps,
+            { resetActiveState: true },
+        );
+    }
+
+    private repositoryFromUri(repoRootUri: vscode.Uri): DiscoveredRepository {
+        const root = repoRootUri.fsPath;
+        const parts = root.split(/[\\/]/).filter(Boolean);
+        return {
+            root,
+            label: parts[parts.length - 1] ?? root,
+        };
+    }
+
+    private setRepositoriesInternal(
+        repositories: DiscoveredRepository[],
+        activeRoot?: string,
+        activeGitOps?: GitOps,
+        options: { resetActiveState?: boolean } = {},
+    ): void {
+        const previousActiveRoot = this.activeRepositoryRoot;
+        const previousActiveRuntime =
+            previousActiveRoot !== null ? this.runtimes.get(previousActiveRoot) : undefined;
+        const nextRoots = new Set(repositories.map((repository) => repository.root));
+
+        for (const [root, runtime] of this.runtimes) {
+            if (nextRoots.has(root)) continue;
+            this.invalidateRuntime(runtime);
+            this.runtimes.delete(root);
+        }
+
+        for (const repository of repositories) {
+            const existing = this.runtimes.get(repository.root);
+            if (existing) {
+                existing.repository = repository;
+                continue;
+            }
+            const gitOps = repository.root === activeRoot ? activeGitOps : undefined;
+            this.runtimes.set(
+                repository.root,
+                new CommitPanelRepositoryRuntime(repository, gitOps),
+            );
+        }
+
+        this.repositories = repositories;
+        const requestedActiveRoot =
+            activeRoot !== undefined && this.runtimes.has(activeRoot) ? activeRoot : null;
+        this.activeRepositoryRoot =
+            requestedActiveRoot ??
+            (this.activeRepositoryRoot !== null && this.runtimes.has(this.activeRepositoryRoot)
+                ? this.activeRepositoryRoot
+                : (repositories[0]?.root ?? null));
+        const activeChanged = previousActiveRoot !== this.activeRepositoryRoot;
+        if (activeChanged && previousActiveRuntime) this.invalidateRuntime(previousActiveRuntime);
+
+        const activeRuntime = this.getActiveRuntime();
+        this.repoRootUri = activeRuntime?.repoRootUri;
+        if (activeChanged || options.resetActiveState) {
+            this.selectedCommitDetail = null;
+            this.commitDetailFolderIconsByName = {};
+            this.branchFolderIconsByName = {};
+            this.commitDetailSeq += 1;
+            this.updateViewCount(activeRuntime ? this.countChangedFiles(activeRuntime) : 0);
+            if (activeRuntime) {
+                this.postToWebview({
+                    type: "restoreCommitDraft",
+                    message: this.getStoredCommitDraft(activeRuntime),
+                });
+            }
+        }
+        this.postRepositoryListHydration();
+    }
+
+    private postRepositoryListHydration(): void {
         this.postToWebview({
-            type: "restoreCommitDraft",
-            message: this.getStoredCommitDraft(),
+            type: "setRepositories",
+            repositories: this.repositories,
+            activeRepositoryRoot: this.activeRepositoryRoot,
         });
     }
+
+    private getActiveRuntime(): CommitPanelRepositoryRuntime | undefined {
+        return this.activeRepositoryRoot !== null
+            ? this.runtimes.get(this.activeRepositoryRoot)
+            : undefined;
+    }
+
+    private requireActiveRuntime(): CommitPanelRepositoryRuntime {
+        const runtime = this.getActiveRuntime();
+        if (!runtime) throw new Error("No active repository selected.");
+        return runtime;
+    }
+
+    private runtimeForMessage(msg: {
+        [key: string]: unknown;
+    }): CommitPanelRepositoryRuntime | undefined {
+        if (msg.repositoryRoot !== undefined) {
+            const repositoryRoot = assertString(msg.repositoryRoot, "repositoryRoot");
+            const runtime = this.runtimes.get(repositoryRoot);
+            if (!runtime) {
+                throw new Error("Unknown repository root received from webview.");
+            }
+            return runtime;
+        }
+        return this.getActiveRuntime();
+    }
+
+    private invalidateRuntime(runtime: CommitPanelRepositoryRuntime): void {
+        runtime.requestSeq += 1;
+        runtime.dataRefreshSeq += 1;
+    }
+
+    private countChangedFiles(runtime: CommitPanelRepositoryRuntime): number {
+        const uniquePaths = new Set<string>();
+        for (const file of runtime.files) {
+            if (file.status !== "!") uniquePaths.add(file.path);
+        }
+        return uniquePaths.size;
+    }
+
+    private actionDepsForRuntime(runtime?: CommitPanelRepositoryRuntime) {
+        return {
+            gitOps: runtime?.gitOps ?? this.gitOps,
+            refreshData: () => (runtime ? this.refreshData(false, runtime) : Promise.resolve()),
+            refreshGraphData: () => (runtime ? this.refreshGraphData(runtime) : Promise.resolve()),
+            fireWorkingTreeChanged: () => this._onDidChangeWorkingTree.fire(),
+            postCommitted: () => this.postToWebview({ type: "committed" }),
+            maybeOfferPublishBranch: () =>
+                runtime ? this.maybeOfferPublishBranch(runtime) : Promise.resolve(),
+        };
+    }
+
+    private fileActionDepsForRuntime(runtime?: CommitPanelRepositoryRuntime) {
+        return {
+            gitOps: runtime?.gitOps ?? this.gitOps,
+            getWorkspaceRoot: () => this.getWorkspaceRoot(runtime),
+            refreshData: (silent = false) =>
+                runtime ? this.refreshData(silent, runtime) : Promise.resolve(),
+            fireWorkingTreeChanged: () => this._onDidChangeWorkingTree.fire(),
+        };
+    }
+
     /** Handles repository label changes while keeping native view descriptions empty. */
     setRepositoryLabel(_label: string): void {
         this.updateViewCount(this.lastFileCount);
@@ -171,7 +296,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      */
     setBranches(branches: Branch[]): void {
         this.branches = branches;
-        this.sendGraphBranches().catch((err) => {
+        const runtime = this.getActiveRuntime();
+        if (!runtime) return;
+        this.sendGraphBranches(runtime).catch((err) => {
             const message = getErrorMessage(err);
             vscode.window.showErrorMessage(
                 vscode.l10n.t("Branch update error: {message}", { message }),
@@ -254,21 +381,24 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.html = this.getHtml(webviewView.webview);
         webviewView.onDidChangeVisibility(() => {
             if (!webviewView.visible) return;
-            this.postWorkingTreeSnapshot();
-            this.refreshDataWithErrorHandling(true);
+            const runtime = this.requireActiveRuntime();
+            this.postWorkingTreeSnapshot(runtime);
+            this.refreshDataWithErrorHandling(true, runtime);
         });
+        this.postRepositoryListHydration();
         this.updateViewCount(this.lastFileCount);
     }
     /**
      * Refreshes working-tree/stash data and then reloads embedded graph state.
      */
     async refresh(): Promise<void> {
-        await this.refreshData(false);
-        await this.refreshGraphData();
+        const runtime = this.requireActiveRuntime();
+        await this.refreshData(false, runtime);
+        await this.refreshGraphData(runtime);
     }
     /** Refreshes working-tree data without showing webview or context-key spinner state. */
     async refreshSilent(): Promise<void> {
-        await this.refreshData(true);
+        await this.refreshData(true, this.requireActiveRuntime());
     }
     /**
      * Runs a visible refresh for explicit user requests in the Changes view.
@@ -276,12 +406,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * The progress location is scoped to the view so refresh feedback appears where the user
      * initiated it instead of as a global notification.
      */
-    private async refreshFromUserAction(): Promise<void> {
+    private async refreshFromUserAction(runtime?: CommitPanelRepositoryRuntime): Promise<void> {
+        if (!runtime) return;
         await vscode.window.withProgress(
             { location: { viewId: CommitPanelViewProvider.viewType } },
             async () => {
-                await this.refreshData(false);
-                await this.refreshGraphData();
+                await this.refreshData(false, runtime);
+                await this.refreshGraphData(runtime);
             },
         );
     }
@@ -292,27 +423,24 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * immediately, before the follow-up silent refresh reconciles any changes that happened while
      * the webview was hidden or loading.
      */
-    private postWorkingTreeSnapshot(
-        currentBranchHasUpstream = this.currentBranchHasUpstreamCache,
-        hasRemotes = this.hasRemotesCache,
-    ): void {
+    private postWorkingTreeSnapshot(runtime: CommitPanelRepositoryRuntime): void {
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         this.postToWebview({
             type: "update",
-            files: this.files,
-            stashes: this.stashes,
-            selectedStashIndex: this.selectedStashIndex,
-            stashFiles: this.stashFiles,
+            files: runtime.files,
+            stashes: runtime.stashes,
+            selectedStashIndex: runtime.selectedStashIndex,
+            stashFiles: runtime.stashFiles,
             folderIcon: folderIcons.folderIcon,
             folderExpandedIcon: folderIcons.folderExpandedIcon,
-            folderIconsByName: this.folderIconsByName,
+            folderIconsByName: runtime.folderIconsByName,
             iconFonts,
-            currentBranchHasUpstream,
-            hasRemotes,
-            currentBranchAhead: this.currentBranchAheadCache,
-            currentBranchBehind: this.currentBranchBehindCache,
-            currentBranchName: this.currentBranchNameCache,
-            currentBranchUpstream: this.currentBranchUpstreamCache,
+            currentBranchHasUpstream: runtime.currentBranchHasUpstreamCache,
+            hasRemotes: runtime.hasRemotesCache,
+            currentBranchAhead: runtime.currentBranchAheadCache,
+            currentBranchBehind: runtime.currentBranchBehindCache,
+            currentBranchName: runtime.currentBranchNameCache,
+            currentBranchUpstream: runtime.currentBranchUpstreamCache,
         });
     }
 
@@ -323,9 +451,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * keep the spinner visible for a short minimum duration to avoid flicker. The selected stash is
      * preserved when it still exists, otherwise the first available stash becomes selected.
      */
-    private async refreshData(silent = false): Promise<void> {
+    private async refreshData(
+        silent = false,
+        runtime: CommitPanelRepositoryRuntime = this.requireActiveRuntime(),
+    ): Promise<void> {
         const refreshStartedAt = Date.now();
-        const refreshRequestId = ++this.dataRefreshSeq;
+        const refreshRequestId = ++runtime.dataRefreshSeq;
         if (!silent) this.postToWebview({ type: "refreshing", active: true });
         if (!silent) {
             void Promise.resolve(
@@ -337,60 +468,60 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             ).catch(() => {});
         }
         try {
-            const status = await this.gitOps.getStatus({ includeIgnored: this.showIgnoredFiles });
+            const status = await runtime.gitOps.getStatus({
+                includeIgnored: runtime.showIgnoredFiles,
+            });
             await this.iconTheme.initIconThemeData().catch(() => {});
             const [stashes, currentBranchStatus] = await Promise.all([
-                this.gitOps.listStashes().catch(() => this.stashes),
-                this.currentBranchStatus().catch(() => ({
-                    hasUpstream: this.currentBranchHasUpstreamCache,
-                    hasRemotes: this.hasRemotesCache,
-                    ahead: this.currentBranchAheadCache,
-                    behind: this.currentBranchBehindCache,
-                    name: this.currentBranchNameCache,
-                    upstream: this.currentBranchUpstreamCache,
+                runtime.gitOps.listStashes().catch(() => runtime.stashes),
+                this.currentBranchStatus(runtime).catch(() => ({
+                    hasUpstream: runtime.currentBranchHasUpstreamCache,
+                    hasRemotes: runtime.hasRemotesCache,
+                    ahead: runtime.currentBranchAheadCache,
+                    behind: runtime.currentBranchBehindCache,
+                    name: runtime.currentBranchNameCache,
+                    upstream: runtime.currentBranchUpstreamCache,
                 })),
             ]);
             const files = await this.iconTheme.decorateWorkingFiles(status).catch(() => status);
             const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
             const hasSelected =
-                this.selectedStashIndex !== null &&
-                stashes.some((entry) => entry.index === this.selectedStashIndex);
+                runtime.selectedStashIndex !== null &&
+                stashes.some((entry) => entry.index === runtime.selectedStashIndex);
             let selectedStashIndex: number | null;
             if (hasSelected) {
-                selectedStashIndex = this.selectedStashIndex;
+                selectedStashIndex = runtime.selectedStashIndex;
             } else {
                 selectedStashIndex = stashes.length > 0 ? stashes[0].index : null;
             }
-            const selectedStashIndexUnchanged = selectedStashIndex === this.selectedStashIndex;
+            const selectedStashIndexUnchanged = selectedStashIndex === runtime.selectedStashIndex;
             const stashFiles =
                 selectedStashIndex !== null
-                    ? await this.gitOps
+                    ? await runtime.gitOps
                           .getStashFiles(selectedStashIndex)
                           .then((files) => this.iconTheme.decorateWorkingFiles(files))
-                          .catch(() => (selectedStashIndexUnchanged ? this.stashFiles : []))
+                          .catch(() => (selectedStashIndexUnchanged ? runtime.stashFiles : []))
                     : [];
             const folderIconsByName = await this.iconTheme
                 .getFolderIconsByWorkingFiles([...files, ...stashFiles])
-                .catch(() => this.folderIconsByName);
-            if (refreshRequestId === this.dataRefreshSeq) {
-                this.folderIconsByName = folderIconsByName;
-                this.files = files;
-                this.stashes = stashes;
-                this.selectedStashIndex = selectedStashIndex;
-                this.stashFiles = stashFiles;
-                this.currentBranchHasUpstreamCache = currentBranchStatus.hasUpstream;
-                this.hasRemotesCache = currentBranchStatus.hasRemotes;
-                this.currentBranchAheadCache = currentBranchStatus.ahead;
-                this.currentBranchBehindCache = currentBranchStatus.behind;
-                this.currentBranchNameCache = currentBranchStatus.name;
-                this.currentBranchUpstreamCache = currentBranchStatus.upstream;
-                const uniquePaths = new Set<string>();
-                for (const file of files) {
-                    if (file.status !== "!") uniquePaths.add(file.path);
+                .catch(() => runtime.folderIconsByName);
+            if (refreshRequestId === runtime.dataRefreshSeq) {
+                runtime.folderIconsByName = folderIconsByName;
+                runtime.files = files;
+                runtime.stashes = stashes;
+                runtime.selectedStashIndex = selectedStashIndex;
+                runtime.stashFiles = stashFiles;
+                runtime.currentBranchHasUpstreamCache = currentBranchStatus.hasUpstream;
+                runtime.hasRemotesCache = currentBranchStatus.hasRemotes;
+                runtime.currentBranchAheadCache = currentBranchStatus.ahead;
+                runtime.currentBranchBehindCache = currentBranchStatus.behind;
+                runtime.currentBranchNameCache = currentBranchStatus.name;
+                runtime.currentBranchUpstreamCache = currentBranchStatus.upstream;
+                const count = this.countChangedFiles(runtime);
+                if (runtime === this.getActiveRuntime()) {
+                    this._onDidChangeFileCount.fire(count);
+                    this.updateViewCount(count);
                 }
-                const count = uniquePaths.size;
-                this._onDidChangeFileCount.fire(count);
-                this.updateViewCount(count);
                 this.postToWebview({
                     type: "update",
                     files,
@@ -399,7 +530,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                     selectedStashIndex,
                     folderIcon: folderIcons.folderIcon,
                     folderExpandedIcon: folderIcons.folderExpandedIcon,
-                    folderIconsByName: this.folderIconsByName,
+                    folderIconsByName: runtime.folderIconsByName,
                     iconFonts,
                     currentBranchHasUpstream: currentBranchStatus.hasUpstream,
                     hasRemotes: currentBranchStatus.hasRemotes,
@@ -429,18 +560,20 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     /**
      * Refreshes embedded graph theme data, branch metadata, first-page commits, and detail state.
      */
-    private async refreshGraphData(): Promise<void> {
+    private async refreshGraphData(
+        runtime: CommitPanelRepositoryRuntime = this.requireActiveRuntime(),
+    ): Promise<void> {
         // Embedded graph refresh relies on current theme data before branch/log decoration.
         // react-doctor-disable-next-line react-doctor/async-parallel
         await this.iconTheme.initIconThemeData();
-        await this.sendGraphBranches();
-        await this.loadInitialGraphCommits();
+        await this.sendGraphBranches(runtime);
+        await this.loadInitialGraphCommits(runtime);
         this.postGraphCommitDetailState();
     }
     /**
      * Sends embedded graph branch data with folder icons derived from branch path segments.
      */
-    private async sendGraphBranches(): Promise<void> {
+    private async sendGraphBranches(runtime: CommitPanelRepositoryRuntime): Promise<void> {
         this.branchFolderIconsByName = await this.iconTheme.getFolderIconsByBranches(this.branches);
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         this.postToWebview({
@@ -450,12 +583,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             folderExpandedIcon: folderIcons.folderExpandedIcon,
             folderIconsByName: this.branchFolderIconsByName,
             iconFonts,
-            currentBranchHasUpstream: this.currentBranchHasUpstreamCache,
-            hasRemotes: this.hasRemotesCache,
-            currentBranchAhead: this.currentBranchAheadCache,
-            currentBranchBehind: this.currentBranchBehindCache,
-            currentBranchName: this.currentBranchNameCache,
-            currentBranchUpstream: this.currentBranchUpstreamCache,
+            currentBranchHasUpstream: runtime.currentBranchHasUpstreamCache,
+            hasRemotes: runtime.hasRemotesCache,
+            currentBranchAhead: runtime.currentBranchAheadCache,
+            currentBranchBehind: runtime.currentBranchBehindCache,
+            currentBranchName: runtime.currentBranchNameCache,
+            currentBranchUpstream: runtime.currentBranchUpstreamCache,
         });
     }
     /**
@@ -464,26 +597,26 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * If the active branch filter disappears from the cached branch list, the selection is cleared
      * before loading so the webview and Git query stay in sync.
      */
-    private async loadInitialGraphCommits(): Promise<void> {
-        const requestId = ++this.requestSeq;
-        this.offset = 0;
-        this.loadingMore = false;
-        if (this.currentBranch && !this.branches.some((b) => b.name === this.currentBranch)) {
-            this.currentBranch = null;
+    private async loadInitialGraphCommits(runtime: CommitPanelRepositoryRuntime): Promise<void> {
+        const requestId = ++runtime.requestSeq;
+        runtime.offset = 0;
+        runtime.loadingMore = false;
+        if (runtime.currentBranch && !this.branches.some((b) => b.name === runtime.currentBranch)) {
+            runtime.currentBranch = null;
             this.postToWebview({ type: "setSelectedBranch", branch: null });
         }
         try {
             const [commits, unpushedHashes] = await Promise.all([
-                this.gitOps.getLog(
+                runtime.gitOps.getLog(
                     this.PAGE_SIZE,
-                    this.currentBranch ?? undefined,
-                    this.filterText || undefined,
+                    runtime.currentBranch ?? undefined,
+                    runtime.filterText || undefined,
                     0,
                 ),
-                this.gitOps.getUnpushedCommitHashes(),
+                runtime.gitOps.getUnpushedCommitHashes(),
             ]);
-            if (requestId === this.requestSeq) {
-                this.offset = commits.length;
+            if (requestId === runtime.requestSeq) {
+                runtime.offset = commits.length;
                 this.postToWebview({
                     type: "loadCommits",
                     commits,
@@ -493,7 +626,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 });
             }
         } catch (err) {
-            if (requestId === this.requestSeq) {
+            if (requestId === runtime.requestSeq) {
                 const message = getErrorMessage(err);
                 vscode.window.showErrorMessage(
                     vscode.l10n.t("Git log error: {message}", { message }),
@@ -505,22 +638,22 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     /**
      * Appends embedded graph commits while coalescing duplicate pagination requests.
      */
-    private async loadMoreGraphCommits(): Promise<void> {
-        if (this.loadingMore) return;
-        this.loadingMore = true;
-        const requestId = ++this.requestSeq;
+    private async loadMoreGraphCommits(runtime: CommitPanelRepositoryRuntime): Promise<void> {
+        if (runtime.loadingMore) return;
+        runtime.loadingMore = true;
+        const requestId = ++runtime.requestSeq;
         try {
             const [commits, unpushedHashes] = await Promise.all([
-                this.gitOps.getLog(
+                runtime.gitOps.getLog(
                     this.PAGE_SIZE,
-                    this.currentBranch ?? undefined,
-                    this.filterText || undefined,
-                    this.offset,
+                    runtime.currentBranch ?? undefined,
+                    runtime.filterText || undefined,
+                    runtime.offset,
                 ),
-                this.gitOps.getUnpushedCommitHashes(),
+                runtime.gitOps.getUnpushedCommitHashes(),
             ]);
-            if (requestId === this.requestSeq) {
-                this.offset += commits.length;
+            if (requestId === runtime.requestSeq) {
+                runtime.offset += commits.length;
                 this.postToWebview({
                     type: "loadCommits",
                     commits,
@@ -530,7 +663,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 });
             }
         } catch (err) {
-            if (requestId === this.requestSeq) {
+            if (requestId === runtime.requestSeq) {
                 const message = getErrorMessage(err);
                 vscode.window.showErrorMessage(
                     vscode.l10n.t("Git log error: {message}", { message }),
@@ -538,14 +671,17 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 this.postToWebview({ type: "loadError", message });
             }
         } finally {
-            if (requestId === this.requestSeq) {
-                this.loadingMore = false;
+            if (requestId === runtime.requestSeq) {
+                runtime.loadingMore = false;
             }
         }
     }
-    private async filterGraphByText(text: string): Promise<void> {
-        this.filterText = text;
-        await this.loadInitialGraphCommits();
+    private async filterGraphByText(
+        runtime: CommitPanelRepositoryRuntime,
+        text: string,
+    ): Promise<void> {
+        runtime.filterText = text;
+        await this.loadInitialGraphCommits(runtime);
     }
     /**
      * Validates and dispatches every message accepted by the Changes webview.
@@ -557,71 +693,70 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      */
     private async handleMessage(raw: unknown): Promise<void> {
         const msg = assertMessage(raw);
-        const actionDeps = {
-            gitOps: this.gitOps,
-            refreshData: () => this.refreshData(),
-            refreshGraphData: () => this.refreshGraphData(),
-            fireWorkingTreeChanged: () => this._onDidChangeWorkingTree.fire(),
-            postCommitted: () => this.postToWebview({ type: "committed" }),
-            maybeOfferPublishBranch: () => this.maybeOfferPublishBranch(),
-        };
-        const fileActionDeps = {
-            gitOps: this.gitOps,
-            getWorkspaceRoot: () => this.getWorkspaceRoot(),
-            refreshData: (silent = false) => this.refreshData(silent),
-            fireWorkingTreeChanged: () => this._onDidChangeWorkingTree.fire(),
-        };
+        const activeRuntime = () => this.requireActiveRuntime();
+        const scopedRuntime = () => this.runtimeForMessage(msg);
         switch (msg.type) {
-            case "ready":
-                this.postWorkingTreeSnapshot();
-                await this.refreshSilent();
-                await this.refreshGraphData();
+            case "ready": {
+                const runtime = this.getActiveRuntime();
+                this.postRepositoryListHydration();
+                if (runtime) {
+                    this.postWorkingTreeSnapshot(runtime);
+                    await this.refreshData(true, runtime);
+                    await this.refreshGraphData(runtime);
+                }
                 this.postToWebview({
                     type: "restoreCommitDraft",
-                    message: this.getStoredCommitDraft(),
+                    message: this.getStoredCommitDraft(runtime),
                 });
                 break;
+            }
             case "refresh":
-                await this.refreshFromUserAction();
+                await this.refreshFromUserAction(scopedRuntime());
                 break;
             case "abortMerge":
-                await this.abortMerge();
+                await this.abortMerge(scopedRuntime());
                 break;
-            case "setShowIgnoredFiles":
-                this.showIgnoredFiles = msg.showIgnoredFiles === true;
-                await this.refreshData(true);
+            case "setShowIgnoredFiles": {
+                const runtime = scopedRuntime();
+                if (runtime) {
+                    runtime.showIgnoredFiles = msg.showIgnoredFiles === true;
+                    await this.refreshData(true, runtime);
+                }
                 break;
+            }
             case "fetch":
-                await runGitOperationFromPanel(actionDeps, "fetch");
+                await runGitOperationFromPanel(this.actionDepsForRuntime(scopedRuntime()), "fetch");
                 break;
             case "pull":
-                await runGitOperationFromPanel(actionDeps, "pull");
+                await runGitOperationFromPanel(this.actionDepsForRuntime(scopedRuntime()), "pull");
                 break;
             case "push":
-                await runGitOperationFromPanel(actionDeps, "push");
+                await runGitOperationFromPanel(this.actionDepsForRuntime(scopedRuntime()), "push");
                 break;
             case "sync":
-                await runGitOperationFromPanel(actionDeps, "sync");
+                await runGitOperationFromPanel(this.actionDepsForRuntime(scopedRuntime()), "sync");
                 break;
             case "selectCommit":
                 this._onCommitSelected.fire(assertGitHash(msg.hash, "hash"));
                 break;
             case "loadMore":
-                await this.loadMoreGraphCommits();
+                await this.loadMoreGraphCommits(activeRuntime());
                 break;
             case "filterText":
-                await this.filterGraphByText(assertString(msg.text, "text"));
+                await this.filterGraphByText(activeRuntime(), assertString(msg.text, "text"));
                 break;
-            case "filterBranch":
-                this.currentBranch = assertNullableString(msg.branch, "branch");
-                this.filterText = "";
-                this._onBranchFilterChanged.fire(this.currentBranch);
+            case "filterBranch": {
+                const runtime = activeRuntime();
+                runtime.currentBranch = assertNullableString(msg.branch, "branch");
+                runtime.filterText = "";
+                this._onBranchFilterChanged.fire(runtime.currentBranch);
                 this.postToWebview({
                     type: "setSelectedBranch",
-                    branch: this.currentBranch,
+                    branch: runtime.currentBranch,
                 });
-                await this.loadInitialGraphCommits();
+                await this.loadInitialGraphCommits(runtime);
                 break;
+            }
             case "branchAction": {
                 const branchAction = assertString(msg.action, "action");
                 if (!isBranchAction(branchAction)) {
@@ -651,23 +786,34 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 });
                 break;
             case "saveCommitDraft": {
+                const runtime = scopedRuntime();
                 const message = assertString(msg.message, "message");
                 await this.workspaceState?.update(
-                    this.getCommitDraftStorageKey(),
+                    this.getCommitDraftStorageKey(runtime),
                     message || undefined,
                 );
                 break;
             }
             case "stageFiles":
-                await stageFilesFromPanel(fileActionDeps, msg.paths);
+                await stageFilesFromPanel(
+                    this.fileActionDepsForRuntime(scopedRuntime()),
+                    msg.paths,
+                );
                 break;
             case "unstageFiles":
-                await unstageFilesFromPanel(fileActionDeps, msg.paths);
+                await unstageFilesFromPanel(
+                    this.fileActionDepsForRuntime(scopedRuntime()),
+                    msg.paths,
+                );
                 break;
             case "trackUnversionedFiles":
-                await trackUnversionedFilesFromPanel(fileActionDeps, msg.paths);
+                await trackUnversionedFilesFromPanel(
+                    this.fileActionDepsForRuntime(scopedRuntime()),
+                    msg.paths,
+                );
                 break;
             case "commitSelected": {
+                const actionDeps = this.actionDepsForRuntime(scopedRuntime());
                 const message = (typeof msg.message === "string" ? msg.message : "").trim();
                 await commitSelectedFromPanel(actionDeps, {
                     message,
@@ -679,33 +825,48 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
             case "commit": {
                 const message = (typeof msg.message === "string" ? msg.message : "").trim();
-                await commitOnlyFromPanel(actionDeps, message, msg.amend === true);
+                await commitOnlyFromPanel(
+                    this.actionDepsForRuntime(scopedRuntime()),
+                    message,
+                    msg.amend === true,
+                );
                 break;
             }
             case "commitAndPush": {
                 const message = (typeof msg.message === "string" ? msg.message : "").trim();
-                await commitAndPushFromPanel(actionDeps, message, msg.amend === true);
+                await commitAndPushFromPanel(
+                    this.actionDepsForRuntime(scopedRuntime()),
+                    message,
+                    msg.amend === true,
+                );
                 break;
             }
             case "getLastCommitMessage": {
-                const lastMsg = await this.gitOps.getLastCommitMessage();
+                const lastMsg = await (
+                    scopedRuntime()?.gitOps ?? this.gitOps
+                ).getLastCommitMessage();
                 this.postToWebview({ type: "lastCommitMessage", message: lastMsg });
                 break;
             }
             case "getAmendBranchCommits": {
-                const commits = await this.gitOps.getAmendBranchCommits();
+                const commits = await (
+                    scopedRuntime()?.gitOps ?? this.gitOps
+                ).getAmendBranchCommits();
                 this.postToWebview({ type: "amendBranchCommits", commits });
                 break;
             }
             case "rollback": {
-                await rollbackFromPanel(actionDeps, assertRepoPathArray(msg.paths, "paths"));
+                await rollbackFromPanel(
+                    this.actionDepsForRuntime(scopedRuntime()),
+                    assertRepoPathArray(msg.paths, "paths"),
+                );
                 break;
             }
             case "showDiff":
-                await showDiffFromPanel(fileActionDeps, msg.path);
+                await showDiffFromPanel(this.fileActionDepsForRuntime(scopedRuntime()), msg.path);
                 break;
             case "stashSave": {
-                await stashSaveFromPanel(actionDeps, {
+                await stashSaveFromPanel(this.actionDepsForRuntime(scopedRuntime()), {
                     name: typeof msg.name === "string" ? msg.name : "Stashed changes",
                     paths:
                         msg.paths !== undefined
@@ -715,59 +876,76 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 break;
             }
             case "stashPop":
-                await stashMutationFromPanel(actionDeps, "pop", assertNumber(msg.index, "index"));
+                await stashMutationFromPanel(
+                    this.actionDepsForRuntime(scopedRuntime()),
+                    "pop",
+                    assertNumber(msg.index, "index"),
+                );
                 break;
             case "stashApply":
-                await stashMutationFromPanel(actionDeps, "apply", assertNumber(msg.index, "index"));
+                await stashMutationFromPanel(
+                    this.actionDepsForRuntime(scopedRuntime()),
+                    "apply",
+                    assertNumber(msg.index, "index"),
+                );
                 break;
             case "stashDelete":
                 await stashMutationFromPanel(
-                    actionDeps,
+                    this.actionDepsForRuntime(scopedRuntime()),
                     "delete",
                     assertNumber(msg.index, "index"),
                 );
                 break;
-            case "stashSelect":
+            case "stashSelect": {
+                const runtime = scopedRuntime();
+                if (!runtime) throw new Error("No active repository selected.");
                 await selectStashFromPanel(
                     {
-                        ...fileActionDeps,
+                        ...this.fileActionDepsForRuntime(runtime),
                         iconTheme: this.iconTheme,
-                        getFiles: () => this.files,
-                        getStashes: () => this.stashes,
+                        getFiles: () => runtime.files,
+                        getStashes: () => runtime.stashes,
                         currentBranchHasUpstream: async () =>
-                            (await this.currentBranchStatus()).hasUpstream,
+                            (await this.currentBranchStatus(runtime)).hasUpstream,
                         setStashState: (state) => {
-                            this.selectedStashIndex = state.selectedStashIndex;
-                            this.stashFiles = state.stashFiles;
-                            this.folderIconsByName = state.folderIconsByName;
+                            runtime.selectedStashIndex = state.selectedStashIndex;
+                            runtime.stashFiles = state.stashFiles;
+                            runtime.folderIconsByName = state.folderIconsByName;
                         },
                         postUpdate: (message) => this.postToWebview(message),
                     },
                     msg.index,
                 );
                 break;
+            }
             case "publishBranch":
-                await publishBranchFromPanel(fileActionDeps);
+                await publishBranchFromPanel(this.fileActionDepsForRuntime(scopedRuntime()));
                 break;
             case "showStashDiff":
-                await showStashDiffFromPanel(fileActionDeps, msg.index, msg.path);
+                await showStashDiffFromPanel(
+                    this.fileActionDepsForRuntime(scopedRuntime()),
+                    msg.index,
+                    msg.path,
+                );
                 break;
             case "openFile":
-                await openFileFromPanel(fileActionDeps, msg.path);
+                await openFileFromPanel(this.fileActionDepsForRuntime(scopedRuntime()), msg.path);
                 break;
             case "deleteFile":
-                await deleteFileFromPanel(fileActionDeps, msg.path);
+                await deleteFileFromPanel(this.fileActionDepsForRuntime(scopedRuntime()), msg.path);
                 break;
         }
     }
 
     /** Confirms and aborts an active merge, then refreshes all conflict and working-tree surfaces. */
-    private async abortMerge(): Promise<void> {
+    private async abortMerge(runtime?: CommitPanelRepositoryRuntime): Promise<void> {
         await abortMergeWithConfirmation({
-            gitOps: this.gitOps,
+            gitOps: runtime?.gitOps ?? this.gitOps,
             onConflictStateChanged: async () => {
-                await this.refreshData(false);
-                await this.refreshGraphData();
+                if (runtime) {
+                    await this.refreshData(false, runtime);
+                    await this.refreshGraphData(runtime);
+                }
                 this._onDidChangeWorkingTree.fire();
                 await vscode.commands.executeCommand("intelligit.mergeConflictsRefresh");
             },
@@ -829,7 +1007,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      *
      * @throws When no active repository or workspace folder can back a file action.
      */
-    private getWorkspaceRoot(): vscode.Uri {
+    private getWorkspaceRoot(runtime?: CommitPanelRepositoryRuntime): vscode.Uri {
+        if (runtime) return runtime.repoRootUri;
         if (this.repoRootUri) return this.repoRootUri;
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
         if (!workspaceRoot) {
@@ -854,9 +1033,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      *
      * @throws When no repository or workspace folder is available to scope the persisted draft.
      */
-    private getCommitDraftStorageKey(): string {
+    private getCommitDraftStorageKey(runtime?: CommitPanelRepositoryRuntime): string {
         const storageRoot =
-            this.repoRootUri?.fsPath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+            runtime?.repository.root ??
+            this.repoRootUri?.fsPath ??
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (!storageRoot) {
             throw new Error("No workspace folder is open.");
         }
@@ -865,8 +1046,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     /**
      * Reads the persisted commit draft for the active repository, defaulting to an empty input.
      */
-    private getStoredCommitDraft(): string {
-        return this.workspaceState?.get<string>(this.getCommitDraftStorageKey()) ?? "";
+    private getStoredCommitDraft(runtime?: CommitPanelRepositoryRuntime): string {
+        return this.workspaceState?.get<string>(this.getCommitDraftStorageKey(runtime)) ?? "";
     }
     /**
      * Releases theme listeners, icon resources, and event emitters owned by the Changes provider.
@@ -888,11 +1069,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * The prompt is best-effort and intentionally swallowed on failure so commit completion is not
      * blocked by optional upstream detection or command-palette wiring.
      */
-    private async maybeOfferPublishBranch(): Promise<void> {
+    private async maybeOfferPublishBranch(runtime: CommitPanelRepositoryRuntime): Promise<void> {
         try {
-            const hasCommits = await this.gitOps.hasAnyCommits();
+            const hasCommits = await runtime.gitOps.hasAnyCommits();
             if (!hasCommits) return;
-            const branches = await this.gitOps.getBranches();
+            const branches = await runtime.gitOps.getBranches();
             const currentBranch = branches.find((b) => b.isCurrent);
             if (!currentBranch) return;
             // Already published — nothing to do
@@ -914,7 +1095,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     /**
      * Reads current-branch upstream, ahead/behind, and remote availability for toolbar state.
      */
-    private async currentBranchStatus(): Promise<{
+    private async currentBranchStatus(runtime: CommitPanelRepositoryRuntime): Promise<{
         hasUpstream: boolean;
         hasRemotes: boolean;
         ahead: number;
@@ -923,8 +1104,8 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         upstream: string | null;
     }> {
         const [branches, remotes] = await Promise.all([
-            this.gitOps.getBranches(),
-            this.gitOps.getRemotes(),
+            runtime.gitOps.getBranches(),
+            runtime.gitOps.getRemotes(),
         ]);
         const currentBranch = branches.find((branch) => branch.isCurrent && !branch.isRemote);
         const upstream = currentBranch?.upstream?.trim() || null;
@@ -940,8 +1121,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     /**
      * Runs a panel data refresh from listeners without leaking rejected promises into VS Code.
      */
-    private refreshDataWithErrorHandling(silent = false): void {
-        this.refreshData(silent).catch((err) => {
+    private refreshDataWithErrorHandling(
+        silent = false,
+        runtime: CommitPanelRepositoryRuntime | undefined = this.getActiveRuntime(),
+    ): void {
+        if (!runtime) return;
+        this.refreshData(silent, runtime).catch((err) => {
             const message = getErrorMessage(err);
             vscode.window.showErrorMessage(message);
             this.postToWebview({ type: "error", message });
@@ -949,7 +1134,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     }
     private registerThemeChangeListeners(): void {
         this.themeChangeDisposables.push(
-            ...registerThemeChangeListeners(() => this.refreshDataWithErrorHandling()),
+            ...registerThemeChangeListeners(() =>
+                this.refreshDataWithErrorHandling(false, this.getActiveRuntime()),
+            ),
         );
     }
     private disposeThemeChangeDisposables(): void {

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -104,13 +104,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      *
      * `repoRootUri` scopes file actions and draft persistence when known at construction time;
      * activation may inject it later, so helpers retain a workspace-root fallback for early view
-     * restoration.
+     * restoration. `secrets` is forwarded to publish flows that need secure token storage.
      */
     constructor(
         private readonly extensionUri: vscode.Uri,
         private readonly gitOps: GitOps,
         private repoRootUri?: vscode.Uri,
         private readonly workspaceState?: vscode.Memento,
+        private readonly secrets?: vscode.SecretStorage,
     ) {
         this.iconTheme = new IconThemeService(this.extensionUri);
         if (repoRootUri) {
@@ -140,6 +141,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * so the webview receives a fresh draft restore message after the root changes.
      */
     setRepositoryRootUri(repoRootUri: vscode.Uri): void {
+        if (this.repositories.some((repository) => repository.root === repoRootUri.fsPath)) {
+            this.setRepositoriesInternal(this.repositories, repoRootUri.fsPath, undefined, {
+                resetActiveState: true,
+            });
+            return;
+        }
         for (const runtime of this.runtimes.values()) {
             this.invalidateRuntime(runtime);
         }
@@ -213,6 +220,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             if (activeRuntime) {
                 this.postToWebview({
                     type: "restoreCommitDraft",
+                    repositoryRoot: activeRuntime.repository.root,
                     message: this.getStoredCommitDraft(activeRuntime),
                 });
             }
@@ -271,9 +279,16 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         return {
             gitOps: runtime?.gitOps ?? this.gitOps,
             refreshData: () => (runtime ? this.refreshData(false, runtime) : Promise.resolve()),
-            refreshGraphData: () => (runtime ? this.refreshGraphData(runtime) : Promise.resolve()),
+            refreshGraphData: () =>
+                runtime && runtime === this.getActiveRuntime()
+                    ? this.refreshGraphData(runtime)
+                    : Promise.resolve(),
             fireWorkingTreeChanged: () => this._onDidChangeWorkingTree.fire(),
-            postCommitted: () => this.postToWebview({ type: "committed" }),
+            postCommitted: () =>
+                this.postToWebview({
+                    type: "committed",
+                    ...(runtime ? { repositoryRoot: runtime.repository.root } : {}),
+                }),
             maybeOfferPublishBranch: () =>
                 runtime ? this.maybeOfferPublishBranch(runtime) : Promise.resolve(),
             publishBranch: runtime ? () => this.publishBranch(runtime) : undefined,
@@ -415,7 +430,9 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             { location: { viewId: CommitPanelViewProvider.viewType } },
             async () => {
                 await this.refreshData(false, runtime);
-                await this.refreshGraphData(runtime);
+                if (runtime === this.getActiveRuntime()) {
+                    await this.refreshGraphData(runtime);
+                }
             },
         );
     }
@@ -430,6 +447,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         this.postToWebview({
             type: "update",
+            repositoryRoot: runtime.repository.root,
             files: runtime.files,
             stashes: runtime.stashes,
             selectedStashIndex: runtime.selectedStashIndex,
@@ -460,7 +478,13 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     ): Promise<void> {
         const refreshStartedAt = Date.now();
         const refreshRequestId = ++runtime.dataRefreshSeq;
-        if (!silent) this.postToWebview({ type: "refreshing", active: true });
+        if (!silent) {
+            this.postToWebview({
+                type: "refreshing",
+                repositoryRoot: runtime.repository.root,
+                active: true,
+            });
+        }
         if (!silent) {
             void Promise.resolve(
                 vscode.commands.executeCommand(
@@ -527,6 +551,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 }
                 this.postToWebview({
                     type: "update",
+                    repositoryRoot: runtime.repository.root,
                     files,
                     stashes,
                     stashFiles,
@@ -549,7 +574,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 if (remainingMs > 0) {
                     await new Promise<void>((resolve) => setTimeout(resolve, remainingMs));
                 }
-                this.postToWebview({ type: "refreshing", active: false });
+                this.postToWebview({
+                    type: "refreshing",
+                    repositoryRoot: runtime.repository.root,
+                    active: false,
+                });
                 void Promise.resolve(
                     vscode.commands.executeCommand(
                         "setContext",
@@ -709,6 +738,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 }
                 this.postToWebview({
                     type: "restoreCommitDraft",
+                    ...(runtime ? { repositoryRoot: runtime.repository.root } : {}),
                     message: this.getStoredCommitDraft(runtime),
                 });
                 break;
@@ -845,17 +875,23 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                 break;
             }
             case "getLastCommitMessage": {
-                const lastMsg = await (
-                    scopedRuntime()?.gitOps ?? this.gitOps
-                ).getLastCommitMessage();
-                this.postToWebview({ type: "lastCommitMessage", message: lastMsg });
+                const runtime = scopedRuntime();
+                const lastMsg = await (runtime?.gitOps ?? this.gitOps).getLastCommitMessage();
+                this.postToWebview({
+                    type: "lastCommitMessage",
+                    ...(runtime ? { repositoryRoot: runtime.repository.root } : {}),
+                    message: lastMsg,
+                });
                 break;
             }
             case "getAmendBranchCommits": {
-                const commits = await (
-                    scopedRuntime()?.gitOps ?? this.gitOps
-                ).getAmendBranchCommits();
-                this.postToWebview({ type: "amendBranchCommits", commits });
+                const runtime = scopedRuntime();
+                const commits = await (runtime?.gitOps ?? this.gitOps).getAmendBranchCommits();
+                this.postToWebview({
+                    type: "amendBranchCommits",
+                    ...(runtime ? { repositoryRoot: runtime.repository.root } : {}),
+                    commits,
+                });
                 break;
             }
             case "rollback": {
@@ -915,7 +951,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
                             runtime.stashFiles = state.stashFiles;
                             runtime.folderIconsByName = state.folderIconsByName;
                         },
-                        postUpdate: (message) => this.postToWebview(message),
+                        postUpdate: (message) =>
+                            this.postToWebview({
+                                ...message,
+                                repositoryRoot: runtime.repository.root,
+                            }),
                     },
                     msg.index,
                 );
@@ -1117,7 +1157,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             vscode.window.showErrorMessage(vscode.l10n.t("No current branch found."));
             return;
         }
-        await runPublishBranchFlow(runtime.gitOps, currentBranch.name, runtime.repository.root);
+        await runPublishBranchFlow(
+            runtime.gitOps,
+            currentBranch.name,
+            runtime.repository.root,
+            this.secrets,
+        );
     }
     /**
      * Reads current-branch upstream, ahead/behind, and remote availability for toolbar state.

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -151,6 +151,7 @@ export class UndockedViewProvider {
     private offset = 0;
     private loadingMore = false;
     private requestSeq = 0;
+    private repositorySwitchSeq = 0;
     private readonly PAGE_SIZE = 500;
     private branches: Branch[] = [];
     private worktrees: GitWorktree[] = [];
@@ -287,7 +288,17 @@ export class UndockedViewProvider {
             this.repositories[0];
         if (selected) {
             const changed = selected.root !== this.selectedRepositoryRoot;
+            const shouldContinue = changed ? this.beginRepositorySwitch() : undefined;
             this.applyRepositoryRoot(selected, { reset: changed, updateExecutor: changed });
+            if (shouldContinue) {
+                this.sendRepositories();
+                void this.reloadSelectedRepository(shouldContinue).catch((err) => {
+                    const message = getErrorMessage(err);
+                    vscode.window.showErrorMessage(message);
+                    this.postToWebview({ type: "error", message });
+                });
+                return;
+            }
         }
         this.sendRepositories();
     }
@@ -317,14 +328,35 @@ export class UndockedViewProvider {
         if (!repository) {
             throw new Error("Unknown repository root received from webview.");
         }
+        const shouldContinue = this.beginRepositorySwitch();
         this.applyRepositoryRoot(repository, { reset: true, updateExecutor: true });
         await this.onSelectedRepositoryRootChanged?.(repository.root);
+        if (!shouldContinue()) return;
         this.sendRepositories();
+        await this.reloadSelectedRepository(shouldContinue);
+    }
+
+    /**
+     * Starts a repository switch and returns a guard for async continuations spawned by it.
+     */
+    private beginRepositorySwitch(): () => boolean {
+        const requestId = ++this.repositorySwitchSeq;
+        return () => requestId === this.repositorySwitchSeq;
+    }
+
+    /**
+     * Reloads all repository-scoped panels after the selected root changes.
+     */
+    private async reloadSelectedRepository(shouldContinue: () => boolean): Promise<void> {
         await this.iconTheme.initIconThemeData();
-        await this.reloadBranches();
+        if (!shouldContinue()) return;
+        if (!(await this.reloadBranches(shouldContinue))) return;
+        if (!shouldContinue()) return;
         await this.loadInitial();
+        if (!shouldContinue()) return;
         this.postCommitDetailState();
-        await this.refreshCommitPanelData();
+        await this.refreshCommitPanelData(false, shouldContinue);
+        if (!shouldContinue()) return;
         this.postToWebview({
             type: "restoreCommitDraft",
             message: this.getStoredCommitDraft(),
@@ -377,13 +409,15 @@ export class UndockedViewProvider {
         });
     }
 
-    private async reloadBranches(): Promise<void> {
+    private async reloadBranches(shouldContinue: () => boolean = () => true): Promise<boolean> {
         const data = this.loadRepositoryData
             ? await this.loadRepositoryData(this.selectedRepositoryRoot)
             : { branches: await this.gitOps.getBranches(), worktrees: [] };
+        if (!shouldContinue()) return false;
         this.branches = data.branches;
         this.worktrees = data.worktrees ?? [];
-        await this.sendBranches();
+        await this.sendBranches(shouldContinue);
+        return shouldContinue();
     }
 
     private repositoryFromRoot(root: string): RepositoryViewIdentity {
@@ -965,7 +999,10 @@ export class UndockedViewProvider {
      * The selected stash is preserved when still present; otherwise the first stash is selected.
      * Non-silent calls emit `refreshing` messages so the undocked UI can show action feedback.
      */
-    private async refreshCommitPanelData(silent = false): Promise<void> {
+    private async refreshCommitPanelData(
+        silent = false,
+        shouldContinue: () => boolean = () => true,
+    ): Promise<void> {
         if (!silent) this.postToWebview({ type: "refreshing", active: true });
         try {
             // Theme initialization must finish before decorated working-tree files are built.
@@ -995,6 +1032,7 @@ export class UndockedViewProvider {
                 ...files,
                 ...stashFiles,
             ]);
+            if (!shouldContinue()) return;
             this.files = files;
             this.stashes = stashes;
             this.selectedStashIndex = selectedStashIndex;
@@ -1024,16 +1062,19 @@ export class UndockedViewProvider {
                 currentBranchUpstream: currentBranchStatus.upstream,
             });
         } finally {
-            if (!silent) this.postToWebview({ type: "refreshing", active: false });
+            if (!silent && shouldContinue())
+                this.postToWebview({ type: "refreshing", active: false });
         }
     }
     // --- Branch sending -----------------------------------------------------
     /**
      * Sends cached branches with folder icons derived from branch path segments.
      */
-    private async sendBranches(): Promise<void> {
-        this.branchFolderIconsByName = await this.iconTheme.getFolderIconsByBranches(this.branches);
+    private async sendBranches(shouldContinue: () => boolean = () => true): Promise<void> {
+        const folderIconsByName = await this.iconTheme.getFolderIconsByBranches(this.branches);
         const currentBranchStatus = await this.currentBranchStatus();
+        if (!shouldContinue()) return;
+        this.branchFolderIconsByName = folderIconsByName;
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         this.postToWebview({
             type: "setBranches",
@@ -1041,7 +1082,7 @@ export class UndockedViewProvider {
             worktrees: this.worktrees,
             folderIcon: folderIcons.folderIcon,
             folderExpandedIcon: folderIcons.folderExpandedIcon,
-            folderIconsByName: this.branchFolderIconsByName,
+            folderIconsByName,
             iconFonts,
             currentBranchHasUpstream: currentBranchStatus.hasUpstream,
             hasRemotes: currentBranchStatus.hasRemotes,

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -2,6 +2,7 @@
 // and commit panel into a single unified view. Used when the user enables
 // intelligit.undockableWindow to allow dragging to a second monitor.
 import * as vscode from "vscode";
+import type { GitExecutor } from "../git/executor";
 import { GitOps } from "../git/operations";
 import { IconThemeService } from "./shared/IconThemeService";
 import { registerThemeChangeListeners, disposeAll } from "./shared/themeListeners";
@@ -27,7 +28,11 @@ import type {
     CommitAction,
     WorktreeAction,
 } from "../webviews/protocol/commitGraphTypes";
-import type { UnifiedOutbound, UnifiedInbound } from "../webviews/protocol/undockedMessages";
+import type {
+    RepositoryViewIdentity,
+    UnifiedOutbound,
+    UnifiedInbound,
+} from "../webviews/protocol/undockedMessages";
 import {
     CommitChecksCoordinator,
     DEFAULT_COMMIT_CHECKS_TTL_MS,
@@ -72,6 +77,19 @@ interface PersistedColumnWidths {
     graphWidth: number;
     infoWidth: number;
     commitPanelWidth: number;
+}
+
+interface UndockedRepositoryData {
+    branches: Branch[];
+    worktrees?: GitWorktree[];
+}
+
+interface UndockedViewProviderOptions {
+    executor?: Pick<GitExecutor, "setRoot">;
+    repositories?: RepositoryViewIdentity[];
+    selectedRepositoryRoot?: string;
+    loadRepositoryData?: (root: string) => Promise<UndockedRepositoryData>;
+    onSelectedRepositoryRootChanged?: (root: string) => Promise<void> | void;
 }
 
 /**
@@ -119,9 +137,14 @@ export class UndockedViewProvider {
     public static readonly viewType = "intelligit.undocked";
     private panel?: vscode.WebviewPanel;
     private readonly gitOps: GitOps;
+    private readonly executor?: Pick<GitExecutor, "setRoot">;
+    private readonly loadRepositoryData?: (root: string) => Promise<UndockedRepositoryData>;
+    private readonly onSelectedRepositoryRootChanged?: (root: string) => Promise<void> | void;
     private readonly iconTheme: IconThemeService;
     private repoRootUri: vscode.Uri;
     private repositoryLabel = "";
+    private repositories: RepositoryViewIdentity[] = [];
+    private selectedRepositoryRoot: string;
     // Graph-side state
     private currentBranch: string | null = null;
     private filterText = "";
@@ -196,9 +219,23 @@ export class UndockedViewProvider {
         private readonly workspaceState?: vscode.Memento,
         hostMap: HostMap = {},
         private readonly commitChecksSettings?: CommitChecksSettings,
+        options: UndockedViewProviderOptions = {},
     ) {
         this.gitOps = gitOps;
-        this.repoRootUri = repoRootUri;
+        this.executor = options.executor;
+        this.loadRepositoryData = options.loadRepositoryData;
+        this.onSelectedRepositoryRootChanged = options.onSelectedRepositoryRootChanged;
+        this.repositories =
+            options.repositories && options.repositories.length > 0
+                ? options.repositories
+                : [this.repositoryFromRoot(repoRootUri.fsPath)];
+        this.selectedRepositoryRoot =
+            this.findRepository(options.selectedRepositoryRoot ?? repoRootUri.fsPath)?.root ??
+            this.findRepository(repoRootUri.fsPath)?.root ??
+            this.repositories[0]?.root ??
+            repoRootUri.fsPath;
+        this.repoRootUri = vscode.Uri.file(this.selectedRepositoryRoot);
+        this.executor?.setRoot(this.selectedRepositoryRoot);
         this.iconTheme = new IconThemeService(this.extensionUri);
         this.commitChecks = new CommitChecksCoordinator(
             this.gitOps,
@@ -235,6 +272,26 @@ export class UndockedViewProvider {
         this.repositoryLabel = label;
         if (this.panel) this.panel.title = `IntelliGit — ${label}`;
     }
+
+    /**
+     * Replaces known repositories while preserving the selected undocked root when possible.
+     */
+    setRepositories(
+        repositories: RepositoryViewIdentity[],
+        selectedRepositoryRoot = this.selectedRepositoryRoot,
+    ): void {
+        this.repositories = repositories;
+        const selected =
+            this.findRepository(selectedRepositoryRoot) ??
+            this.findRepository(this.selectedRepositoryRoot) ??
+            this.repositories[0];
+        if (selected) {
+            const changed = selected.root !== this.selectedRepositoryRoot;
+            this.applyRepositoryRoot(selected, { reset: changed, updateExecutor: changed });
+        }
+        this.sendRepositories();
+    }
+
     /**
      * Switches the undocked panel to a new active repository and clears repository-scoped caches.
      *
@@ -242,7 +299,51 @@ export class UndockedViewProvider {
      * are reset so subsequent refreshes cannot display rows from the previous repository.
      */
     setRepositoryRootUri(repoRootUri: vscode.Uri): void {
-        this.repoRootUri = repoRootUri;
+        this.applyRepositoryRoot(
+            this.findRepository(repoRootUri.fsPath) ?? this.repositoryFromRoot(repoRootUri.fsPath),
+            { reset: true, updateExecutor: false },
+        );
+    }
+
+    /**
+     * Switches the dedicated undocked runtime to a known repository root.
+     *
+     * Unknown roots are rejected before the executor moves. Successful switches reset repository
+     * caches, persist selection through the caller callback, reload branches, reload the first graph
+     * page, refresh the commit-panel snapshot, and restore the selected repository draft.
+     */
+    async setActiveRepositoryRoot(root: string): Promise<void> {
+        const repository = this.findRepository(root);
+        if (!repository) {
+            throw new Error("Unknown repository root received from webview.");
+        }
+        this.applyRepositoryRoot(repository, { reset: true, updateExecutor: true });
+        await this.onSelectedRepositoryRootChanged?.(repository.root);
+        this.sendRepositories();
+        await this.iconTheme.initIconThemeData();
+        await this.reloadBranches();
+        await this.loadInitial();
+        this.postCommitDetailState();
+        await this.refreshCommitPanelData();
+        this.postToWebview({
+            type: "restoreCommitDraft",
+            message: this.getStoredCommitDraft(),
+        });
+    }
+
+    private applyRepositoryRoot(
+        repository: RepositoryViewIdentity,
+        options: { reset: boolean; updateExecutor: boolean },
+    ): void {
+        this.selectedRepositoryRoot = repository.root;
+        this.repoRootUri = vscode.Uri.file(repository.root);
+        this.repositoryLabel = repository.label;
+        if (this.panel) this.panel.title = `IntelliGit — ${repository.label}`;
+        if (options.updateExecutor) this.executor?.setRoot(repository.root);
+        if (options.reset) this.resetRepositoryScopedState();
+    }
+
+    private resetRepositoryScopedState(): void {
         this.requestSeq += 1;
         this.commitDetailSeq += 1;
         this.files = [];
@@ -275,6 +376,37 @@ export class UndockedViewProvider {
             );
         });
     }
+
+    private async reloadBranches(): Promise<void> {
+        const data = this.loadRepositoryData
+            ? await this.loadRepositoryData(this.selectedRepositoryRoot)
+            : { branches: await this.gitOps.getBranches(), worktrees: [] };
+        this.branches = data.branches;
+        this.worktrees = data.worktrees ?? [];
+        await this.sendBranches();
+    }
+
+    private repositoryFromRoot(root: string): RepositoryViewIdentity {
+        const parts = root.split(/[\\/]/).filter(Boolean);
+        return {
+            root,
+            label: parts[parts.length - 1] ?? root,
+        };
+    }
+
+    private findRepository(root: string | undefined): RepositoryViewIdentity | undefined {
+        if (!root) return undefined;
+        return this.repositories.find((repository) => repository.root === root);
+    }
+
+    private sendRepositories(): void {
+        this.postToWebview({
+            type: "repositories",
+            repositories: this.repositories,
+            selectedRepositoryRoot: this.selectedRepositoryRoot,
+        });
+    }
+
     /**
      * Caches the selected commit detail and decorates it with icon metadata asynchronously.
      *
@@ -436,6 +568,7 @@ export class UndockedViewProvider {
                 // never overwrites them with its pre-restore equal widths.
                 this.sendPersistedColumnWidths();
                 this.sendSettings();
+                this.sendRepositories();
                 await this.iconTheme.initIconThemeData();
                 await this.sendBranches();
                 await this.loadInitial();
@@ -445,6 +578,11 @@ export class UndockedViewProvider {
                     type: "restoreCommitDraft",
                     message: this.getStoredCommitDraft(),
                 });
+                break;
+            case "selectRepository":
+                await this.setActiveRepositoryRoot(
+                    assertString(msg.repositoryRoot, "repositoryRoot"),
+                );
                 break;
             case "selectCommit":
                 this._onCommitSelected.fire(assertGitHash(msg.hash, "hash"));

--- a/src/views/commitPanelActions.ts
+++ b/src/views/commitPanelActions.ts
@@ -14,6 +14,7 @@ interface CommitPanelActionDeps {
     fireWorkingTreeChanged: () => void;
     postCommitted: () => void;
     maybeOfferPublishBranch: () => Promise<void>;
+    publishBranch?: () => Promise<void>;
 }
 
 /**
@@ -151,7 +152,7 @@ export async function commitAndPushFromPanel(
 export async function runGitOperationFromPanel(
     deps: Pick<
         CommitPanelActionDeps,
-        "gitOps" | "refreshData" | "refreshGraphData" | "fireWorkingTreeChanged"
+        "gitOps" | "refreshData" | "refreshGraphData" | "fireWorkingTreeChanged" | "publishBranch"
     >,
     operation: CommitPanelGitOperation,
 ): Promise<void> {
@@ -166,7 +167,8 @@ export async function runGitOperationFromPanel(
         if (operation === "push") {
             // Publishing must finish before commit-panel and graph refresh read branch state.
             // react-doctor-disable-next-line react-doctor/async-parallel
-            await vscode.commands.executeCommand("intelligit.publishBranch");
+            await (deps.publishBranch?.() ??
+                vscode.commands.executeCommand("intelligit.publishBranch"));
             await deps.refreshData();
             await deps.refreshGraphData?.();
             deps.fireWorkingTreeChanged();

--- a/src/views/commitPanelRepositoryRuntime.ts
+++ b/src/views/commitPanelRepositoryRuntime.ts
@@ -32,6 +32,8 @@ export class CommitPanelRepositoryRuntime {
     loadingMore = false;
     requestSeq = 0;
     dataRefreshSeq = 0;
+    countRefreshSeq = 0;
+    hasScannedFileCount = false;
 
     /**
      * Creates a runtime for one repository root.

--- a/src/views/commitPanelRepositoryRuntime.ts
+++ b/src/views/commitPanelRepositoryRuntime.ts
@@ -1,0 +1,47 @@
+import * as vscode from "vscode";
+import { GitExecutor } from "../git/executor";
+import { GitOps } from "../git/operations";
+import type { DiscoveredRepository } from "../services/repositoryDiscovery";
+import type { StashEntry, ThemeFolderIconMap, WorkingFile } from "../types";
+
+/**
+ * Holds mutable commit-panel state for one discovered repository.
+ *
+ * The provider still owns behavior in this phase; this object only keeps the state and Git facade
+ * that must not bleed between repositories while the webview UI is still single-repository.
+ */
+export class CommitPanelRepositoryRuntime {
+    repository: DiscoveredRepository;
+    readonly repoRootUri: vscode.Uri;
+    readonly gitOps: GitOps;
+    files: WorkingFile[] = [];
+    stashes: StashEntry[] = [];
+    selectedStashIndex: number | null = null;
+    stashFiles: WorkingFile[] = [];
+    folderIconsByName: ThemeFolderIconMap = {};
+    showIgnoredFiles = false;
+    currentBranch: string | null = null;
+    currentBranchHasUpstreamCache = false;
+    hasRemotesCache = false;
+    currentBranchAheadCache = 0;
+    currentBranchBehindCache = 0;
+    currentBranchNameCache: string | null = null;
+    currentBranchUpstreamCache: string | null = null;
+    filterText = "";
+    offset = 0;
+    loadingMore = false;
+    requestSeq = 0;
+    dataRefreshSeq = 0;
+
+    /**
+     * Creates a runtime for one repository root.
+     *
+     * `gitOps` is injectable only so the existing single-repository activation path can keep using
+     * its already-constructed facade; newly discovered roots get an executor bound to their root.
+     */
+    constructor(repository: DiscoveredRepository, gitOps?: GitOps) {
+        this.repository = repository;
+        this.repoRootUri = vscode.Uri.file(repository.root);
+        this.gitOps = gitOps ?? new GitOps(new GitExecutor(repository.root));
+    }
+}

--- a/src/webviews/protocol/commitGraphTypes.ts
+++ b/src/webviews/protocol/commitGraphTypes.ts
@@ -223,6 +223,8 @@ export type CommitGraphInbound =
           type: "setBranches";
           /** Branches parsed from `git branch -a`; names are display and action identifiers. */
           branches: Branch[];
+          /** Optional repository label for compact graph headers embedded in multi-repo views. */
+          repositoryLabel?: string | null;
           /** Worktrees parsed from `git worktree list --porcelain -z` for branch navigation. */
           worktrees?: GitWorktree[];
           /** Default collapsed folder icon for branch tree groups when the theme resolves one. */

--- a/src/webviews/protocol/commitGraphTypes.ts
+++ b/src/webviews/protocol/commitGraphTypes.ts
@@ -264,6 +264,12 @@ export type CommitGraphInbound =
           branch: string | null;
       }
     | {
+          /** State update echoing the text filter that the host accepted. */
+          type: "setFilterText";
+          /** Accepted fixed-text git-log filter. */
+          text: string;
+      }
+    | {
           /** State update containing the currently selected commit detail. */
           type: "setCommitDetail";
           /** Git `show`/`diff-tree` detail snapshot; `detail.hash` is the stable action ID. */

--- a/src/webviews/protocol/commitPanelMessages.ts
+++ b/src/webviews/protocol/commitPanelMessages.ts
@@ -11,6 +11,25 @@ import type {
 } from "../../types";
 
 /**
+ * Optional repository selector for webview commands that operate on Git or repository files.
+ *
+ * Rootless messages remain valid during the single-repository UI transition; when present, the
+ * extension host must reject roots that are not in its current repository runtime map.
+ */
+type RepositoryScopedMessage<T extends { type: string }> = T & {
+    /** Absolute repository root originally supplied by host repository hydration. */
+    repositoryRoot?: string;
+};
+
+/** Minimal repository identity sent from the extension host to the commit-panel webview. */
+interface CommitPanelRepositorySummary {
+    /** Absolute filesystem path to the Git repository root. */
+    root: string;
+    /** Stable display label for repository pickers and headings. */
+    label: string;
+}
+
+/**
  * Commit panel messages sent from the webview to the extension host.
  *
  * Commands that carry paths use repository-relative Git paths originally
@@ -23,61 +42,61 @@ export type OutboundMessage =
           /** Lifecycle event requesting working-tree, stash, graph, and draft state. */
           type: "ready";
       }
-    | {
+    | RepositoryScopedMessage<{
           /** User event requesting a fresh working-tree and stash snapshot. */
           type: "refresh";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command aborting the active merge after host confirmation. */
           type: "abortMerge";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** View option controlling whether ignored files are included in working-tree snapshots. */
           type: "setShowIgnoredFiles";
           /** True asks the host to include `git status --ignored` rows; false restores the default. */
           showIgnoredFiles: boolean;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command fetching remote refs without changing the current working tree. */
           type: "fetch";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command pulling the current branch with rebase semantics. */
           type: "pull";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command pushing the current branch to its upstream. */
           type: "push";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command pulling the current branch and then pushing it. */
           type: "sync";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Persistence event storing the commit message draft in workspace state. */
           type: "saveCommitDraft";
           /** Plain commit message text scoped by repository root; empty text clears storage. */
           message: string;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command staging selected working-tree files. */
           type: "stageFiles";
           /** Repository-relative paths from `WorkingFile.path`; empty arrays are a no-op. */
           paths: string[];
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command unstaging selected index entries. */
           type: "unstageFiles";
           /** Repository-relative paths from `WorkingFile.path`; empty arrays are a no-op. */
           paths: string[];
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command marking selected unversioned paths as intent-to-add. */
           type: "trackUnversionedFiles";
           /** Repository-relative unversioned paths from `WorkingFile.path`; host revalidates status. */
           paths: string[];
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command staging selected paths and then committing, optionally pushing. */
           type: "commitSelected";
           /** Repository-relative paths to stage before commit; empty is valid only for amend. */
@@ -88,99 +107,99 @@ export type OutboundMessage =
           amend: boolean;
           /** Whether a successful commit should be followed by a push. */
           push: boolean;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command committing currently staged changes without staging panel selections first. */
           type: "commit";
           /** Commit message after UI trimming; the host allows empty text only while amending. */
           message: string;
           /** Whether the host should run the commit as an amend operation. */
           amend: boolean;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command committing currently staged changes and then pushing. */
           type: "commitAndPush";
           /** Commit message after UI trimming; the host allows empty text only while amending. */
           message: string;
           /** Whether the host should run the commit as an amend operation. */
           amend: boolean;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command delegating publish-branch setup to the extension host. */
           type: "publishBranch";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Request for the latest commit message used to prefill amend text. */
           type: "getLastCommitMessage";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Request for branch-local history shown as amend context. */
           type: "getAmendBranchCommits";
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command rolling back selected paths, or all changes when no path is selected. */
           type: "rollback";
           /** Repository-relative paths from `WorkingFile.path`; empty means rollback all. */
           paths: string[];
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command opening the VS Code working-tree diff for a selected file. */
           type: "showDiff";
           /** Repository-relative path from the working-tree snapshot. */
           path: string;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command saving selected or all changes to the Git stash. */
           type: "stashSave";
           /** Optional stash message; host defaults to a generic stash name when absent. */
           name?: string;
           /** Repository-relative paths to stash; omitted means stash all tracked/untracked changes. */
           paths?: string[];
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command applying and dropping a stashed change via `git stash pop`. */
           type: "stashPop";
           /** Current `stash@{n}` index from `StashEntry.index`; unstable after stash mutations. */
           index: number;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command applying a stashed change without dropping it. */
           type: "stashApply";
           /** Current `stash@{n}` index from `StashEntry.index`; unstable after stash mutations. */
           index: number;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command deleting a stashed change after host confirmation. */
           type: "stashDelete";
           /** Current `stash@{n}` index from `StashEntry.index`; unstable after stash mutations. */
           index: number;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Request loading the file list for one stashed change. */
           type: "stashSelect";
           /** Current `stash@{n}` index whose files should populate `stashFiles`. */
           index: number;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command opening a preview diff for one file inside a stashed change. */
           type: "showStashDiff";
           /** Current `stash@{n}` index containing the file. */
           index: number;
           /** Repository-relative path from the selected stash file list. */
           path: string;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command opening a working-tree file in the editor. */
           type: "openFile";
           /** Repository-relative path from the working-tree snapshot. */
           path: string;
-      }
-    | {
+      }>
+    | RepositoryScopedMessage<{
           /** Command deleting a working-tree file after host confirmation. */
           type: "deleteFile";
           /** Repository-relative path from the working-tree snapshot. */
           path: string;
-      };
+      }>;
 
 /**
  * Commit panel messages sent from the extension host to the webview.
@@ -191,6 +210,14 @@ export type OutboundMessage =
  * data for the current view.
  */
 export type InboundMessage =
+    | {
+          /** Repository list hydration for host-owned multi-repository state. */
+          type: "setRepositories";
+          /** Discovered repositories known to the host, in display order. */
+          repositories: CommitPanelRepositorySummary[];
+          /** Active host repository root, or `null` when no repository is selected. */
+          activeRepositoryRoot: string | null;
+      }
     | {
           /** State update for working-tree files, stashes, and render-only icon metadata. */
           type: "update";

--- a/src/webviews/protocol/commitPanelMessages.ts
+++ b/src/webviews/protocol/commitPanelMessages.ts
@@ -21,6 +21,12 @@ type RepositoryScopedMessage<T extends { type: string }> = T & {
     repositoryRoot?: string;
 };
 
+/** Optional repository identity attached to host messages derived from a repository runtime. */
+type RepositoryIdentifiedMessage<T extends { type: string }> = T & {
+    /** Absolute repository root for the runtime that produced this payload. */
+    repositoryRoot?: string;
+};
+
 /** Minimal repository identity sent from the extension host to the commit-panel webview. */
 interface CommitPanelRepositorySummary {
     /** Absolute filesystem path to the Git repository root. */
@@ -218,7 +224,7 @@ export type InboundMessage =
           /** Active host repository root, or `null` when no repository is selected. */
           activeRepositoryRoot: string | null;
       }
-    | {
+    | RepositoryIdentifiedMessage<{
           /** State update for working-tree files, stashes, and render-only icon metadata. */
           type: "update";
           /** Working-tree and index entries parsed from `git status` and numstat output. */
@@ -252,35 +258,35 @@ export type InboundMessage =
           currentBranchName?: string | null;
           /** Current branch upstream tracking ref, when configured. */
           currentBranchUpstream?: string | null;
-      }
-    | {
+      }>
+    | RepositoryIdentifiedMessage<{
           /** State update restoring the repository-scoped commit draft from workspace state. */
           type: "restoreCommitDraft";
           /** Plain draft text; empty string means no saved draft. */
           message: string;
-      }
-    | {
+      }>
+    | RepositoryIdentifiedMessage<{
           /** Response to `getLastCommitMessage` for amend prefill. */
           type: "lastCommitMessage";
           /** Full body from `git log -1 --format=%B`, or empty string when unavailable. */
           message: string;
-      }
-    | {
+      }>
+    | RepositoryIdentifiedMessage<{
           /** Response to `getAmendBranchCommits` for amend context display. */
           type: "amendBranchCommits";
           /** Git log summaries from upstream-to-HEAD when possible, otherwise recent HEAD history. */
           commits: AmendBranchCommitSummary[];
-      }
-    | {
+      }>
+    | RepositoryIdentifiedMessage<{
           /** Event indicating a commit completed and the webview should clear committed state. */
           type: "committed";
-      }
-    | {
+      }>
+    | RepositoryIdentifiedMessage<{
           /** Status event toggling refresh affordances while host refresh work is active. */
           type: "refreshing";
           /** `true` starts visible refresh feedback; `false` clears it after host completion. */
           active: boolean;
-      }
+      }>
     | {
           /** General host error event for commit-panel commands. */
           type: "error";

--- a/src/webviews/protocol/commitPanelMessages.ts
+++ b/src/webviews/protocol/commitPanelMessages.ts
@@ -310,8 +310,14 @@ export type InboundMessage =
           active: boolean;
       }>
     | {
-          /** General host error event for commit-panel commands. */
+          /** Accepted graph text filter mirrored back to graph UI state. */
+          type: "setFilterText";
+          /** Text filter currently owned by the extension host. */
+          text: string;
+      }
+    | RepositoryIdentifiedMessage<{
+          /** General or repository-scoped host error event for commit-panel commands. */
           type: "error";
           /** User-visible error text normalized by the host. */
           message: string;
-      };
+      }>;

--- a/src/webviews/protocol/commitPanelMessages.ts
+++ b/src/webviews/protocol/commitPanelMessages.ts
@@ -33,6 +33,53 @@ interface CommitPanelRepositorySummary {
     root: string;
     /** Stable display label for repository pickers and headings. */
     label: string;
+    /** Last-known non-ignored changed-file count for collapsed repository rows. */
+    changedFileCount: number;
+}
+
+/** Full host-side snapshot for one commit-panel repository runtime. */
+export interface CommitPanelRepositorySnapshot {
+    /** Absolute filesystem path to the Git repository root that produced this snapshot. */
+    repositoryRoot?: string;
+    /** Stable display label for repository rows. */
+    repositoryLabel?: string;
+    /** Last-known non-ignored unique changed-file count for this repository. */
+    changedFileCount?: number;
+    /** Working-tree and index entries parsed from `git status` and numstat output. */
+    files: WorkingFile[];
+    /** Stashed changes parsed from `git stash list`; indices are not stable after refresh. */
+    stashes: StashEntry[];
+    /** Files for `selectedStashIndex`, parsed from `git stash show` output. */
+    stashFiles: WorkingFile[];
+    /** Selected `stash@{n}` index, or `null` when no stash entry is available. */
+    selectedStashIndex: number | null;
+    /** Default collapsed folder icon for file trees when the theme resolves one. */
+    folderIcon?: ThemeTreeIcon;
+    /** Default expanded folder icon for file trees when the theme resolves one. */
+    folderExpandedIcon?: ThemeTreeIcon;
+    /** Folder icon overrides keyed by file-icon-theme folder name. */
+    folderIconsByName?: ThemeFolderIconMap;
+    /** Webview-safe font-face payloads needed to render glyph-based file icons. */
+    iconFonts?: ThemeIconFont[];
+    /**
+     * Whether the current branch has an upstream; absent producers are treated as
+     * `true` so older payloads do not incorrectly switch the UI to Publish Branch.
+     */
+    currentBranchHasUpstream?: boolean;
+    /** Whether the repository has at least one configured remote for fetch operations. */
+    hasRemotes?: boolean;
+    /** Number of commits the current branch is ahead of its upstream, when known. */
+    currentBranchAhead?: number;
+    /** Number of commits the current branch is behind its upstream, when known. */
+    currentBranchBehind?: number;
+    /** Current local branch name, when the repository is not detached. */
+    currentBranchName?: string | null;
+    /** Current branch upstream tracking ref, when configured. */
+    currentBranchUpstream?: string | null;
+    /** Whether this repository is currently running a host refresh. */
+    refreshing?: boolean;
+    /** Last repository-scoped refresh error, or `null` when the latest snapshot is healthy. */
+    error?: string | null;
 }
 
 /**
@@ -52,6 +99,12 @@ export type OutboundMessage =
           /** User event requesting a fresh working-tree and stash snapshot. */
           type: "refresh";
       }>
+    | {
+          /** Repository accordion state sent by the webview so the host can watch expanded rows. */
+          type: "setExpandedRepositories";
+          /** Absolute repository roots that are currently expanded in the docked commit panel. */
+          repositoryRoots: string[];
+      }
     | RepositoryScopedMessage<{
           /** Command aborting the active merge after host confirmation. */
           type: "abortMerge";
@@ -224,41 +277,10 @@ export type InboundMessage =
           /** Active host repository root, or `null` when no repository is selected. */
           activeRepositoryRoot: string | null;
       }
-    | RepositoryIdentifiedMessage<{
+    | ({
           /** State update for working-tree files, stashes, and render-only icon metadata. */
           type: "update";
-          /** Working-tree and index entries parsed from `git status` and numstat output. */
-          files: WorkingFile[];
-          /** Stashed changes parsed from `git stash list`; indices are not stable after refresh. */
-          stashes: StashEntry[];
-          /** Files for `selectedStashIndex`, parsed from `git stash show` output. */
-          stashFiles: WorkingFile[];
-          /** Selected `stash@{n}` index, or `null` when no stash entry is available. */
-          selectedStashIndex: number | null;
-          /** Default collapsed folder icon for file trees when the theme resolves one. */
-          folderIcon?: ThemeTreeIcon;
-          /** Default expanded folder icon for file trees when the theme resolves one. */
-          folderExpandedIcon?: ThemeTreeIcon;
-          /** Folder icon overrides keyed by file-icon-theme folder name. */
-          folderIconsByName?: ThemeFolderIconMap;
-          /** Webview-safe font-face payloads needed to render glyph-based file icons. */
-          iconFonts?: ThemeIconFont[];
-          /**
-           * Whether the current branch has an upstream; absent producers are treated as
-           * `true` so older payloads do not incorrectly switch the UI to Publish Branch.
-           */
-          currentBranchHasUpstream?: boolean;
-          /** Whether the repository has at least one configured remote for fetch operations. */
-          hasRemotes?: boolean;
-          /** Number of commits the current branch is ahead of its upstream, when known. */
-          currentBranchAhead?: number;
-          /** Number of commits the current branch is behind its upstream, when known. */
-          currentBranchBehind?: number;
-          /** Current local branch name, when the repository is not detached. */
-          currentBranchName?: string | null;
-          /** Current branch upstream tracking ref, when configured. */
-          currentBranchUpstream?: string | null;
-      }>
+      } & CommitPanelRepositorySnapshot)
     | RepositoryIdentifiedMessage<{
           /** State update restoring the repository-scoped commit draft from workspace state. */
           type: "restoreCommitDraft";

--- a/src/webviews/protocol/undockedMessages.ts
+++ b/src/webviews/protocol/undockedMessages.ts
@@ -10,6 +10,14 @@ import type {
 } from "./commitPanelMessages";
 import type { CommitGraphInbound } from "./commitGraphTypes";
 
+/** Minimal repository identity sent to the undocked repository selector. */
+export interface RepositoryViewIdentity {
+    /** Absolute filesystem path to the Git repository root. */
+    root: string;
+    /** Stable display label for repository rows. */
+    label: string;
+}
+
 /**
  * Messages sent from the extension host to the undocked editor-tab webview.
  *
@@ -21,6 +29,14 @@ import type { CommitGraphInbound } from "./commitGraphTypes";
 export type UnifiedInbound =
     | CommitGraphInbound
     | CommitPanelInbound
+    | {
+          /** Repository list hydration for the fixed far-left undocked selector. */
+          type: "repositories";
+          /** Known Git repositories that the undocked runtime can switch between. */
+          repositories: RepositoryViewIdentity[];
+          /** Repository root currently bound to the undocked runtime. */
+          selectedRepositoryRoot: string;
+      }
     | {
           /** Layout setting event resolved from IntelliGit/workbench configuration. */
           type: "settings";
@@ -54,6 +70,12 @@ type GraphOutbound =
     | {
           /** Lifecycle event requesting initial graph, commit-panel, layout, and draft state. */
           type: "ready";
+      }
+    | {
+          /** Repository selector event requesting a dedicated undocked runtime root switch. */
+          type: "selectRepository";
+          /** Absolute repository root previously supplied by the host. */
+          repositoryRoot: string;
       }
     | {
           /** Selection event for the commit whose detail panes should be loaded. */

--- a/src/webviews/react/NativeCommitGraph.tsx
+++ b/src/webviews/react/NativeCommitGraph.tsx
@@ -206,6 +206,9 @@ export function NativeCommitGraph({
                     selectFirstOnNextLoadRef.current = true;
                     dispatch({ type: "setSelectedBranch", branch: data.branch ?? null });
                     break;
+                case "setFilterText":
+                    dispatch({ type: "setFilterText", text: data.text });
+                    break;
                 case "setBranches":
                     dispatch({
                         type: "setBranches",

--- a/src/webviews/react/NativeCommitGraph.tsx
+++ b/src/webviews/react/NativeCommitGraph.tsx
@@ -33,6 +33,7 @@ interface NativeCommitGraphState {
     unpushedHashes: Set<string>;
     commitChecks: Map<string, CommitChecksValue>;
     commitChecksEnabled: boolean;
+    repositoryLabel: string | null;
 }
 
 type NativeCommitGraphAction =
@@ -45,7 +46,12 @@ type NativeCommitGraphAction =
           unpushedHashes?: string[];
       }
     | { type: "setSelectedBranch"; branch: string | null }
-    | { type: "setBranches"; branches: Branch[]; commitChecksEnabled?: boolean }
+    | {
+          type: "setBranches";
+          branches: Branch[];
+          commitChecksEnabled?: boolean;
+          repositoryLabel?: string | null;
+      }
     | { type: "loadError"; clearCommits: boolean }
     | { type: "setCommitChecks"; snapshot: CommitChecksSnapshot }
     | { type: "markCommitChecksLoading"; hash: string }
@@ -62,6 +68,7 @@ const initialNativeCommitGraphState: NativeCommitGraphState = {
     unpushedHashes: new Set(),
     commitChecks: new Map(),
     commitChecksEnabled: true,
+    repositoryLabel: null,
 };
 
 function nativeCommitGraphReducer(
@@ -84,6 +91,7 @@ function nativeCommitGraphReducer(
                 ...state,
                 branches: action.branches,
                 commitChecksEnabled: action.commitChecksEnabled ?? true,
+                repositoryLabel: action.repositoryLabel ?? null,
             };
         case "loadError":
             return {
@@ -133,6 +141,7 @@ export function NativeCommitGraph({
         unpushedHashes,
         commitChecks,
         commitChecksEnabled,
+        repositoryLabel,
     } = state;
     const loadingMore = useRef(false);
     const selectedHashRef = useRef<string | null>(selectedHash);
@@ -207,6 +216,7 @@ export function NativeCommitGraph({
                         type: "setBranches",
                         branches: data.branches,
                         commitChecksEnabled: data.commitChecksEnabled,
+                        repositoryLabel: data.repositoryLabel,
                     });
                     break;
                 case "loadError":
@@ -282,6 +292,7 @@ export function NativeCommitGraph({
         },
         [vscode],
     );
+    const headerLabel = repositoryLabel ? `Graph ${repositoryLabel}` : "Graph";
     return (
         <CommitList
             commits={commits}
@@ -301,7 +312,7 @@ export function NativeCommitGraph({
             onSignInForCommitChecks={commitChecksEnabled ? handleSignInForCommitChecks : undefined}
             showSearch={false}
             showAuthorDate={false}
-            headerLabel="Graph"
+            headerLabel={headerLabel}
         />
     );
 }

--- a/src/webviews/react/NativeCommitGraph.tsx
+++ b/src/webviews/react/NativeCommitGraph.tsx
@@ -33,7 +33,6 @@ interface NativeCommitGraphState {
     unpushedHashes: Set<string>;
     commitChecks: Map<string, CommitChecksValue>;
     commitChecksEnabled: boolean;
-    repositoryLabel: string | null;
 }
 
 type NativeCommitGraphAction =
@@ -50,7 +49,6 @@ type NativeCommitGraphAction =
           type: "setBranches";
           branches: Branch[];
           commitChecksEnabled?: boolean;
-          repositoryLabel?: string | null;
       }
     | { type: "loadError"; clearCommits: boolean }
     | { type: "setCommitChecks"; snapshot: CommitChecksSnapshot }
@@ -68,7 +66,6 @@ const initialNativeCommitGraphState: NativeCommitGraphState = {
     unpushedHashes: new Set(),
     commitChecks: new Map(),
     commitChecksEnabled: true,
-    repositoryLabel: null,
 };
 
 function nativeCommitGraphReducer(
@@ -91,7 +88,6 @@ function nativeCommitGraphReducer(
                 ...state,
                 branches: action.branches,
                 commitChecksEnabled: action.commitChecksEnabled ?? true,
-                repositoryLabel: action.repositoryLabel ?? null,
             };
         case "loadError":
             return {
@@ -141,7 +137,6 @@ export function NativeCommitGraph({
         unpushedHashes,
         commitChecks,
         commitChecksEnabled,
-        repositoryLabel,
     } = state;
     const loadingMore = useRef(false);
     const selectedHashRef = useRef<string | null>(selectedHash);
@@ -216,7 +211,6 @@ export function NativeCommitGraph({
                         type: "setBranches",
                         branches: data.branches,
                         commitChecksEnabled: data.commitChecksEnabled,
-                        repositoryLabel: data.repositoryLabel,
                     });
                     break;
                 case "loadError":
@@ -292,7 +286,6 @@ export function NativeCommitGraph({
         },
         [vscode],
     );
-    const headerLabel = repositoryLabel ? `Graph ${repositoryLabel}` : "Graph";
     return (
         <CommitList
             commits={commits}
@@ -312,7 +305,7 @@ export function NativeCommitGraph({
             onSignInForCommitChecks={commitChecksEnabled ? handleSignInForCommitChecks : undefined}
             showSearch={false}
             showAuthorDate={false}
-            headerLabel={headerLabel}
+            headerLabel="Graph"
         />
     );
 }

--- a/src/webviews/react/UndockedApp.tsx
+++ b/src/webviews/react/UndockedApp.tsx
@@ -35,7 +35,7 @@ import type {
     ThemeIconFont,
     ThemeTreeIcon,
 } from "../../types";
-import type { UnifiedOutbound } from "../protocol/undockedMessages";
+import type { RepositoryViewIdentity, UnifiedOutbound } from "../protocol/undockedMessages";
 
 // --- Helpers ----------------------------------------------------------------
 
@@ -82,6 +82,8 @@ const initialGraphState: GraphState = {
 
 function graphReducer(state: GraphState, action: GraphAction): GraphState {
     switch (action.type) {
+        case "resetRepository":
+            return { ...initialGraphState, iconFonts: state.iconFonts };
         case "loadCommits":
             return {
                 ...state,
@@ -171,6 +173,8 @@ function readInitialWidths(): SectionWidths {
 function App(): React.ReactElement {
     // --- Graph-side state ---
     const [graphState, graphDispatch] = useReducer(graphReducer, initialGraphState);
+    const [repositories, setRepositories] = useState<RepositoryViewIdentity[]>([]);
+    const [selectedRepositoryRoot, setSelectedRepositoryRoot] = useState<string | null>(null);
     const {
         commits,
         branches,
@@ -387,6 +391,9 @@ function App(): React.ReactElement {
         cpDispatch,
         loadingMore,
         selectedHash,
+        selectedRepositoryRoot,
+        setRepositories,
+        setSelectedRepositoryRoot,
         markWidthsHydrated,
         setSectionWidths,
         layoutRef,
@@ -431,6 +438,8 @@ function App(): React.ReactElement {
             branchWidth={branchWidth}
             graphWidth={graphWidth}
             infoWidth={infoWidth}
+            repositories={repositories}
+            selectedRepositoryRoot={selectedRepositoryRoot}
             branches={branches}
             worktrees={worktrees}
             selectedBranch={selectedBranch}
@@ -467,6 +476,7 @@ function App(): React.ReactElement {
             onGraphDividerKeyDown={onGraphDividerKeyDown}
             onRightCommitPanelDividerMouseDown={onRightCommitPanelDividerMouseDown}
             onRightCommitPanelDividerKeyDown={onRightCommitPanelDividerKeyDown}
+            handleSelectRepository={actions.handleSelectRepository}
             handleSelectCommit={actions.handleSelectCommit}
             handleFilterText={actions.handleFilterText}
             handleLoadMore={actions.handleLoadMore}

--- a/src/webviews/react/commit-graph/useCommitGraphMessages.ts
+++ b/src/webviews/react/commit-graph/useCommitGraphMessages.ts
@@ -96,6 +96,9 @@ export function useCommitGraphMessages(params: {
                     selectFirstOnNextLoadRef.current = true;
                     dispatch({ type: "setSelectedBranch", branch: data.branch ?? null });
                     break;
+                case "setFilterText":
+                    dispatch({ type: "setFilterText", text: data.text });
+                    break;
                 case "setCommitDetail":
                     dispatch({
                         type: "setCommitDetail",

--- a/src/webviews/react/commit-info/CommitInfoPane.tsx
+++ b/src/webviews/react/commit-info/CommitInfoPane.tsx
@@ -25,6 +25,11 @@ import {
 type TreeEntry = GenericTreeEntry<CommitFile>;
 type TreeFolder = GenericTreeFolder<CommitFile>;
 
+interface FileStats {
+    additions: number;
+    deletions: number;
+}
+
 interface CommitScopedExpandedDirs {
     commitHash: string | null;
     dirs: Set<string>;
@@ -60,6 +65,16 @@ const VISUALLY_HIDDEN_STYLE: React.CSSProperties = {
     whiteSpace: "nowrap",
     border: 0,
 };
+
+function sumCommitFileStats(files: CommitFile[]): FileStats {
+    return files.reduce<FileStats>(
+        (stats, file) => ({
+            additions: stats.additions + file.additions,
+            deletions: stats.deletions + file.deletions,
+        }),
+        { additions: 0, deletions: 0 },
+    );
+}
 
 function CommitRefRow({
     kind,
@@ -300,11 +315,13 @@ function SectionHeader({
     label,
     expanded,
     onToggle,
+    stats,
     borderBottom = false,
 }: {
     label: string;
     expanded: boolean;
     onToggle?: () => void;
+    stats?: FileStats;
     borderBottom?: boolean;
 }): React.ReactElement {
     return (
@@ -334,7 +351,26 @@ function SectionHeader({
                     : undefined
             }
         >
-            <ChevronIcon expanded={expanded} /> {label}
+            <ChevronIcon expanded={expanded} />
+            <Box as="span">{label}</Box>
+            {stats && (stats.additions > 0 || stats.deletions > 0) && (
+                <Box as="span" ml="auto" fontSize="11px" flexShrink={0}>
+                    {stats.additions > 0 && (
+                        <Box
+                            as="span"
+                            color="var(--intelligit-pycharm-added)"
+                            mr={stats.deletions > 0 ? "4px" : "0"}
+                        >
+                            +{stats.additions}
+                        </Box>
+                    )}
+                    {stats.deletions > 0 && (
+                        <Box as="span" color="var(--intelligit-pycharm-deleted)">
+                            -{stats.deletions}
+                        </Box>
+                    )}
+                </Box>
+            )}
         </Box>
     );
 }
@@ -366,12 +402,15 @@ function CommitChangedFilesPanel({
     onSelectFile: (path: string) => void;
     onOpenDiff?: (commitHash: string, filePath: string) => void;
 }): React.ReactElement {
+    const stats = sumCommitFileStats(detail.files);
+
     return (
         <>
             <SectionHeader
                 label={t("commitInfo.changedFiles")}
                 expanded={!filesCollapsed}
                 onToggle={onToggleFiles}
+                stats={stats}
                 borderBottom={true}
             />
             {!filesCollapsed && (

--- a/src/webviews/react/commit-panel/CommitPanelApp.tsx
+++ b/src/webviews/react/commit-panel/CommitPanelApp.tsx
@@ -1,18 +1,14 @@
 // Entry point for the commit panel React webview. Wraps the app in
 // ChakraProvider with the VS Code theme and composes all panels.
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ChakraProvider, Box } from "@chakra-ui/react";
 import theme from "./theme";
-import { TabBar } from "./components/TabBar";
-import { CommitTab } from "./components/CommitTab";
-import { StashTab } from "./components/StashTab";
+import { RepositoryAccordion } from "./components/RepositoryAccordion";
 import { useExtensionMessages } from "./hooks/useExtensionMessages";
-import { useCheckedFiles } from "./hooks/useCheckedFiles";
 import { getVsCodeApi } from "./hooks/useVsCodeApi";
 import { ThemeIconFontFaces } from "../shared/components/ThemeIconFontFaces";
-import { canRunCommitAction } from "./commitEligibility";
 
 /**
  * Root commit-panel React app wired to the VS Code webview host.
@@ -25,144 +21,55 @@ import { canRunCommitAction } from "./commitEligibility";
 // react-doctor-disable-next-line react-doctor/only-export-components
 function App(): React.ReactElement {
     const [state, dispatch] = useExtensionMessages();
-    const { checkedPaths, toggleFile, toggleFolder, toggleSection, isAllChecked, isSomeChecked } =
-        useCheckedFiles(state.files);
-
     const vscode = getVsCodeApi();
     const [groupByDir, setGroupByDir] = useState<boolean>(() => {
         const saved = vscode.getState?.();
         return typeof saved?.groupByDir === "boolean" ? saved.groupByDir : true;
     });
-    const [showIgnoredFiles, setShowIgnoredFiles] = useState<boolean>(() => {
-        const saved = vscode.getState?.();
-        return saved?.showIgnoredFiles === true;
-    });
-    const showIgnoredFilesPostedRef = useRef(false);
-
-    useEffect(() => {
-        if (!state.isAmend) return;
-        if (state.isRefreshing) return;
-        vscode.postMessage({ type: "getAmendBranchCommits" });
-    }, [state.isAmend, state.isRefreshing, vscode]);
+    const iconFonts = useMemo(
+        () => state.repositories.flatMap((repository) => repository.iconFonts),
+        [state.repositories],
+    );
 
     useEffect(() => {
         const prev = vscode.getState?.() ?? {};
-        vscode.setState({ ...prev, groupByDir, showIgnoredFiles });
-    }, [groupByDir, showIgnoredFiles, vscode]);
+        vscode.setState({ ...prev, groupByDir });
+    }, [groupByDir, vscode]);
 
-    useEffect(() => {
-        const shouldPost = showIgnoredFilesPostedRef.current || showIgnoredFiles;
-        showIgnoredFilesPostedRef.current = true;
-        if (!shouldPost) return;
-        vscode.postMessage({ type: "setShowIgnoredFiles", showIgnoredFiles });
-    }, [showIgnoredFiles, vscode]);
-
-    const handleMessageChange = useCallback(
-        (message: string) => {
-            dispatch({ type: "SET_COMMIT_MESSAGE", message });
-            vscode.postMessage({ type: "saveCommitDraft", message });
+    const handleToggleExpanded = useCallback(
+        (root: string) => {
+            const nextRoots = state.expandedRepositoryRoots.includes(root)
+                ? state.expandedRepositoryRoots.filter((repositoryRoot) => repositoryRoot !== root)
+                : [...state.expandedRepositoryRoots, root];
+            dispatch({ type: "SET_EXPANDED_REPOSITORIES", repositoryRoots: nextRoots });
+            vscode.postMessage({ type: "setExpandedRepositories", repositoryRoots: nextRoots });
         },
-        [dispatch, vscode],
+        [dispatch, state.expandedRepositoryRoots, vscode],
     );
-
-    const handleAmendChange = useCallback(
-        (isAmend: boolean) => {
-            dispatch({ type: "SET_AMEND", isAmend });
-            if (isAmend) {
-                vscode.postMessage({ type: "getLastCommitMessage" });
-            }
-        },
-        [dispatch, vscode],
-    );
-
-    const canCommit = canRunCommitAction(state.isAmend, checkedPaths.size, state.commitMessage);
-    const shouldPublishBranch = !state.currentBranchHasUpstream;
-    const canPush = shouldPublishBranch
-        ? state.currentBranchName !== null
-        : state.currentBranchAhead > 0;
-    const pushLabel = shouldPublishBranch ? "commit.action.publishAndPush" : "common.push";
-
-    const handleCommit = useCallback(() => {
-        const msg = state.commitMessage.trim();
-        vscode.postMessage({
-            type: "commitSelected",
-            message: msg,
-            amend: state.isAmend,
-            push: false,
-            paths: Array.from(checkedPaths),
-        });
-    }, [vscode, state.commitMessage, state.isAmend, checkedPaths]);
-
-    const handlePush = useCallback(() => {
-        vscode.postMessage({ type: shouldPublishBranch ? "publishBranch" : "push" });
-    }, [vscode, shouldPublishBranch]);
-
-    const handleSync = useCallback(() => {
-        vscode.postMessage({ type: "sync" });
-    }, [vscode]);
-
-    const handleFetch = useCallback(() => {
-        vscode.postMessage({ type: "fetch" });
-    }, [vscode]);
-
-    const handlePull = useCallback(() => {
-        vscode.postMessage({ type: "pull" });
-    }, [vscode]);
 
     return (
-        <Box display="flex" flexDirection="column" h="100%" bg="var(--intelligit-pycharm-panel)">
-            <ThemeIconFontFaces fonts={state.iconFonts} />
-            <TabBar
-                stashCount={state.stashes.length}
-                onSync={handleSync}
-                onFetch={handleFetch}
-                onPull={handlePull}
-                onPush={handlePush}
-                commitContent={
-                    <CommitTab
-                        files={state.files}
-                        commitMessage={state.commitMessage}
-                        isAmend={state.isAmend}
-                        amendBranchCommits={state.amendBranchCommits}
-                        amendBranchHistoryLoaded={state.amendBranchHistoryLoaded}
-                        isRefreshing={state.isRefreshing}
-                        checkedPaths={checkedPaths}
-                        onToggleFile={toggleFile}
-                        onToggleFolder={toggleFolder}
-                        onToggleSection={toggleSection}
-                        isAllChecked={isAllChecked}
-                        isSomeChecked={isSomeChecked}
-                        onMessageChange={handleMessageChange}
-                        onAmendChange={handleAmendChange}
-                        onCommit={handleCommit}
-                        canCommit={canCommit}
-                        onPush={handlePush}
-                        canPush={canPush}
-                        pushLabel={pushLabel}
-                        currentBranchName={state.currentBranchName}
-                        currentBranchUpstream={state.currentBranchUpstream}
-                        folderIcon={state.folderIcon}
-                        folderExpandedIcon={state.folderExpandedIcon}
-                        folderIconsByName={state.folderIconsByName}
+        <Box
+            display="flex"
+            flexDirection="column"
+            h="100%"
+            overflow="hidden"
+            bg="var(--intelligit-pycharm-panel)"
+        >
+            <ThemeIconFontFaces fonts={iconFonts} />
+            <Box flex={1} minH={0} overflowY="auto" display="flex" flexDirection="column">
+                {state.repositories.map((repository) => (
+                    <RepositoryAccordion
+                        key={repository.root}
+                        repository={repository}
+                        isExpanded={state.expandedRepositoryRoots.includes(repository.root)}
+                        isOnlyRepository={state.repositories.length === 1}
                         groupByDir={groupByDir}
-                        showIgnoredFiles={showIgnoredFiles}
-                        onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                        onToggleShowIgnoredFiles={() => setShowIgnoredFiles((show) => !show)}
+                        onToggleExpanded={handleToggleExpanded}
+                        onToggleGroupBy={() => setGroupByDir((value) => !value)}
+                        dispatch={dispatch}
                     />
-                }
-                stashContent={
-                    <StashTab
-                        stashes={state.stashes}
-                        stashFiles={state.stashFiles}
-                        selectedIndex={state.selectedStashIndex}
-                        folderIcon={state.folderIcon}
-                        folderExpandedIcon={state.folderExpandedIcon}
-                        folderIconsByName={state.folderIconsByName}
-                        groupByDir={groupByDir}
-                        onToggleGroupBy={() => setGroupByDir((g) => !g)}
-                    />
-                }
-            />
+                ))}
+            </Box>
         </Box>
     );
 }

--- a/src/webviews/react/commit-panel/components/CommitTab.tsx
+++ b/src/webviews/react/commit-panel/components/CommitTab.tsx
@@ -19,6 +19,7 @@ import { AmendContextSection } from "./AmendContextSection";
 const MIN_REFRESH_FEEDBACK_MS = 700;
 
 interface Props {
+    repositoryRoot?: string;
     files: WorkingFile[];
     folderIcon?: ThemeTreeIcon;
     folderExpandedIcon?: ThemeTreeIcon;
@@ -59,6 +60,7 @@ interface Props {
 // Independent commit workflow flags come from different host state; grouping them would hide intent.
 // react-doctor-disable-next-line react-doctor/no-many-boolean-props
 export function CommitTab({
+    repositoryRoot,
     files,
     folderIcon,
     folderExpandedIcon,
@@ -130,44 +132,61 @@ export function CommitTab({
 
     const handleRefresh = useCallback(() => {
         showRefreshFeedback();
-        vscode.postMessage({ type: "refresh" });
-    }, [showRefreshFeedback, vscode]);
+        vscode.postMessage({ type: "refresh", ...(repositoryRoot ? { repositoryRoot } : {}) });
+    }, [repositoryRoot, showRefreshFeedback, vscode]);
 
     const handleRollback = useCallback(() => {
-        vscode.postMessage({ type: "rollback", paths: Array.from(checkedPaths) });
-    }, [vscode, checkedPaths]);
+        vscode.postMessage({
+            type: "rollback",
+            ...(repositoryRoot ? { repositoryRoot } : {}),
+            paths: Array.from(checkedPaths),
+        });
+    }, [repositoryRoot, vscode, checkedPaths]);
 
     const handleStash = useCallback(() => {
         const selected = Array.from(checkedPaths);
         vscode.postMessage({
             type: "stashSave",
+            ...(repositoryRoot ? { repositoryRoot } : {}),
             paths: selected.length > 0 ? selected : undefined,
         });
-    }, [vscode, checkedPaths]);
+    }, [repositoryRoot, vscode, checkedPaths]);
 
     const handleShowDiff = useCallback(() => {
         const selected = Array.from(checkedPaths);
         if (selected.length > 0) {
-            vscode.postMessage({ type: "showDiff", path: selected[0] });
+            vscode.postMessage({
+                type: "showDiff",
+                ...(repositoryRoot ? { repositoryRoot } : {}),
+                path: selected[0],
+            });
         }
-    }, [vscode, checkedPaths]);
+    }, [repositoryRoot, vscode, checkedPaths]);
 
     const handleAbortMerge = useCallback(() => {
-        vscode.postMessage({ type: "abortMerge" });
-    }, [vscode]);
+        vscode.postMessage({ type: "abortMerge", ...(repositoryRoot ? { repositoryRoot } : {}) });
+    }, [repositoryRoot, vscode]);
 
     const handleFileClick = useCallback(
         (path: string) => {
-            vscode.postMessage({ type: "showDiff", path });
+            vscode.postMessage({
+                type: "showDiff",
+                ...(repositoryRoot ? { repositoryRoot } : {}),
+                path,
+            });
         },
-        [vscode],
+        [repositoryRoot, vscode],
     );
 
     const handleTrackUnversionedFiles = useCallback(
         (paths: string[]) => {
-            vscode.postMessage({ type: "trackUnversionedFiles", paths });
+            vscode.postMessage({
+                type: "trackUnversionedFiles",
+                ...(repositoryRoot ? { repositoryRoot } : {}),
+                paths,
+            });
         },
-        [vscode],
+        [repositoryRoot, vscode],
     );
 
     return (

--- a/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
+++ b/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
@@ -1,0 +1,448 @@
+// Repository row shell for the docked multi-repository commit panel.
+
+import React, { useCallback, useEffect, useRef, useState, type Dispatch } from "react";
+import { Box, Flex, IconButton, Tooltip } from "@chakra-ui/react";
+import { TabBar } from "./TabBar";
+import { CommitTab } from "./CommitTab";
+import { StashTab } from "./StashTab";
+import { useCheckedFiles } from "../hooks/useCheckedFiles";
+import { getVsCodeApi } from "../hooks/useVsCodeApi";
+import { canRunCommitAction } from "../commitEligibility";
+import { getSettings } from "../../shared/settings";
+import { t } from "../../shared/i18n";
+import type { CommitPanelAction, RepositoryCommitPanelState } from "../types";
+
+interface Props {
+    repository: RepositoryCommitPanelState;
+    isExpanded: boolean;
+    isOnlyRepository: boolean;
+    groupByDir: boolean;
+    onToggleExpanded: (root: string) => void;
+    onToggleGroupBy: () => void;
+    dispatch: Dispatch<CommitPanelAction>;
+}
+
+type SavedWebviewState = Record<string, unknown> | undefined;
+
+function savedBooleanByRepository(
+    saved: SavedWebviewState,
+    key: string,
+    repositoryRoot: string,
+): boolean | undefined {
+    const byRepository = saved?.[key];
+    if (!byRepository || typeof byRepository !== "object" || Array.isArray(byRepository)) {
+        return undefined;
+    }
+    const value = (byRepository as Record<string, unknown>)[repositoryRoot];
+    return typeof value === "boolean" ? value : undefined;
+}
+
+function savedShowIgnoredFiles(saved: SavedWebviewState, repositoryRoot: string): boolean {
+    return (
+        savedBooleanByRepository(saved, "showIgnoredFilesByRepository", repositoryRoot) ??
+        saved?.showIgnoredFiles === true
+    );
+}
+
+function savedObjectByRepository(saved: SavedWebviewState, key: string): Record<string, unknown> {
+    const byRepository = saved?.[key];
+    return byRepository && typeof byRepository === "object" && !Array.isArray(byRepository)
+        ? { ...byRepository }
+        : {};
+}
+
+function branchSummary(repository: RepositoryCommitPanelState): string {
+    const parts: string[] = [];
+    if (repository.currentBranchName) {
+        parts.push(
+            repository.currentBranchUpstream
+                ? `${repository.currentBranchName} -> ${repository.currentBranchUpstream}`
+                : repository.currentBranchName,
+        );
+    }
+    const divergence: string[] = [];
+    if (repository.currentBranchAhead > 0) divergence.push(`+${repository.currentBranchAhead}`);
+    if (repository.currentBranchBehind > 0) divergence.push(`-${repository.currentBranchBehind}`);
+    if (divergence.length > 0) parts.push(divergence.join(" "));
+    return parts.join(" | ");
+}
+
+function repositoryScope(root: string): { repositoryRoot?: string } {
+    return root ? { repositoryRoot: root } : {};
+}
+
+/**
+ * Renders one repository accordion row and scopes every outbound row action by root.
+ *
+ * Commit, stash, refresh, draft, amend, and Git transport commands keep the
+ * repository root in their payload so the host can route them to the matching runtime.
+ */
+// This row keeps root-scoped actions next to their matching tab content to avoid indirect routing.
+// react-doctor-disable-next-line react-doctor/no-giant-component
+export function RepositoryAccordion({
+    repository,
+    isExpanded,
+    isOnlyRepository,
+    groupByDir,
+    onToggleExpanded,
+    onToggleGroupBy,
+    dispatch,
+}: Props): React.ReactElement {
+    const vscode = getVsCodeApi();
+    const [showIgnoredFiles, setShowIgnoredFiles] = useState<boolean>(() => {
+        const saved = vscode.getState?.();
+        return savedShowIgnoredFiles(saved, repository.root);
+    });
+    const showIgnoredFilesPostedRef = useRef(false);
+    const { checkedPaths, toggleFile, toggleFolder, toggleSection, isAllChecked, isSomeChecked } =
+        useCheckedFiles(repository.files, repository.root || undefined);
+    const summary = branchSummary(repository);
+    const canCommit = canRunCommitAction(
+        repository.isAmend,
+        checkedPaths.size,
+        repository.commitMessage,
+    );
+    const shouldPublishBranch = !repository.currentBranchHasUpstream;
+    const canPush = shouldPublishBranch
+        ? repository.currentBranchName !== null
+        : repository.currentBranchAhead > 0;
+    const pushLabel = shouldPublishBranch ? "commit.action.publishAndPush" : "common.push";
+
+    useEffect(() => {
+        const prev = vscode.getState?.() ?? {};
+        vscode.setState({
+            ...prev,
+            showIgnoredFilesByRepository: {
+                ...savedObjectByRepository(prev, "showIgnoredFilesByRepository"),
+                [repository.root]: showIgnoredFiles,
+            },
+        });
+    }, [repository.root, showIgnoredFiles, vscode]);
+
+    useEffect(() => {
+        const shouldPost = showIgnoredFilesPostedRef.current || showIgnoredFiles;
+        showIgnoredFilesPostedRef.current = true;
+        if (!shouldPost) return;
+        vscode.postMessage({
+            type: "setShowIgnoredFiles",
+            ...repositoryScope(repository.root),
+            showIgnoredFiles,
+        });
+    }, [repository.root, showIgnoredFiles, vscode]);
+
+    useEffect(() => {
+        if (!isExpanded) return;
+        if (!repository.isAmend) return;
+        if (repository.isRefreshing) return;
+        vscode.postMessage({
+            type: "getAmendBranchCommits",
+            ...repositoryScope(repository.root),
+        });
+    }, [isExpanded, repository.isAmend, repository.isRefreshing, repository.root, vscode]);
+
+    const postRepositoryCommand = useCallback(
+        (type: "sync" | "fetch" | "pull" | "push" | "publishBranch") => {
+            vscode.postMessage({ type, ...repositoryScope(repository.root) });
+        },
+        [repository.root, vscode],
+    );
+
+    const handleMessageChange = useCallback(
+        (message: string) => {
+            dispatch({ type: "SET_COMMIT_MESSAGE", repositoryRoot: repository.root, message });
+            vscode.postMessage({
+                type: "saveCommitDraft",
+                ...repositoryScope(repository.root),
+                message,
+            });
+        },
+        [dispatch, repository.root, vscode],
+    );
+
+    const handleAmendChange = useCallback(
+        (isAmend: boolean) => {
+            dispatch({ type: "SET_AMEND", repositoryRoot: repository.root, isAmend });
+            if (isAmend) {
+                vscode.postMessage({
+                    type: "getLastCommitMessage",
+                    ...repositoryScope(repository.root),
+                });
+            }
+        },
+        [dispatch, repository.root, vscode],
+    );
+
+    const handleCommit = useCallback(() => {
+        vscode.postMessage({
+            type: "commitSelected",
+            ...repositoryScope(repository.root),
+            message: repository.commitMessage.trim(),
+            amend: repository.isAmend,
+            push: false,
+            paths: Array.from(checkedPaths),
+        });
+    }, [checkedPaths, repository.commitMessage, repository.isAmend, repository.root, vscode]);
+
+    const handlePush = useCallback(() => {
+        postRepositoryCommand(shouldPublishBranch ? "publishBranch" : "push");
+    }, [postRepositoryCommand, shouldPublishBranch]);
+
+    const handleToggleShowIgnoredFiles = useCallback(() => {
+        setShowIgnoredFiles((value) => !value);
+    }, []);
+
+    return (
+        <Flex
+            data-testid="repository-accordion"
+            data-repository-root={repository.root}
+            direction="column"
+            flex={isOnlyRepository && isExpanded ? 1 : "0 0 auto"}
+            minH={isOnlyRepository ? 0 : undefined}
+            borderBottom="1px solid var(--intelligit-pycharm-border)"
+        >
+            <Flex
+                as="button"
+                type="button"
+                data-testid="repository-accordion-header"
+                align="center"
+                gap="8px"
+                w="100%"
+                minH="34px"
+                px="8px"
+                py="4px"
+                bg="var(--intelligit-pycharm-header)"
+                color="var(--intelligit-pycharm-foreground)"
+                textAlign="left"
+                onClick={() => onToggleExpanded(repository.root)}
+                aria-expanded={isExpanded}
+            >
+                <Box as="span" w="12px" flexShrink={0} fontSize="12px">
+                    {isExpanded ? "v" : ">"}
+                </Box>
+                <Box as="span" flexShrink={0} fontSize="12px" fontWeight={700}>
+                    {repository.label}
+                </Box>
+                {summary ? (
+                    <Box
+                        as="span"
+                        flex={1}
+                        minW={0}
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                        whiteSpace="nowrap"
+                        color="var(--vscode-descriptionForeground)"
+                        fontSize="11px"
+                    >
+                        {summary}
+                    </Box>
+                ) : (
+                    <Box as="span" flex={1} />
+                )}
+                {repository.isRefreshing ? (
+                    <Box as="span" color="var(--vscode-descriptionForeground)" fontSize="11px">
+                        {t("common.refreshing")}
+                    </Box>
+                ) : null}
+                {repository.error ? (
+                    <Box
+                        as="span"
+                        color="var(--vscode-errorForeground)"
+                        fontSize="12px"
+                        title={repository.error}
+                    >
+                        !
+                    </Box>
+                ) : null}
+                <Box
+                    as="span"
+                    minW="22px"
+                    px="5px"
+                    textAlign="center"
+                    fontSize="11px"
+                    color="var(--vscode-descriptionForeground)"
+                    border="1px solid var(--intelligit-pycharm-border)"
+                    borderRadius="999px"
+                >
+                    {repository.changedFileCount}
+                </Box>
+            </Flex>
+            {isExpanded ? (
+                <Flex
+                    direction="column"
+                    h={isOnlyRepository ? "100%" : "520px"}
+                    minH={isOnlyRepository ? 0 : "360px"}
+                    overflow="hidden"
+                >
+                    <Flex
+                        data-testid="repository-action-toolbar"
+                        align="center"
+                        justify="flex-end"
+                        minH="28px"
+                        px="6px"
+                        bg="var(--intelligit-pycharm-header)"
+                        borderBottom="1px solid var(--intelligit-pycharm-border)"
+                    >
+                        <RepositoryActionButton
+                            label={t("common.sync")}
+                            onClick={() => postRepositoryCommand("sync")}
+                            color="#c8a2ff"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
+                            />
+                        </RepositoryActionButton>
+                        <RepositoryActionButton
+                            label={t("common.fetch")}
+                            onClick={() => postRepositoryCommand("fetch")}
+                            color="#8fd5ff"
+                        >
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="1.3"
+                                d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
+                            />
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="1.3"
+                                d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
+                            />
+                        </RepositoryActionButton>
+                        <RepositoryActionButton
+                            label={t("common.pull")}
+                            onClick={() => postRepositoryCommand("pull")}
+                            color="#8fd5ff"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
+                            />
+                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                        </RepositoryActionButton>
+                        <RepositoryActionButton
+                            label={t("common.push")}
+                            onClick={handlePush}
+                            color="#a6e3a1"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
+                            />
+                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                        </RepositoryActionButton>
+                    </Flex>
+                    <Box flex={1} minH={0} overflow="hidden">
+                        <TabBar
+                            stashCount={repository.stashes.length}
+                            commitContent={
+                                <CommitTab
+                                    repositoryRoot={repository.root || undefined}
+                                    files={repository.files}
+                                    commitMessage={repository.commitMessage}
+                                    isAmend={repository.isAmend}
+                                    amendBranchCommits={repository.amendBranchCommits}
+                                    amendBranchHistoryLoaded={repository.amendBranchHistoryLoaded}
+                                    isRefreshing={repository.isRefreshing}
+                                    checkedPaths={checkedPaths}
+                                    onToggleFile={toggleFile}
+                                    onToggleFolder={toggleFolder}
+                                    onToggleSection={toggleSection}
+                                    isAllChecked={isAllChecked}
+                                    isSomeChecked={isSomeChecked}
+                                    onMessageChange={handleMessageChange}
+                                    onAmendChange={handleAmendChange}
+                                    onCommit={handleCommit}
+                                    canCommit={canCommit}
+                                    onPush={handlePush}
+                                    canPush={canPush}
+                                    pushLabel={pushLabel}
+                                    currentBranchName={repository.currentBranchName}
+                                    currentBranchUpstream={repository.currentBranchUpstream}
+                                    folderIcon={repository.folderIcon}
+                                    folderExpandedIcon={repository.folderExpandedIcon}
+                                    folderIconsByName={repository.folderIconsByName}
+                                    groupByDir={groupByDir}
+                                    showIgnoredFiles={showIgnoredFiles}
+                                    onToggleGroupBy={onToggleGroupBy}
+                                    onToggleShowIgnoredFiles={handleToggleShowIgnoredFiles}
+                                />
+                            }
+                            stashContent={
+                                <StashTab
+                                    repositoryRoot={repository.root || undefined}
+                                    stashes={repository.stashes}
+                                    stashFiles={repository.stashFiles}
+                                    selectedIndex={repository.selectedStashIndex}
+                                    folderIcon={repository.folderIcon}
+                                    folderExpandedIcon={repository.folderExpandedIcon}
+                                    folderIconsByName={repository.folderIconsByName}
+                                    groupByDir={groupByDir}
+                                    onToggleGroupBy={onToggleGroupBy}
+                                />
+                            }
+                        />
+                    </Box>
+                </Flex>
+            ) : null}
+        </Flex>
+    );
+}
+
+function RepositoryActionButton({
+    label,
+    onClick,
+    color,
+    disabled = false,
+    children,
+}: {
+    label: string;
+    onClick: () => void;
+    color: string;
+    disabled?: boolean;
+    children: React.ReactNode;
+}): React.ReactElement {
+    const { hoverDelay, tooltipsEnabled, iconStyle } = getSettings();
+    const resolvedColor = disabled
+        ? "var(--vscode-disabledForeground)"
+        : iconStyle === "standard"
+          ? "var(--vscode-icon-foreground)"
+          : color;
+    return (
+        <Tooltip
+            label={label}
+            fontSize="11px"
+            placement="bottom"
+            openDelay={hoverDelay}
+            isDisabled={!tooltipsEnabled}
+        >
+            <IconButton
+                aria-label={label}
+                aria-disabled={disabled || undefined}
+                isDisabled={disabled}
+                variant="toolbarGhost"
+                size="sm"
+                alignSelf="center"
+                mx="4px"
+                opacity={disabled ? 0.55 : undefined}
+                cursor={disabled ? "default" : undefined}
+                onClick={disabled ? undefined : onClick}
+                icon={
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        style={{ color: resolvedColor }}
+                    >
+                        {children}
+                    </svg>
+                }
+            />
+        </Tooltip>
+    );
+}

--- a/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
+++ b/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
@@ -191,13 +191,75 @@ export function RepositoryAccordion({
         setShowIgnoredFiles((value) => !value);
     }, []);
 
+    const commitContent = (
+        <CommitTab
+            repositoryRoot={repository.root || undefined}
+            files={repository.files}
+            commitMessage={repository.commitMessage}
+            isAmend={repository.isAmend}
+            amendBranchCommits={repository.amendBranchCommits}
+            amendBranchHistoryLoaded={repository.amendBranchHistoryLoaded}
+            isRefreshing={repository.isRefreshing}
+            checkedPaths={checkedPaths}
+            onToggleFile={toggleFile}
+            onToggleFolder={toggleFolder}
+            onToggleSection={toggleSection}
+            isAllChecked={isAllChecked}
+            isSomeChecked={isSomeChecked}
+            onMessageChange={handleMessageChange}
+            onAmendChange={handleAmendChange}
+            onCommit={handleCommit}
+            canCommit={canCommit}
+            onPush={handlePush}
+            canPush={canPush}
+            pushLabel={pushLabel}
+            currentBranchName={repository.currentBranchName}
+            currentBranchUpstream={repository.currentBranchUpstream}
+            folderIcon={repository.folderIcon}
+            folderExpandedIcon={repository.folderExpandedIcon}
+            folderIconsByName={repository.folderIconsByName}
+            groupByDir={groupByDir}
+            showIgnoredFiles={showIgnoredFiles}
+            onToggleGroupBy={onToggleGroupBy}
+            onToggleShowIgnoredFiles={handleToggleShowIgnoredFiles}
+        />
+    );
+    const stashContent = (
+        <StashTab
+            repositoryRoot={repository.root || undefined}
+            stashes={repository.stashes}
+            stashFiles={repository.stashFiles}
+            selectedIndex={repository.selectedStashIndex}
+            folderIcon={repository.folderIcon}
+            folderExpandedIcon={repository.folderExpandedIcon}
+            folderIconsByName={repository.folderIconsByName}
+            groupByDir={groupByDir}
+            onToggleGroupBy={onToggleGroupBy}
+        />
+    );
+
+    if (isOnlyRepository) {
+        return (
+            <Flex direction="column" flex={1} minH={0} overflow="hidden">
+                <TabBar
+                    stashCount={repository.stashes.length}
+                    onSync={() => postRepositoryCommand("sync")}
+                    onFetch={() => postRepositoryCommand("fetch")}
+                    onPull={() => postRepositoryCommand("pull")}
+                    onPush={handlePush}
+                    commitContent={commitContent}
+                    stashContent={stashContent}
+                />
+            </Flex>
+        );
+    }
+
     return (
         <Flex
             data-testid="repository-accordion"
             data-repository-root={repository.root}
             direction="column"
-            flex={isOnlyRepository && isExpanded ? 1 : "0 0 auto"}
-            minH={isOnlyRepository ? 0 : undefined}
+            flex="0 0 auto"
             borderBottom="1px solid var(--intelligit-pycharm-border)"
         >
             <Flex
@@ -340,52 +402,8 @@ export function RepositoryAccordion({
                     <Box flex={1} minH={0} overflow="hidden">
                         <TabBar
                             stashCount={repository.stashes.length}
-                            commitContent={
-                                <CommitTab
-                                    repositoryRoot={repository.root || undefined}
-                                    files={repository.files}
-                                    commitMessage={repository.commitMessage}
-                                    isAmend={repository.isAmend}
-                                    amendBranchCommits={repository.amendBranchCommits}
-                                    amendBranchHistoryLoaded={repository.amendBranchHistoryLoaded}
-                                    isRefreshing={repository.isRefreshing}
-                                    checkedPaths={checkedPaths}
-                                    onToggleFile={toggleFile}
-                                    onToggleFolder={toggleFolder}
-                                    onToggleSection={toggleSection}
-                                    isAllChecked={isAllChecked}
-                                    isSomeChecked={isSomeChecked}
-                                    onMessageChange={handleMessageChange}
-                                    onAmendChange={handleAmendChange}
-                                    onCommit={handleCommit}
-                                    canCommit={canCommit}
-                                    onPush={handlePush}
-                                    canPush={canPush}
-                                    pushLabel={pushLabel}
-                                    currentBranchName={repository.currentBranchName}
-                                    currentBranchUpstream={repository.currentBranchUpstream}
-                                    folderIcon={repository.folderIcon}
-                                    folderExpandedIcon={repository.folderExpandedIcon}
-                                    folderIconsByName={repository.folderIconsByName}
-                                    groupByDir={groupByDir}
-                                    showIgnoredFiles={showIgnoredFiles}
-                                    onToggleGroupBy={onToggleGroupBy}
-                                    onToggleShowIgnoredFiles={handleToggleShowIgnoredFiles}
-                                />
-                            }
-                            stashContent={
-                                <StashTab
-                                    repositoryRoot={repository.root || undefined}
-                                    stashes={repository.stashes}
-                                    stashFiles={repository.stashFiles}
-                                    selectedIndex={repository.selectedStashIndex}
-                                    folderIcon={repository.folderIcon}
-                                    folderExpandedIcon={repository.folderExpandedIcon}
-                                    folderIconsByName={repository.folderIconsByName}
-                                    groupByDir={groupByDir}
-                                    onToggleGroupBy={onToggleGroupBy}
-                                />
-                            }
+                            commitContent={commitContent}
+                            stashContent={stashContent}
                         />
                     </Box>
                 </Flex>

--- a/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
+++ b/src/webviews/react/commit-panel/components/RepositoryAccordion.tsx
@@ -1,14 +1,14 @@
 // Repository row shell for the docked multi-repository commit panel.
 
 import React, { useCallback, useEffect, useRef, useState, type Dispatch } from "react";
-import { Box, Flex, IconButton, Tooltip } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 import { TabBar } from "./TabBar";
 import { CommitTab } from "./CommitTab";
 import { StashTab } from "./StashTab";
 import { useCheckedFiles } from "../hooks/useCheckedFiles";
 import { getVsCodeApi } from "../hooks/useVsCodeApi";
 import { canRunCommitAction } from "../commitEligibility";
-import { getSettings } from "../../shared/settings";
+import { ChevronIcon } from "../../shared/components/Icons";
 import { t } from "../../shared/i18n";
 import type { CommitPanelAction, RepositoryCommitPanelState } from "../types";
 
@@ -278,8 +278,14 @@ export function RepositoryAccordion({
                 onClick={() => onToggleExpanded(repository.root)}
                 aria-expanded={isExpanded}
             >
-                <Box as="span" w="12px" flexShrink={0} fontSize="12px">
-                    {isExpanded ? "v" : ">"}
+                <Box
+                    as="span"
+                    display="inline-flex"
+                    w="16px"
+                    flexShrink={0}
+                    color="var(--vscode-descriptionForeground)"
+                >
+                    <ChevronIcon expanded={isExpanded} />
                 </Box>
                 <Box as="span" flexShrink={0} fontSize="12px" fontWeight={700}>
                     {repository.label}
@@ -335,73 +341,13 @@ export function RepositoryAccordion({
                     minH={isOnlyRepository ? 0 : "360px"}
                     overflow="hidden"
                 >
-                    <Flex
-                        data-testid="repository-action-toolbar"
-                        align="center"
-                        justify="flex-end"
-                        minH="28px"
-                        px="6px"
-                        bg="var(--intelligit-pycharm-header)"
-                        borderBottom="1px solid var(--intelligit-pycharm-border)"
-                    >
-                        <RepositoryActionButton
-                            label={t("common.sync")}
-                            onClick={() => postRepositoryCommand("sync")}
-                            color="#c8a2ff"
-                        >
-                            <path
-                                fill="currentColor"
-                                d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
-                            />
-                        </RepositoryActionButton>
-                        <RepositoryActionButton
-                            label={t("common.fetch")}
-                            onClick={() => postRepositoryCommand("fetch")}
-                            color="#8fd5ff"
-                        >
-                            <path
-                                fill="none"
-                                stroke="currentColor"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth="1.3"
-                                d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
-                            />
-                            <path
-                                fill="none"
-                                stroke="currentColor"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth="1.3"
-                                d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
-                            />
-                        </RepositoryActionButton>
-                        <RepositoryActionButton
-                            label={t("common.pull")}
-                            onClick={() => postRepositoryCommand("pull")}
-                            color="#8fd5ff"
-                        >
-                            <path
-                                fill="currentColor"
-                                d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
-                            />
-                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                        </RepositoryActionButton>
-                        <RepositoryActionButton
-                            label={t("common.push")}
-                            onClick={handlePush}
-                            color="#a6e3a1"
-                        >
-                            <path
-                                fill="currentColor"
-                                d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
-                            />
-                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                        </RepositoryActionButton>
-                    </Flex>
                     <Box flex={1} minH={0} overflow="hidden">
                         <TabBar
                             stashCount={repository.stashes.length}
+                            onSync={() => postRepositoryCommand("sync")}
+                            onFetch={() => postRepositoryCommand("fetch")}
+                            onPull={() => postRepositoryCommand("pull")}
+                            onPush={handlePush}
                             commitContent={commitContent}
                             stashContent={stashContent}
                         />
@@ -409,58 +355,5 @@ export function RepositoryAccordion({
                 </Flex>
             ) : null}
         </Flex>
-    );
-}
-
-function RepositoryActionButton({
-    label,
-    onClick,
-    color,
-    disabled = false,
-    children,
-}: {
-    label: string;
-    onClick: () => void;
-    color: string;
-    disabled?: boolean;
-    children: React.ReactNode;
-}): React.ReactElement {
-    const { hoverDelay, tooltipsEnabled, iconStyle } = getSettings();
-    const resolvedColor = disabled
-        ? "var(--vscode-disabledForeground)"
-        : iconStyle === "standard"
-          ? "var(--vscode-icon-foreground)"
-          : color;
-    return (
-        <Tooltip
-            label={label}
-            fontSize="11px"
-            placement="bottom"
-            openDelay={hoverDelay}
-            isDisabled={!tooltipsEnabled}
-        >
-            <IconButton
-                aria-label={label}
-                aria-disabled={disabled || undefined}
-                isDisabled={disabled}
-                variant="toolbarGhost"
-                size="sm"
-                alignSelf="center"
-                mx="4px"
-                opacity={disabled ? 0.55 : undefined}
-                cursor={disabled ? "default" : undefined}
-                onClick={disabled ? undefined : onClick}
-                icon={
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 16 16"
-                        style={{ color: resolvedColor }}
-                    >
-                        {children}
-                    </svg>
-                }
-            />
-        </Tooltip>
     );
 }

--- a/src/webviews/react/commit-panel/components/StashTab.tsx
+++ b/src/webviews/react/commit-panel/components/StashTab.tsx
@@ -15,6 +15,7 @@ import type { TreeEntry } from "../types";
 import { t } from "../../shared/i18n";
 
 interface Props {
+    repositoryRoot?: string;
     stashes: StashEntry[];
     stashFiles: WorkingFile[];
     selectedIndex: number | null;
@@ -47,6 +48,7 @@ interface ExpandedDirsState {
  * directory expansion, context menu, and drag-to-resize state.
  */
 export function StashTab({
+    repositoryRoot,
     stashes,
     stashFiles,
     selectedIndex,
@@ -102,10 +104,14 @@ export function StashTab({
                 setLocalExpansion(null, false);
             } else {
                 setLocalExpansion(index, true);
-                vscode.postMessage({ type: "stashSelect", index });
+                vscode.postMessage({
+                    type: "stashSelect",
+                    ...(repositoryRoot ? { repositoryRoot } : {}),
+                    index,
+                });
             }
         },
-        [expandedIndex, setLocalExpansion, vscode],
+        [expandedIndex, repositoryRoot, setLocalExpansion, vscode],
     );
 
     const handleStashAction = useCallback(
@@ -113,18 +119,35 @@ export function StashTab({
             if (index === null) return;
             switch (kind) {
                 case "apply":
-                    vscode.postMessage({ type: "stashApply", index });
+                    vscode.postMessage({
+                        type: "stashApply",
+                        ...(repositoryRoot ? { repositoryRoot } : {}),
+                        index,
+                    });
                     return;
                 case "pop":
-                    vscode.postMessage({ type: "stashPop", index });
+                    vscode.postMessage({
+                        type: "stashPop",
+                        ...(repositoryRoot ? { repositoryRoot } : {}),
+                        index,
+                    });
                     return;
                 case "delete":
-                    vscode.postMessage({ type: "stashDelete", index });
+                    vscode.postMessage({
+                        type: "stashDelete",
+                        ...(repositoryRoot ? { repositoryRoot } : {}),
+                        index,
+                    });
                     return;
                 case "showDiff": {
                     const firstFile = selectedIndex === index ? stashFiles[0]?.path : undefined;
                     if (firstFile) {
-                        vscode.postMessage({ type: "showStashDiff", index, path: firstFile });
+                        vscode.postMessage({
+                            type: "showStashDiff",
+                            ...(repositoryRoot ? { repositoryRoot } : {}),
+                            index,
+                            path: firstFile,
+                        });
                     }
                     return;
                 }
@@ -134,7 +157,7 @@ export function StashTab({
                 }
             }
         },
-        [selectedIndex, stashFiles, vscode],
+        [repositoryRoot, selectedIndex, stashFiles, vscode],
     );
 
     const toggleDir = useCallback(
@@ -163,9 +186,14 @@ export function StashTab({
 
     const handleShowStashDiff = useCallback(
         (index: number, path: string) => {
-            vscode.postMessage({ type: "showStashDiff", index, path });
+            vscode.postMessage({
+                type: "showStashDiff",
+                ...(repositoryRoot ? { repositoryRoot } : {}),
+                index,
+                path,
+            });
         },
-        [vscode],
+        [repositoryRoot, vscode],
     );
 
     const handleStashContextMenu = useCallback(
@@ -174,11 +202,15 @@ export function StashTab({
             event.stopPropagation();
             if (expandedIndex !== index) {
                 setLocalExpansion(index, true);
-                vscode.postMessage({ type: "stashSelect", index });
+                vscode.postMessage({
+                    type: "stashSelect",
+                    ...(repositoryRoot ? { repositoryRoot } : {}),
+                    index,
+                });
             }
             setContextMenu({ x: event.clientX, y: event.clientY, index });
         },
-        [expandedIndex, setLocalExpansion, vscode],
+        [expandedIndex, repositoryRoot, setLocalExpansion, vscode],
     );
 
     const [fileTreeHeight, setFileTreeHeight] = useState(150);

--- a/src/webviews/react/commit-panel/components/TabBar.tsx
+++ b/src/webviews/react/commit-panel/components/TabBar.tsx
@@ -17,10 +17,10 @@ import { t } from "../../shared/i18n";
 
 interface Props {
     stashCount: number;
-    onSync: () => void;
-    onFetch: () => void;
-    onPull: () => void;
-    onPush: () => void;
+    onSync?: () => void;
+    onFetch?: () => void;
+    onPull?: () => void;
+    onPush?: () => void;
     commitContent: React.ReactNode;
     stashContent: React.ReactNode;
 }
@@ -46,8 +46,7 @@ const sharedTabStyles = {
  * Hosts the Commit and Stash tab panels with VS Code sidebar styling.
  *
  * Callers provide already-wired panel content, allowing the tab shell to stay
- * presentation-only while still reflecting the current stash count in the stash
- * label.
+ * presentation-only while reflecting the current stash count in the stash label.
  */
 export function TabBar({
     stashCount,
@@ -69,6 +68,8 @@ export function TabBar({
             content: stashContent,
         },
     ];
+    const gitActions =
+        onSync && onFetch && onPull && onPush ? { onSync, onFetch, onPull, onPush } : null;
 
     return (
         <Tabs
@@ -92,46 +93,64 @@ export function TabBar({
                         </Tab>
                     ))}
                 </TabList>
-                <Flex align="center" ml="auto">
-                    <GitActionButton label={t("common.sync")} onClick={onSync} color="#c8a2ff">
-                        <path
-                            fill="currentColor"
-                            d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
-                        />
-                    </GitActionButton>
-                    <GitActionButton label={t("common.fetch")} onClick={onFetch} color="#8fd5ff">
-                        <path
-                            fill="none"
-                            stroke="currentColor"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth="1.3"
-                            d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
-                        />
-                        <path
-                            fill="none"
-                            stroke="currentColor"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth="1.3"
-                            d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
-                        />
-                    </GitActionButton>
-                    <GitActionButton label={t("common.pull")} onClick={onPull} color="#8fd5ff">
-                        <path
-                            fill="currentColor"
-                            d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
-                        />
-                        <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                    </GitActionButton>
-                    <GitActionButton label={t("common.push")} onClick={onPush} color="#a6e3a1">
-                        <path
-                            fill="currentColor"
-                            d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
-                        />
-                        <path fill="currentColor" d="M3 13h10v1H3v-1z" />
-                    </GitActionButton>
-                </Flex>
+                {gitActions ? (
+                    <Flex align="center" ml="auto">
+                        <GitActionButton
+                            label={t("common.sync")}
+                            onClick={gitActions.onSync}
+                            color="#c8a2ff"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M13 2v4H9l1.55-1.55A4.4 4.4 0 0 0 3.9 6.2l-.94-.34A5.4 5.4 0 0 1 11.25 3.75L13 2zM3 14v-4h4l-1.55 1.55A4.4 4.4 0 0 0 12.1 9.8l.94.34a5.4 5.4 0 0 1-8.29 2.11L3 14z"
+                            />
+                        </GitActionButton>
+                        <GitActionButton
+                            label={t("common.fetch")}
+                            onClick={gitActions.onFetch}
+                            color="#8fd5ff"
+                        >
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="1.3"
+                                d="M5 12.5h-.5a2.8 2.8 0 0 1-.35-5.58A4.1 4.1 0 0 1 12 5.8a2.9 2.9 0 0 1 .5 5.7H11"
+                            />
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="1.3"
+                                d="M8 6.7v5.6m-2.1-2L8 12.4l2.1-2.1"
+                            />
+                        </GitActionButton>
+                        <GitActionButton
+                            label={t("common.pull")}
+                            onClick={gitActions.onPull}
+                            color="#8fd5ff"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M7.5 1h1v8.1l2.15-2.15.7.7L8 11 4.65 7.65l.7-.7L7.5 9.1V1z"
+                            />
+                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                        </GitActionButton>
+                        <GitActionButton
+                            label={t("common.push")}
+                            onClick={gitActions.onPush}
+                            color="#a6e3a1"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M8 1l3.35 3.35-.7.7L8.5 2.9V11h-1V2.9L5.35 5.05l-.7-.7L8 1z"
+                            />
+                            <path fill="currentColor" d="M3 13h10v1H3v-1z" />
+                        </GitActionButton>
+                    </Flex>
+                ) : null}
             </Flex>
             <TabPanels flex={1} overflow="hidden" display="flex" flexDirection="column">
                 {tabs.map((tab) => (

--- a/src/webviews/react/commit-panel/hooks/useCheckedFiles.ts
+++ b/src/webviews/react/commit-panel/hooks/useCheckedFiles.ts
@@ -14,12 +14,37 @@ interface CheckedFilesAPI {
     isSomeChecked: (files: WorkingFile[]) => boolean;
 }
 
+type SavedWebviewState = Record<string, unknown> | undefined;
+
 function pruneToKnownPaths(paths: Set<string>, validPaths: Set<string>): Set<string> {
     const next = new Set<string>();
     for (const path of paths) {
         if (validPaths.has(path)) next.add(path);
     }
     return next.size === paths.size ? paths : next;
+}
+
+function stringArray(value: unknown): string[] {
+    return Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === "string")
+        : [];
+}
+
+function savedCheckedPaths(saved: SavedWebviewState, repositoryRoot?: string): string[] {
+    if (repositoryRoot) {
+        const byRepository = saved?.checkedByRepository;
+        if (byRepository && typeof byRepository === "object" && !Array.isArray(byRepository)) {
+            return stringArray((byRepository as Record<string, unknown>)[repositoryRoot]);
+        }
+    }
+    return stringArray(saved?.checked);
+}
+
+function savedCheckedByRepository(saved: SavedWebviewState): Record<string, unknown> {
+    const byRepository = saved?.checkedByRepository;
+    return byRepository && typeof byRepository === "object" && !Array.isArray(byRepository)
+        ? { ...byRepository }
+        : {};
 }
 
 function buildSelectablePathSet(files: WorkingFile[]): Set<string> {
@@ -37,12 +62,11 @@ function buildSelectablePathSet(files: WorkingFile[]): Set<string> {
  * new file snapshot, and toggled by exact path so grouped folders and top-level
  * sections can share the same all-or-none behavior.
  */
-export function useCheckedFiles(allFiles: WorkingFile[]): CheckedFilesAPI {
+export function useCheckedFiles(allFiles: WorkingFile[], repositoryRoot?: string): CheckedFilesAPI {
     const [checkedPaths, setCheckedPaths] = useState<Set<string>>(() => {
         const vscode = getVsCodeApi();
         const saved = vscode.getState();
-        const arr = (saved as { checked?: string[] } | undefined)?.checked;
-        return new Set(arr ?? []);
+        return new Set(savedCheckedPaths(saved, repositoryRoot));
     });
     const validPaths = useMemo(() => buildSelectablePathSet(allFiles), [allFiles]);
     const currentCheckedPaths = useMemo(
@@ -60,8 +84,18 @@ export function useCheckedFiles(allFiles: WorkingFile[]): CheckedFilesAPI {
     useEffect(() => {
         const vscode = getVsCodeApi();
         const prev = vscode.getState() ?? {};
+        if (repositoryRoot) {
+            vscode.setState({
+                ...prev,
+                checkedByRepository: {
+                    ...savedCheckedByRepository(prev),
+                    [repositoryRoot]: Array.from(currentCheckedPaths),
+                },
+            });
+            return;
+        }
         vscode.setState({ ...prev, checked: Array.from(currentCheckedPaths) });
-    }, [currentCheckedPaths]);
+    }, [currentCheckedPaths, repositoryRoot]);
 
     const toggleFile = useCallback(
         (path: string) => {

--- a/src/webviews/react/commit-panel/hooks/useCheckedFiles.ts
+++ b/src/webviews/react/commit-panel/hooks/useCheckedFiles.ts
@@ -75,16 +75,18 @@ export function useCheckedFiles(allFiles: WorkingFile[], repositoryRoot?: string
     );
 
     useEffect(() => {
+        if (repositoryRoot && validPaths.size === 0) return;
         // Host file snapshots invalidate stale selections after render; backing state must be pruned.
         // react-doctor-disable-next-line react-doctor/no-derived-state
         setCheckedPaths((prev) => pruneToKnownPaths(prev, validPaths));
-    }, [validPaths]);
+    }, [repositoryRoot, validPaths]);
 
     // Persist to vscode state on every change (merge to preserve other keys)
     useEffect(() => {
         const vscode = getVsCodeApi();
         const prev = vscode.getState() ?? {};
         if (repositoryRoot) {
+            if (validPaths.size === 0) return;
             vscode.setState({
                 ...prev,
                 checkedByRepository: {
@@ -95,7 +97,7 @@ export function useCheckedFiles(allFiles: WorkingFile[], repositoryRoot?: string
             return;
         }
         vscode.setState({ ...prev, checked: Array.from(currentCheckedPaths) });
-    }, [currentCheckedPaths, repositoryRoot]);
+    }, [currentCheckedPaths, repositoryRoot, validPaths]);
 
     const toggleFile = useCallback(
         (path: string) => {

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -319,7 +319,11 @@ export function useExtensionMessages(): [
                     });
                     break;
                 case "error":
-                    dispatch({ type: "SET_ERROR", message: msg.message });
+                    dispatch({
+                        type: "SET_ERROR",
+                        repositoryRoot: msg.repositoryRoot,
+                        message: msg.message,
+                    });
                     break;
             }
         };

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -101,7 +101,11 @@ function updateRepository(
             : [...state.repositories, nextRepository];
     const activeRepositoryRoot = state.activeRepositoryRoot ?? root;
     const expandedRepositoryRoots =
-        state.expandedRepositoryRoots.length > 0 ? state.expandedRepositoryRoots : [root];
+        state.expandedRepositoryRoots.length > 0
+            ? state.expandedRepositoryRoots
+            : state.repositories.length > 0
+              ? []
+              : [root];
     return { repositories, activeRepositoryRoot, expandedRepositoryRoots };
 }
 

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -1,121 +1,248 @@
-// Listens for messages from the extension host and dispatches actions
-// to a useReducer-based state. Sends "ready" on mount.
+// Message bridge between the VS Code extension host and commit panel React app.
 
-import { useEffect, useReducer } from "react";
+import { useEffect, useReducer, type Dispatch } from "react";
 import { getVsCodeApi } from "./useVsCodeApi";
-import type { CommitPanelState, CommitPanelAction, InboundMessage } from "../types";
+import type {
+    CommitPanelAction,
+    CommitPanelRepositorySummary,
+    InboundMessage,
+    MultiRepositoryCommitPanelState,
+    RepositoryCommitPanelState,
+} from "../types";
+import type { WorkingFile } from "../../../../types";
 
-const initialState: CommitPanelState = {
-    files: [],
-    stashes: [],
-    stashFiles: [],
-    selectedStashIndex: null,
-    folderIcon: undefined,
-    folderExpandedIcon: undefined,
-    folderIconsByName: undefined,
-    iconFonts: [],
-    commitMessage: "",
-    isAmend: false,
-    amendBranchCommits: [],
-    amendBranchHistoryLoaded: false,
-    isRefreshing: false,
-    error: null,
-    currentBranchHasUpstream: true,
-    hasRemotes: true,
-    currentBranchAhead: 0,
-    currentBranchBehind: 0,
-    currentBranchName: null,
-    currentBranchUpstream: null,
+const LEGACY_REPOSITORY_ROOT = "";
+
+function createRepositoryState(
+    root: string,
+    label: string,
+    changedFileCount: number = 0,
+): RepositoryCommitPanelState {
+    return {
+        root,
+        label,
+        changedFileCount,
+        files: [],
+        stashes: [],
+        stashFiles: [],
+        selectedStashIndex: null,
+        folderIcon: undefined,
+        folderExpandedIcon: undefined,
+        folderIconsByName: {},
+        iconFonts: [],
+        commitMessage: "",
+        isAmend: false,
+        amendBranchCommits: [],
+        amendBranchHistoryLoaded: false,
+        isRefreshing: false,
+        error: null,
+        currentBranchHasUpstream: true,
+        hasRemotes: true,
+        currentBranchAhead: 0,
+        currentBranchBehind: 0,
+        currentBranchName: null,
+        currentBranchUpstream: null,
+    };
+}
+
+const initialState: MultiRepositoryCommitPanelState = {
+    repositories: [],
+    activeRepositoryRoot: null,
+    expandedRepositoryRoots: [],
 };
 
-function reducer(state: CommitPanelState, action: CommitPanelAction): CommitPanelState {
+function countChangedFiles(files: WorkingFile[]): number {
+    const paths = new Set<string>();
+    for (const file of files) {
+        if (file.status !== "!") paths.add(file.path);
+    }
+    return paths.size;
+}
+
+function targetRoot(state: MultiRepositoryCommitPanelState, repositoryRoot?: string): string {
+    return (
+        repositoryRoot ??
+        state.activeRepositoryRoot ??
+        state.repositories[0]?.root ??
+        LEGACY_REPOSITORY_ROOT
+    );
+}
+
+function expandedRootsFor(
+    state: MultiRepositoryCommitPanelState,
+    repositories: CommitPanelRepositorySummary[],
+    activeRepositoryRoot: string | null,
+): string[] {
+    const knownRoots = new Set(repositories.map((repository) => repository.root));
+    const retained = state.expandedRepositoryRoots.filter((root) => knownRoots.has(root));
+    if (retained.length > 0) return retained;
+    const fallbackRoot = activeRepositoryRoot ?? repositories[0]?.root;
+    return fallbackRoot ? [fallbackRoot] : [];
+}
+
+function updateRepository(
+    state: MultiRepositoryCommitPanelState,
+    repositoryRoot: string | undefined,
+    update: (repository: RepositoryCommitPanelState) => RepositoryCommitPanelState,
+): MultiRepositoryCommitPanelState {
+    const root = targetRoot(state, repositoryRoot);
+    const index = state.repositories.findIndex((repository) => repository.root === root);
+    const existing =
+        index >= 0
+            ? state.repositories[index]
+            : createRepositoryState(root, root === LEGACY_REPOSITORY_ROOT ? "" : root);
+    const nextRepository = update(existing);
+    const repositories =
+        index >= 0
+            ? state.repositories.map((repository, currentIndex) =>
+                  currentIndex === index ? nextRepository : repository,
+              )
+            : [...state.repositories, nextRepository];
+    const activeRepositoryRoot = state.activeRepositoryRoot ?? root;
+    const expandedRepositoryRoots =
+        state.expandedRepositoryRoots.length > 0 ? state.expandedRepositoryRoots : [root];
+    return { repositories, activeRepositoryRoot, expandedRepositoryRoots };
+}
+
+function updateRepositoryMetadata(
+    repository: RepositoryCommitPanelState,
+    summary: CommitPanelRepositorySummary,
+): RepositoryCommitPanelState {
+    return {
+        ...repository,
+        root: summary.root,
+        label: summary.label,
+        changedFileCount: summary.changedFileCount,
+    };
+}
+
+function reducer(
+    state: MultiRepositoryCommitPanelState,
+    action: CommitPanelAction,
+): MultiRepositoryCommitPanelState {
     switch (action.type) {
-        case "SET_FILES_AND_STASHES":
+        case "SET_REPOSITORIES": {
+            const roots = new Set(action.repositories.map((repository) => repository.root));
+            const activeRepositoryRoot =
+                action.activeRepositoryRoot !== null && roots.has(action.activeRepositoryRoot)
+                    ? action.activeRepositoryRoot
+                    : (action.repositories[0]?.root ?? null);
+            return {
+                repositories: action.repositories.map((summary) => {
+                    const existing = state.repositories.find(
+                        (repository) => repository.root === summary.root,
+                    );
+                    return updateRepositoryMetadata(
+                        existing ?? createRepositoryState(summary.root, summary.label),
+                        summary,
+                    );
+                }),
+                activeRepositoryRoot,
+                expandedRepositoryRoots: expandedRootsFor(
+                    state,
+                    action.repositories,
+                    activeRepositoryRoot,
+                ),
+            };
+        }
+        case "SET_EXPANDED_REPOSITORIES": {
+            const knownRoots = new Set(state.repositories.map((repository) => repository.root));
             return {
                 ...state,
+                expandedRepositoryRoots: action.repositoryRoots.filter((root) =>
+                    knownRoots.has(root),
+                ),
+            };
+        }
+        case "SET_FILES_AND_STASHES":
+            return updateRepository(state, action.repositoryRoot, (repository) => ({
+                ...repository,
+                label: action.repositoryLabel ?? repository.label,
+                changedFileCount: action.changedFileCount ?? countChangedFiles(action.files),
                 files: action.files,
                 stashes: action.stashes,
                 stashFiles: action.stashFiles,
                 selectedStashIndex: action.selectedStashIndex,
-                folderIcon: action.folderIcon ?? state.folderIcon,
-                folderExpandedIcon: action.folderExpandedIcon ?? state.folderExpandedIcon,
-                folderIconsByName: action.folderIconsByName ?? state.folderIconsByName,
-                iconFonts: action.iconFonts ?? state.iconFonts,
+                folderIcon: action.folderIcon ?? repository.folderIcon,
+                folderExpandedIcon: action.folderExpandedIcon ?? repository.folderExpandedIcon,
+                folderIconsByName: action.folderIconsByName ?? repository.folderIconsByName,
+                iconFonts: action.iconFonts ?? repository.iconFonts,
                 currentBranchHasUpstream: action.currentBranchHasUpstream,
-                hasRemotes: action.hasRemotes ?? state.hasRemotes,
+                hasRemotes: action.hasRemotes ?? repository.hasRemotes,
                 currentBranchAhead: action.currentBranchAhead,
                 currentBranchBehind: action.currentBranchBehind,
                 currentBranchName:
                     action.currentBranchName !== undefined
                         ? action.currentBranchName
-                        : state.currentBranchName,
+                        : repository.currentBranchName,
                 currentBranchUpstream:
                     action.currentBranchUpstream !== undefined
                         ? action.currentBranchUpstream
-                        : state.currentBranchUpstream,
-                error: null,
-            };
+                        : repository.currentBranchUpstream,
+                isRefreshing: action.refreshing ?? repository.isRefreshing,
+                error: action.error ?? null,
+            }));
         case "SET_REFRESHING":
-            if (action.active && state.isAmend) {
-                return {
-                    ...state,
-                    isRefreshing: true,
-                    amendBranchCommits: [],
-                    amendBranchHistoryLoaded: false,
-                };
-            }
-            return { ...state, isRefreshing: action.active };
+            return updateRepository(state, action.repositoryRoot, (repository) => {
+                if (action.active && repository.isAmend) {
+                    return {
+                        ...repository,
+                        isRefreshing: true,
+                        amendBranchCommits: [],
+                        amendBranchHistoryLoaded: false,
+                    };
+                }
+                return { ...repository, isRefreshing: action.active };
+            });
         case "RESTORE_COMMIT_DRAFT":
-            return { ...state, commitMessage: action.message };
         case "SET_LAST_COMMIT_MESSAGE":
-            return { ...state, commitMessage: action.message };
+        case "SET_COMMIT_MESSAGE":
+            return updateRepository(state, action.repositoryRoot, (repository) => ({
+                ...repository,
+                commitMessage: action.message,
+            }));
         case "COMMITTED":
-            return {
-                ...state,
+            return updateRepository(state, action.repositoryRoot, (repository) => ({
+                ...repository,
                 commitMessage: "",
                 isAmend: false,
                 amendBranchCommits: [],
                 amendBranchHistoryLoaded: false,
-            };
+            }));
         case "SET_ERROR":
-            return { ...state, error: action.message };
-        case "SET_COMMIT_MESSAGE":
-            return { ...state, commitMessage: action.message };
+            return updateRepository(state, action.repositoryRoot, (repository) => ({
+                ...repository,
+                error: action.message,
+            }));
         case "SET_AMEND":
-            if (action.isAmend) {
-                return {
-                    ...state,
-                    isAmend: true,
-                    amendBranchCommits: [],
-                    amendBranchHistoryLoaded: false,
-                };
-            }
-            return {
-                ...state,
-                isAmend: false,
+            return updateRepository(state, action.repositoryRoot, (repository) => ({
+                ...repository,
+                isAmend: action.isAmend,
                 amendBranchCommits: [],
                 amendBranchHistoryLoaded: false,
-            };
+            }));
         case "SET_AMEND_BRANCH_COMMITS":
-            if (!state.isAmend) {
-                return state;
-            }
-            return {
-                ...state,
-                amendBranchCommits: action.commits,
-                amendBranchHistoryLoaded: true,
-            };
+            return updateRepository(state, action.repositoryRoot, (repository) => {
+                if (!repository.isAmend) return repository;
+                return {
+                    ...repository,
+                    amendBranchCommits: action.commits,
+                    amendBranchHistoryLoaded: true,
+                };
+            });
     }
 }
 
 /**
- * Connects the commit-panel reducer to extension-host webview messages.
+ * Subscribes to extension-host commit-panel messages and exposes reducer state.
  *
- * The hook sends the initial `ready` message on mount, applies host snapshots to
- * local reducer state, and ignores late amend-history payloads once amend mode is
- * no longer active.
+ * Host snapshots are merged by repository root. Rootless messages target the
+ * active repository so the docked panel remains compatible with older producers.
  */
-export function useExtensionMessages(): [CommitPanelState, React.Dispatch<CommitPanelAction>] {
+export function useExtensionMessages(): [
+    MultiRepositoryCommitPanelState,
+    Dispatch<CommitPanelAction>,
+] {
     const [state, dispatch] = useReducer(reducer, initialState);
 
     useEffect(() => {
@@ -124,9 +251,19 @@ export function useExtensionMessages(): [CommitPanelState, React.Dispatch<Commit
         const handler = (event: MessageEvent<InboundMessage>) => {
             const msg = event.data;
             switch (msg.type) {
+                case "setRepositories":
+                    dispatch({
+                        type: "SET_REPOSITORIES",
+                        repositories: msg.repositories,
+                        activeRepositoryRoot: msg.activeRepositoryRoot,
+                    });
+                    break;
                 case "update":
                     dispatch({
                         type: "SET_FILES_AND_STASHES",
+                        repositoryRoot: msg.repositoryRoot,
+                        repositoryLabel: msg.repositoryLabel,
+                        changedFileCount: msg.changedFileCount,
                         files: msg.files,
                         stashes: msg.stashes,
                         stashFiles: msg.stashFiles,
@@ -141,22 +278,40 @@ export function useExtensionMessages(): [CommitPanelState, React.Dispatch<Commit
                         currentBranchBehind: msg.currentBranchBehind ?? 0,
                         currentBranchName: msg.currentBranchName,
                         currentBranchUpstream: msg.currentBranchUpstream,
+                        refreshing: msg.refreshing,
+                        error: msg.error,
                     });
                     break;
                 case "restoreCommitDraft":
-                    dispatch({ type: "RESTORE_COMMIT_DRAFT", message: msg.message });
+                    dispatch({
+                        type: "RESTORE_COMMIT_DRAFT",
+                        repositoryRoot: msg.repositoryRoot,
+                        message: msg.message,
+                    });
                     break;
                 case "lastCommitMessage":
-                    dispatch({ type: "SET_LAST_COMMIT_MESSAGE", message: msg.message });
+                    dispatch({
+                        type: "SET_LAST_COMMIT_MESSAGE",
+                        repositoryRoot: msg.repositoryRoot,
+                        message: msg.message,
+                    });
                     break;
                 case "amendBranchCommits":
-                    dispatch({ type: "SET_AMEND_BRANCH_COMMITS", commits: msg.commits });
+                    dispatch({
+                        type: "SET_AMEND_BRANCH_COMMITS",
+                        repositoryRoot: msg.repositoryRoot,
+                        commits: msg.commits,
+                    });
                     break;
                 case "committed":
-                    dispatch({ type: "COMMITTED" });
+                    dispatch({ type: "COMMITTED", repositoryRoot: msg.repositoryRoot });
                     break;
                 case "refreshing":
-                    dispatch({ type: "SET_REFRESHING", active: msg.active });
+                    dispatch({
+                        type: "SET_REFRESHING",
+                        repositoryRoot: msg.repositoryRoot,
+                        active: msg.active,
+                    });
                     break;
                 case "error":
                     dispatch({ type: "SET_ERROR", message: msg.message });

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -76,6 +76,7 @@ function expandedRootsFor(
     const knownRoots = new Set(repositories.map((repository) => repository.root));
     const retained = state.expandedRepositoryRoots.filter((root) => knownRoots.has(root));
     if (retained.length > 0) return retained;
+    if (state.repositories.length > 0) return [];
     const fallbackRoot = activeRepositoryRoot ?? repositories[0]?.root;
     return fallbackRoot ? [fallbackRoot] : [];
 }

--- a/src/webviews/react/commit-panel/types.ts
+++ b/src/webviews/react/commit-panel/types.ts
@@ -23,7 +23,7 @@ export type { InboundMessage, OutboundMessage } from "../../protocol/commitPanel
  * refresh state so UI interactions can stay responsive while host messages are
  * in flight.
  */
-export interface CommitPanelState {
+interface CommitPanelState {
     files: WorkingFile[];
     stashes: StashEntry[];
     stashFiles: WorkingFile[];
@@ -47,6 +47,27 @@ export interface CommitPanelState {
     currentBranchUpstream: string | null;
 }
 
+/** Summary row supplied by the extension host for a known Git repository. */
+export interface CommitPanelRepositorySummary {
+    root: string;
+    label: string;
+    changedFileCount: number;
+}
+
+/** Commit-panel state for one repository row in the docked multi-repository view. */
+export interface RepositoryCommitPanelState extends CommitPanelState {
+    root: string;
+    label: string;
+    changedFileCount: number;
+}
+
+/** Root commit-panel state keyed by repository root. */
+export interface MultiRepositoryCommitPanelState {
+    repositories: RepositoryCommitPanelState[];
+    activeRepositoryRoot: string | null;
+    expandedRepositoryRoots: string[];
+}
+
 /**
  * Actions dispatched by host messages and commit-panel UI events.
  *
@@ -56,7 +77,16 @@ export interface CommitPanelState {
  */
 export type CommitPanelAction =
     | {
+          type: "SET_REPOSITORIES";
+          repositories: CommitPanelRepositorySummary[];
+          activeRepositoryRoot: string | null;
+      }
+    | { type: "SET_EXPANDED_REPOSITORIES"; repositoryRoots: string[] }
+    | {
           type: "SET_FILES_AND_STASHES";
+          repositoryRoot?: string;
+          repositoryLabel?: string;
+          changedFileCount?: number;
           files: WorkingFile[];
           stashes: StashEntry[];
           stashFiles: WorkingFile[];
@@ -71,15 +101,21 @@ export type CommitPanelAction =
           currentBranchBehind: number;
           currentBranchName?: string | null;
           currentBranchUpstream?: string | null;
+          refreshing?: boolean;
+          error?: string | null;
       }
-    | { type: "RESTORE_COMMIT_DRAFT"; message: string }
-    | { type: "SET_LAST_COMMIT_MESSAGE"; message: string }
-    | { type: "COMMITTED" }
-    | { type: "SET_REFRESHING"; active: boolean }
-    | { type: "SET_ERROR"; message: string }
-    | { type: "SET_COMMIT_MESSAGE"; message: string }
-    | { type: "SET_AMEND"; isAmend: boolean }
-    | { type: "SET_AMEND_BRANCH_COMMITS"; commits: AmendBranchCommitSummary[] };
+    | { type: "RESTORE_COMMIT_DRAFT"; repositoryRoot?: string; message: string }
+    | { type: "SET_LAST_COMMIT_MESSAGE"; repositoryRoot?: string; message: string }
+    | { type: "COMMITTED"; repositoryRoot?: string }
+    | { type: "SET_REFRESHING"; repositoryRoot?: string; active: boolean }
+    | { type: "SET_ERROR"; repositoryRoot?: string; message: string }
+    | { type: "SET_COMMIT_MESSAGE"; repositoryRoot?: string; message: string }
+    | { type: "SET_AMEND"; repositoryRoot?: string; isAmend: boolean }
+    | {
+          type: "SET_AMEND_BRANCH_COMMITS";
+          repositoryRoot?: string;
+          commits: AmendBranchCommitSummary[];
+      };
 
 /**
  * Directory node used by grouped commit-panel file trees.

--- a/src/webviews/react/undocked/RepositoryColumn.tsx
+++ b/src/webviews/react/undocked/RepositoryColumn.tsx
@@ -1,0 +1,86 @@
+// Far-left repository selector for the undocked multi-repository view.
+
+import React from "react";
+import { Box } from "@chakra-ui/react";
+import type { RepositoryViewIdentity } from "../../protocol/undockedMessages";
+
+interface RepositoryColumnProps {
+    repositories: RepositoryViewIdentity[];
+    selectedRepositoryRoot: string | null;
+    onSelectRepository: (root: string) => void;
+}
+
+/**
+ * Renders known repositories as a fixed selector column.
+ *
+ * The column never moves with the commit-panel side setting; it only emits roots
+ * that came from host repository hydration.
+ */
+export function RepositoryColumn({
+    repositories,
+    selectedRepositoryRoot,
+    onSelectRepository,
+}: RepositoryColumnProps): React.ReactElement {
+    return (
+        <Box
+            data-testid="undocked-repository-section"
+            width="168px"
+            flexShrink={0}
+            overflowY="auto"
+            overflowX="hidden"
+            bg="var(--vscode-sideBar-background)"
+            borderRight="1px solid var(--vscode-panel-border)"
+        >
+            {repositories.map((repository) => {
+                const isSelected = repository.root === selectedRepositoryRoot;
+                return (
+                    <Box
+                        as="button"
+                        type="button"
+                        key={repository.root}
+                        data-testid="undocked-repository-row"
+                        data-repository-root={repository.root}
+                        aria-current={isSelected ? "true" : undefined}
+                        title={repository.root}
+                        width="100%"
+                        minH="32px"
+                        px="8px"
+                        py="5px"
+                        border={0}
+                        borderBottom="1px solid var(--vscode-panel-border)"
+                        bg={
+                            isSelected
+                                ? "var(--vscode-list-activeSelectionBackground)"
+                                : "transparent"
+                        }
+                        color={
+                            isSelected
+                                ? "var(--vscode-list-activeSelectionForeground)"
+                                : "var(--vscode-sideBar-foreground)"
+                        }
+                        textAlign="left"
+                        cursor="pointer"
+                        onClick={() => onSelectRepository(repository.root)}
+                        _hover={{
+                            bg: isSelected
+                                ? "var(--vscode-list-activeSelectionBackground)"
+                                : "var(--vscode-list-hoverBackground)",
+                        }}
+                    >
+                        <Box
+                            as="span"
+                            display="block"
+                            overflow="hidden"
+                            textOverflow="ellipsis"
+                            whiteSpace="nowrap"
+                            fontSize="12px"
+                            fontWeight={isSelected ? 700 : 500}
+                        >
+                            {repository.label}
+                        </Box>
+                    </Box>
+                );
+            })}
+        </Box>
+    );
+}

--- a/src/webviews/react/undocked/UndockedLayout.tsx
+++ b/src/webviews/react/undocked/UndockedLayout.tsx
@@ -15,6 +15,7 @@ import type {
     WorkingFile,
 } from "../../../types";
 import type { BranchAction, CommitAction, WorktreeAction } from "../../protocol/commitGraphTypes";
+import type { RepositoryViewIdentity } from "../../protocol/undockedMessages";
 import { BranchColumn } from "../BranchColumn";
 import { CommitList } from "../CommitList";
 import { CommitInfoPane } from "../commit-info/CommitInfoPane";
@@ -22,6 +23,7 @@ import theme from "../commit-panel/theme";
 import { t } from "../shared/i18n";
 import { ThemeIconFontFaces } from "../shared/components/ThemeIconFontFaces";
 import { CommitPanelPane } from "./CommitPanelPane";
+import { RepositoryColumn } from "./RepositoryColumn";
 import { UndockedHeader } from "./UndockedHeader";
 import type { CommitChecksValue, CommitPanelState } from "./commitPanelState";
 
@@ -40,6 +42,8 @@ export interface UndockedLayoutProps {
     branchWidth: number;
     graphWidth: number;
     infoWidth: number;
+    repositories: RepositoryViewIdentity[];
+    selectedRepositoryRoot: string | null;
     branches: Branch[];
     worktrees: GitWorktree[];
     selectedBranch: string | null;
@@ -76,6 +80,7 @@ export interface UndockedLayoutProps {
     onGraphDividerKeyDown: (e: React.KeyboardEvent) => void;
     onRightCommitPanelDividerMouseDown: (e: React.MouseEvent) => void;
     onRightCommitPanelDividerKeyDown: (e: React.KeyboardEvent) => void;
+    handleSelectRepository: (repositoryRoot: string) => void;
     handleSelectCommit: (hash: string) => void;
     handleFilterText: (text: string) => void;
     handleLoadMore: () => void;
@@ -118,6 +123,8 @@ export function UndockedLayout(props: UndockedLayoutProps): React.ReactElement {
         branchWidth,
         graphWidth,
         infoWidth,
+        repositories,
+        selectedRepositoryRoot,
         branches,
         worktrees,
         selectedBranch,
@@ -154,6 +161,7 @@ export function UndockedLayout(props: UndockedLayoutProps): React.ReactElement {
         onGraphDividerKeyDown,
         onRightCommitPanelDividerMouseDown,
         onRightCommitPanelDividerKeyDown,
+        handleSelectRepository,
         handleSelectCommit,
         handleFilterText,
         handleLoadMore,
@@ -187,6 +195,12 @@ export function UndockedLayout(props: UndockedLayoutProps): React.ReactElement {
             <Box display="flex" height="100vh" overflow="hidden" flexDirection="column">
                 <UndockedHeader onDock={onDock} />
                 <Box ref={layoutRef} display="flex" flex={1} overflow="hidden" minHeight={0}>
+                    <RepositoryColumn
+                        repositories={repositories}
+                        selectedRepositoryRoot={selectedRepositoryRoot}
+                        onSelectRepository={handleSelectRepository}
+                    />
+
                     {/* Divider and commit panel — only on left side */}
                     {commitPanelPosition === "left" && (
                         <>

--- a/src/webviews/react/undocked/commitPanelState.ts
+++ b/src/webviews/react/undocked/commitPanelState.ts
@@ -17,6 +17,7 @@ export type CommitChecksValue = CommitChecksSnapshot | "loading";
 
 /** Reducer action for graph state owned by the undocked app shell. */
 export type GraphAction =
+    | { type: "resetRepository" }
     | {
           type: "loadCommits";
           commits: Commit[];
@@ -81,6 +82,7 @@ export interface CommitPanelState {
 
 /** Reducer actions emitted by unified undocked messages and local commit-panel controls. */
 export type CommitPanelAction =
+    | { type: "RESET_REPOSITORY" }
     | {
           type: "SET_FILES_AND_STASHES";
           files: WorkingFile[];
@@ -140,6 +142,8 @@ export function commitPanelReducer(
     action: CommitPanelAction,
 ): CommitPanelState {
     switch (action.type) {
+        case "RESET_REPOSITORY":
+            return initialCommitPanelState;
         case "SET_FILES_AND_STASHES":
             return {
                 ...state,

--- a/src/webviews/react/undocked/useUndockedActions.ts
+++ b/src/webviews/react/undocked/useUndockedActions.ts
@@ -34,6 +34,7 @@ export interface UseUndockedActionsParams {
 
 /** Callback set consumed by the undocked layout and child panes. */
 export interface UndockedActions {
+    handleSelectRepository: (repositoryRoot: string) => void;
     handleSelectCommit: (hash: string) => void;
     handleFilterText: (text: string) => void;
     handleLoadMore: () => void;
@@ -72,6 +73,14 @@ export function useUndockedActions(params: UseUndockedActionsParams): UndockedAc
         checkedPaths,
         shouldPublishBranch,
     } = params;
+
+    const handleSelectRepository = useCallback((repositoryRoot: string) => {
+        loadingMore.current = false;
+        graphDispatch({ type: "resetRepository" });
+        cpDispatch({ type: "RESET_REPOSITORY" });
+        vscode.postMessage({ type: "selectRepository", repositoryRoot });
+        // react-doctor-disable-next-line react-doctor/exhaustive-deps
+    }, []);
 
     const handleSelectCommit = useCallback((hash: string) => {
         graphDispatch({ type: "selectCommit", hash });
@@ -186,6 +195,7 @@ export function useUndockedActions(params: UseUndockedActionsParams): UndockedAc
     }, []);
 
     return {
+        handleSelectRepository,
         handleSelectCommit,
         handleFilterText,
         handleLoadMore,

--- a/src/webviews/react/undocked/useUnifiedMessages.ts
+++ b/src/webviews/react/undocked/useUnifiedMessages.ts
@@ -6,7 +6,11 @@
 
 import { useEffect, useRef } from "react";
 import type React from "react";
-import type { UnifiedInbound, UnifiedOutbound } from "../../protocol/undockedMessages";
+import type {
+    RepositoryViewIdentity,
+    UnifiedInbound,
+    UnifiedOutbound,
+} from "../../protocol/undockedMessages";
 import { getVsCodeApi } from "../shared/vscodeApi";
 import { normalizeSectionWidths, type SectionWidths } from "./sectionWidths";
 import type { CommitPanelAction, GraphAction } from "./commitPanelState";
@@ -24,6 +28,9 @@ export interface UseUnifiedMessagesParams {
     cpDispatch: React.Dispatch<CommitPanelAction>;
     loadingMore: React.MutableRefObject<boolean>;
     selectedHash: string | null;
+    selectedRepositoryRoot: string | null;
+    setRepositories: (repositories: RepositoryViewIdentity[]) => void;
+    setSelectedRepositoryRoot: (root: string) => void;
     markWidthsHydrated: () => void;
     setSectionWidths: (next: SectionWidths) => void;
     layoutRef: React.MutableRefObject<HTMLDivElement | null>;
@@ -41,6 +48,9 @@ export function useUnifiedMessages(params: UseUnifiedMessagesParams): void {
         cpDispatch,
         loadingMore,
         selectedHash,
+        selectedRepositoryRoot,
+        setRepositories,
+        setSelectedRepositoryRoot,
         markWidthsHydrated,
         setSectionWidths,
         layoutRef,
@@ -48,12 +58,28 @@ export function useUnifiedMessages(params: UseUnifiedMessagesParams): void {
     } = params;
     const selectedHashRef = useRef<string | null>(selectedHash);
     selectedHashRef.current = selectedHash;
+    const selectedRepositoryRootRef = useRef<string | null>(selectedRepositoryRoot);
+    selectedRepositoryRootRef.current = selectedRepositoryRoot;
 
     useEffect(() => {
         const handler = (event: MessageEvent<UnifiedInbound>) => {
             const data = event.data;
 
             switch (data.type) {
+                case "repositories": {
+                    const previousRoot = selectedRepositoryRootRef.current;
+                    setRepositories(data.repositories);
+                    setSelectedRepositoryRoot(data.selectedRepositoryRoot);
+                    if (previousRoot !== data.selectedRepositoryRoot) {
+                        selectedRepositoryRootRef.current = data.selectedRepositoryRoot;
+                        selectedHashRef.current = null;
+                        loadingMore.current = false;
+                        graphDispatch({ type: "resetRepository" });
+                        cpDispatch({ type: "RESET_REPOSITORY" });
+                    }
+                    return;
+                }
+
                 // --- Graph-side messages ---
                 case "loadCommits":
                     loadingMore.current = false;

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -52,6 +52,8 @@ const registerWebviewPanelSerializer = vi.fn(() => ({ dispose: vi.fn() }));
 const registerTextDocumentContentProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const createTerminal = vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() }));
 const textDocListeners: Array<() => void> = [];
+const activeTextEditorListeners: Array<(editor?: { document: { uri: unknown } }) => void> = [];
+let activeTextEditor: { document: { uri: unknown } } | undefined;
 const closeDocListeners: Array<
     (document: { uri: { scheme: string; toString: () => string } }) => void
 > = [];
@@ -527,6 +529,15 @@ vi.mock("vscode", () => ({
     window: {
         registerWebviewViewProvider,
         registerWebviewPanelSerializer,
+        get activeTextEditor() {
+            return activeTextEditor;
+        },
+        onDidChangeActiveTextEditor: vi.fn(
+            (listener: (editor?: { document: { uri: unknown } }) => void) => {
+                activeTextEditorListeners.push(listener);
+                return { dispose: vi.fn() };
+            },
+        ),
         createTreeView: vi.fn((id: string) => {
             const view: MockTreeView = {
                 badge: initialTreeViewBadges.get(id),
@@ -823,6 +834,8 @@ describe("extension integration", () => {
         registeredCommands.clear();
         mockDisposables.length = 0;
         textDocListeners.length = 0;
+        activeTextEditorListeners.length = 0;
+        activeTextEditor = undefined;
         closeDocListeners.length = 0;
         saveDocListeners.length = 0;
         createFileListeners.length = 0;

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -306,6 +306,7 @@ class MockCommitGraphViewProvider {
     refresh = vi.fn(async () => undefined);
     clearChecksCache = vi.fn();
     filterByBranch = vi.fn(async () => undefined);
+    resetFilters = vi.fn();
     setCommitDetail = vi.fn();
     clearCommitDetail = vi.fn();
     setRepositoryLabel = vi.fn();
@@ -2984,6 +2985,20 @@ describe("extension integration", () => {
             );
             expect(latestCommitPanelProvider!.refresh).toHaveBeenCalled();
             expect(latestCommitGraphProvider!.refresh).toHaveBeenCalled();
+            expect(latestCommitGraphProvider!.resetFilters).toHaveBeenCalled();
+            expect(latestSidebarGraphProvider!.resetFilters).toHaveBeenCalled();
+
+            showQuickPick.mockImplementationOnce(async (items: unknown[]) => items[0]);
+            await registeredCommands.get("intelligit.selectRepository")?.();
+
+            expect(context.workspaceState?.update).toHaveBeenCalledWith(
+                SELECTED_REPOSITORY_KEY,
+                firstRepo,
+            );
+            expect(latestCommitGraphProvider!.setRepositoryLabel).toHaveBeenCalledWith("app-a");
+            expect(latestCommitPanelProvider!.setRepositoryRootUri).toHaveBeenCalledWith(
+                expect.objectContaining({ fsPath: firstRepo }),
+            );
         } finally {
             await fs.rm(workspace, { recursive: true, force: true });
         }

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -382,6 +382,7 @@ class MockCommitPanelViewProvider {
     refreshSilent = vi.fn(async () => {
         await commitPanelRefreshHook?.(this);
     });
+    setRepositories = vi.fn();
     setRepositoryRootUri = vi.fn();
     setRepositoryLabel = vi.fn();
     setBranches = vi.fn();

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -310,6 +310,7 @@ class MockCommitGraphViewProvider {
     setCommitDetail = vi.fn();
     clearCommitDetail = vi.fn();
     setRepositoryLabel = vi.fn();
+    setShowRepositoryLabel = vi.fn();
     dispose = vi.fn();
 
     /** Emits commit selection from the mocked graph provider. */
@@ -873,6 +874,7 @@ describe("extension integration", () => {
         );
         executorRun.mockImplementation(defaultExecutorRunImpl);
         gitOpsState.isRepository.mockResolvedValue(true);
+        gitOpsState.getRepositoryRoot.mockResolvedValue("/repo");
         gitOpsState.getBranches.mockResolvedValue([
             {
                 name: "main",
@@ -1000,7 +1002,7 @@ describe("extension integration", () => {
     });
 
     it("activates onboarding with initialize action outside the graph view when a workspace is not a Git repository", async () => {
-        gitOpsState.isRepository.mockResolvedValue(false);
+        gitOpsState.getRepositoryRoot.mockRejectedValue(new Error("not a repository"));
         const { activate } = await import("../../../src/extension");
         const context = {
             extensionUri: { fsPath: "/ext", path: "/ext" },
@@ -1025,7 +1027,10 @@ describe("extension integration", () => {
 
     it("initializes Git in an uninitialized workspace and activates repository views without reload", async () => {
         let initialized = false;
-        gitOpsState.isRepository.mockImplementation(async () => initialized);
+        gitOpsState.getRepositoryRoot.mockImplementation(async () => {
+            if (!initialized) throw new Error("not a repository");
+            return "/repo";
+        });
         executorRun.mockImplementation(async (args: string[]) => {
             if (args[0] === "init") {
                 initialized = true;
@@ -1043,7 +1048,7 @@ describe("extension integration", () => {
         await registeredCommands.get("intelligit.initializeRepository")?.();
 
         expect(executorRun).toHaveBeenCalledWith(["init"]);
-        expect(gitOpsState.isRepository).toHaveBeenCalledTimes(2);
+        expect(gitOpsState.getRepositoryRoot).toHaveBeenCalledTimes(2);
         expect(showInformationMessage).toHaveBeenCalledWith("Repository initialized.");
         expect(executeCommandFallback).not.toHaveBeenCalledWith("workbench.action.reloadWindow");
         expect(latestCommitGraphProvider).toBeDefined();

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -53,6 +53,7 @@ const registerTextDocumentContentProvider = vi.fn(() => ({ dispose: vi.fn() }));
 const createTerminal = vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() }));
 const textDocListeners: Array<() => void> = [];
 const activeTextEditorListeners: Array<(editor?: { document: { uri: unknown } }) => void> = [];
+const workspaceFolderListeners: Array<() => Promise<void> | void> = [];
 let activeTextEditor: { document: { uri: unknown } } | undefined;
 const closeDocListeners: Array<
     (document: { uri: { scheme: string; toString: () => string } }) => void
@@ -451,6 +452,7 @@ class MockUndockedViewProvider {
     onDidDispose = this.disposeEmitter.event;
     setRepositoryLabel = vi.fn();
     setRepositoryRootUri = vi.fn();
+    setRepositories = vi.fn();
     setBranches = vi.fn();
     setCommitDetail = vi.fn();
     open = vi.fn(async () => undefined);
@@ -595,6 +597,10 @@ vi.mock("vscode", () => ({
             update: configurationUpdate,
         })),
         onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidChangeWorkspaceFolders: vi.fn((listener: () => Promise<void> | void) => {
+            workspaceFolderListeners.push(listener);
+            return { dispose: vi.fn() };
+        }),
         fs: { writeFile },
         openTextDocument,
         registerTextDocumentContentProvider,
@@ -836,6 +842,7 @@ describe("extension integration", () => {
         mockDisposables.length = 0;
         textDocListeners.length = 0;
         activeTextEditorListeners.length = 0;
+        workspaceFolderListeners.length = 0;
         activeTextEditor = undefined;
         closeDocListeners.length = 0;
         saveDocListeners.length = 0;

--- a/tests/integration/extension/extension.integration.test.ts
+++ b/tests/integration/extension/extension.integration.test.ts
@@ -2941,6 +2941,7 @@ describe("extension integration", () => {
     });
 
     it("switches the active repository from the selector", async () => {
+        const { SELECTED_REPOSITORY_KEY } = await import("../../../src/activation/common");
         const { activate } = await import("../../../src/extension");
         const workspace = await fs.realpath(
             await fs.mkdtemp(path.join(os.tmpdir(), "intelligit-workspace-")),
@@ -2960,10 +2961,15 @@ describe("extension integration", () => {
             const context = {
                 extensionUri: { fsPath: "/ext", path: "/ext" },
                 subscriptions: [],
+                workspaceState: createWorkspaceState(),
             } as unknown as MockExtensionContext;
             await activate(context);
             await registeredCommands.get("intelligit.selectRepository")?.();
 
+            expect(context.workspaceState?.update).toHaveBeenCalledWith(
+                SELECTED_REPOSITORY_KEY,
+                secondRepo,
+            );
             expect(latestCommitGraphProvider!.setRepositoryLabel).toHaveBeenCalledWith("app-b");
             expect(latestCommitPanelProvider!.setRepositoryRootUri).toHaveBeenCalledWith(
                 expect.objectContaining({ fsPath: secondRepo }),

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -790,6 +790,19 @@ describe("view providers integration", () => {
             } as never,
         );
         expect(activeTextEditorListeners).toHaveLength(1);
+        expect(registeredCommands.has("intelligit.sidebarRepositoryIndicator")).toBe(true);
+        expect(registeredCommands.has("intelligit.sidebarRepositoryIndicator.color")).toBe(true);
+        expect(
+            await registeredCommands.get("intelligit.sidebarRepositoryIndicator")!(),
+        ).toBeUndefined();
+        expect(
+            await registeredCommands.get("intelligit.sidebarRepositoryIndicator.color")!(),
+        ).toBeUndefined();
+        expect(executeCommand).toHaveBeenCalledWith(
+            "setContext",
+            "intelligit.hasMultipleRepositories",
+            true,
+        );
         expect(captured.commitPanel!.repositories).toEqual([
             { root: repoA, label: "workspace" },
             { root: repoB, label: "app" },
@@ -839,6 +852,26 @@ describe("view providers integration", () => {
         expect(captured.commitPanel!.expandedRepositoryRoots.has(repoA)).toBe(true);
         expect(captured.commitPanel!.runtimes.has(repoA)).toBe(true);
         expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
+    });
+
+    it("clears the multi-repository context for single-repository activation", async () => {
+        const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
+
+        await activateRepositoryMode(
+            {
+                extensionUri: vscodeMock.Uri.file("/ext"),
+                subscriptions: [],
+                workspaceState: createMemento(),
+                secrets: {},
+            } as never,
+            [{ root: "/workspace", label: "workspace" }],
+        );
+
+        expect(executeCommand).toHaveBeenCalledWith(
+            "setContext",
+            "intelligit.hasMultipleRepositories",
+            false,
+        );
     });
 
     it("workspace folder changes refresh repository rows and fall back when the active repository disappears", async () => {
@@ -1626,6 +1659,50 @@ describe("view providers integration", () => {
         expect(lastCommitChecksSnapshot()).toEqual(expect.objectContaining({ state: "success" }));
         expect(providerGetChecks).toHaveBeenCalledTimes(2);
         provider.dispose();
+    });
+
+    it("CommitGraphViewProvider shows repository labels in the sidebar graph description only when enabled", async () => {
+        const { CommitGraphViewProvider } =
+            await import("../../../src/views/CommitGraphViewProvider");
+        const sidebarProvider = new CommitGraphViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            makeGitOpsMock() as unknown as object,
+            makeCredentialStore() as unknown as object,
+            {
+                scriptFile: "webview-compactcommitgraph.js",
+                title: "Graph",
+                showRepositoryLabel: true,
+            },
+        );
+        const sidebarWebview = createWebviewView();
+
+        sidebarProvider.setRepositoryLabel("repo-a");
+        sidebarProvider.resolveWebviewView(
+            sidebarWebview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        expect(sidebarWebview.view.description).toBe("repo-a");
+        await sidebarWebview.send({ type: "ready" });
+
+        sidebarProvider.setRepositoryLabel("repo-b");
+        expect(sidebarWebview.view.description).toBe("repo-b");
+
+        const fullGraphProvider = new CommitGraphViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            makeGitOpsMock() as unknown as object,
+            makeCredentialStore() as unknown as object,
+            { title: "Graph" },
+        );
+        const fullGraphWebview = createWebviewView();
+
+        fullGraphProvider.resolveWebviewView(
+            fullGraphWebview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        fullGraphProvider.setRepositoryLabel("repo-a");
+        expect(fullGraphWebview.view.description).toBeUndefined();
     });
 
     it("CommitGraphViewProvider handles webview events and refresh/load flows", async () => {

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -75,6 +75,39 @@ function createMemento(initial: Record<string, unknown> = {}) {
     };
 }
 
+function createControlledMemento(initial: Record<string, unknown> = {}) {
+    const store = new Map<string, unknown>(Object.entries(initial));
+    const pendingUpdates: Array<{
+        key: string;
+        value: unknown | undefined;
+        resolved?: boolean;
+        resolve: () => void;
+    }> = [];
+    return {
+        memento: {
+            get: vi.fn((key: string) => store.get(key)),
+            update: vi.fn(
+                (key: string, value: unknown | undefined) =>
+                    new Promise<void>((resolve) => {
+                        pendingUpdates.push({
+                            key,
+                            value,
+                            resolve: () => {
+                                if (value === undefined) {
+                                    store.delete(key);
+                                } else {
+                                    store.set(key, value);
+                                }
+                                resolve();
+                            },
+                        });
+                    }),
+            ),
+        },
+        pendingUpdates,
+    };
+}
+
 const vscodeMock = {
     EventEmitter: FakeEventEmitter,
     TreeItem: FakeTreeItem,
@@ -194,27 +227,51 @@ const providerGetChecks = vi.hoisted(() => vi.fn());
 // the GitLab path (GitHub matches first), so this stays uninvoked there.
 const httpGetJsonSpy = vi.hoisted(() => vi.fn());
 const gitExecutorSetRoot = vi.hoisted(() => vi.fn());
+const activeGitRoot = vi.hoisted(() => ({ value: "" }));
+const deferBranchRefreshes = vi.hoisted(() => ({ active: false }));
+const branchRefreshControls = vi.hoisted(
+    () =>
+        [] as Array<{
+            root: string;
+            resolved?: boolean;
+            resolve: (branches: unknown[]) => void;
+        }>,
+);
+const makeBranchesForRoot = vi.hoisted(
+    () => (root: string) => [
+        {
+            name: `branch-${root.split(/[\\/]/).pop() ?? root}`,
+            hash: "abc1234",
+            isRemote: false,
+            isCurrent: true,
+            upstream: "origin/main",
+            ahead: 0,
+            behind: 0,
+        },
+    ],
+);
 
 vi.mock("vscode", () => vscodeMock);
 vi.mock("../../../src/git/executor", () => ({
     GitExecutor: class {
-        constructor(public readonly root: string) {}
-        setRoot = gitExecutorSetRoot;
+        constructor(public readonly root: string) {
+            activeGitRoot.value = root;
+        }
+        setRoot = vi.fn((root: string) => {
+            activeGitRoot.value = root;
+            gitExecutorSetRoot(root);
+        });
     },
 }));
 vi.mock("../../../src/git/operations", () => ({
     GitOps: class {
-        getBranches = vi.fn(async () => [
-            {
-                name: "main",
-                hash: "abc1234",
-                isRemote: false,
-                isCurrent: true,
-                upstream: "origin/main",
-                ahead: 0,
-                behind: 0,
-            },
-        ]);
+        getBranches = vi.fn(async () => {
+            const root = activeGitRoot.value;
+            if (!deferBranchRefreshes.active) return makeBranchesForRoot(root);
+            return new Promise<unknown[]>((resolve) => {
+                branchRefreshControls.push({ root, resolve });
+            });
+        });
         getLog = vi.fn(async () => []);
         getRemotes = vi.fn(async () => ["origin"]);
         getRemoteUrl = vi.fn(async () => "https://github.com/owner/repo.git");
@@ -517,6 +574,9 @@ describe("view providers integration", () => {
         registeredCommands.clear();
         activeTextEditorListeners.length = 0;
         activeTextEditor = undefined;
+        activeGitRoot.value = "";
+        deferBranchRefreshes.active = false;
+        branchRefreshControls.length = 0;
         workspaceState.workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         showWarningMessage.mockResolvedValue(undefined);
         providerGetChecks.mockImplementation(async (hash: string) => ({
@@ -591,6 +651,99 @@ describe("view providers integration", () => {
         expect(sidebarGraphLabelSpy).toHaveBeenCalledWith("app");
         expect(commitPanelRootSpy).toHaveBeenCalledWith(expect.objectContaining({ fsPath: repoB }));
         expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
+    });
+
+    it("keeps the latest active-editor repository when earlier refreshes finish last", async () => {
+        const { SELECTED_REPOSITORY_KEY } = await import("../../../src/activation/common");
+        const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
+        const initialRepo = "/workspace/app-c";
+        const repoA = "/workspace/app-a";
+        const repoB = "/workspace/app-b";
+        const captured: {
+            commitGraph?: { setBranches: (branches: unknown[], worktrees: unknown[]) => void };
+            commitPanel?: { setRepositoryRootUri: (uri: { fsPath: string }) => void };
+        } = {};
+        const controlledWorkspaceStore = createControlledMemento();
+        const context = {
+            extensionUri: vscodeMock.Uri.file("/ext"),
+            subscriptions: [],
+            workspaceState: controlledWorkspaceStore.memento,
+            secrets: {},
+        };
+
+        await activateRepositoryMode(
+            context as never,
+            [
+                { root: initialRepo, label: "app-c" },
+                { root: repoA, label: "app-a" },
+                { root: repoB, label: "app-b" },
+            ],
+            {
+                commitGraph: {
+                    setProvider: (provider: unknown) => (captured.commitGraph = provider as never),
+                },
+                commitPanel: {
+                    setProvider: (provider: unknown) => (captured.commitPanel = provider as never),
+                },
+            } as never,
+        );
+
+        const commitGraphBranchesSpy = vi.spyOn(captured.commitGraph!, "setBranches");
+        const commitPanelRootSpy = vi.spyOn(captured.commitPanel!, "setRepositoryRootUri");
+        deferBranchRefreshes.active = true;
+        const resolvePendingUpdatesFor = async (root: string): Promise<void> => {
+            let resolvedAny = true;
+            while (resolvedAny) {
+                resolvedAny = false;
+                for (const update of controlledWorkspaceStore.pendingUpdates.filter(
+                    (candidate) => !candidate.resolved && candidate.value === root,
+                )) {
+                    update.resolved = true;
+                    update.resolve();
+                    resolvedAny = true;
+                }
+                await flushMicrotasks();
+            }
+        };
+        const resolveBranchRefreshesFor = async (root: string): Promise<void> => {
+            let resolvedAny = true;
+            while (resolvedAny) {
+                resolvedAny = false;
+                for (const control of branchRefreshControls.filter(
+                    (candidate) => !candidate.resolved && candidate.root === root,
+                )) {
+                    control.resolved = true;
+                    control.resolve(makeBranchesForRoot(root));
+                    resolvedAny = true;
+                }
+                await flushMicrotasks();
+            }
+        };
+
+        activeTextEditorListeners.forEach((listener) =>
+            listener({ document: { uri: vscodeMock.Uri.file(`${repoA}/src/a.ts`) } }),
+        );
+        await flushMicrotasks();
+
+        activeTextEditorListeners.forEach((listener) =>
+            listener({ document: { uri: vscodeMock.Uri.file(`${repoB}/src/b.ts`) } }),
+        );
+        await flushMicrotasks();
+
+        await resolvePendingUpdatesFor(repoB);
+        await resolveBranchRefreshesFor(repoB);
+        await flushMicrotasks();
+        await resolvePendingUpdatesFor(repoB);
+        await resolvePendingUpdatesFor(repoA);
+        await resolveBranchRefreshesFor(repoA);
+        await resolvePendingUpdatesFor(repoA);
+
+        const latestBranches = commitGraphBranchesSpy.mock.calls.at(-1)?.[0] as
+            | Array<{ name: string }>
+            | undefined;
+        expect(commitPanelRootSpy).toHaveBeenLastCalledWith(expect.objectContaining({ fsPath: repoB }));
+        expect(latestBranches?.[0]?.name).toBe("branch-app-b");
+        expect(controlledWorkspaceStore.memento.get(SELECTED_REPOSITORY_KEY)).toBe(repoB);
     });
 
     it("OnboardingViewProvider renders clone and open-folder actions when no workspace is open", async () => {

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -623,6 +623,9 @@ describe("view providers integration", () => {
             commitGraph?: { setRepositoryLabel: (label: string) => void };
             sidebarGraph?: { setRepositoryLabel: (label: string) => void };
             commitPanel?: {
+                activeRepositoryRoot: string | null;
+                repositories: Array<{ root: string; label: string }>;
+                runtimes: Map<string, unknown>;
                 setRepositoryLabel: (label: string) => void;
                 setRepositoryRootUri: (uri: { fsPath: string }) => void;
             };
@@ -653,6 +656,13 @@ describe("view providers integration", () => {
             } as never,
         );
         expect(activeTextEditorListeners).toHaveLength(1);
+        expect(captured.commitPanel!.repositories).toEqual([
+            { root: repoA, label: "workspace" },
+            { root: repoB, label: "app" },
+        ]);
+        expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoA);
+        expect(captured.commitPanel!.runtimes.has(repoA)).toBe(true);
+        expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
 
         const commitGraphLabelSpy = vi.spyOn(captured.commitGraph!, "setRepositoryLabel");
         const sidebarGraphLabelSpy = vi.spyOn(captured.sidebarGraph!, "setRepositoryLabel");
@@ -679,6 +689,9 @@ describe("view providers integration", () => {
         expect(sidebarGraphLabelSpy).toHaveBeenCalledWith("app");
         expect(commitPanelRootSpy).toHaveBeenCalledWith(expect.objectContaining({ fsPath: repoB }));
         expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
+        expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoB);
+        expect(captured.commitPanel!.runtimes.has(repoA)).toBe(true);
+        expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
     });
 
     it("registers startup active-editor repository watchers once", async () => {
@@ -1779,6 +1792,32 @@ describe("view providers integration", () => {
             type: "error",
             message: "Unknown repository root received from webview.",
         });
+        provider.dispose();
+    });
+
+    it("Unknown repository openCommitFileDiff is rejected before firing the graph event", async () => {
+        const { provider, webview } = await setupCommitPanelProvider();
+        const openCommitFileDiff = vi.fn();
+        const disposable = provider.onOpenCommitFileDiff(openCommitFileDiff);
+        showErrorMessage.mockClear();
+        postMessageSpy.mockClear();
+
+        await webview.send({
+            type: "openCommitFileDiff",
+            repositoryRoot: "/unknown",
+            commitHash: "abc1234",
+            filePath: "src/a.ts",
+        });
+
+        expect(openCommitFileDiff).not.toHaveBeenCalled();
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            "Unknown repository root received from webview.",
+        );
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "error",
+            message: "Unknown repository root received from webview.",
+        });
+        disposable.dispose();
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -237,6 +237,14 @@ const branchRefreshControls = vi.hoisted(
             resolve: (branches: unknown[]) => void;
         }>,
 );
+const refreshServiceInstances = vi.hoisted(
+    () =>
+        [] as Array<{
+            root: string;
+            registerFileWatchers: ReturnType<typeof vi.fn>;
+            dispose: ReturnType<typeof vi.fn>;
+        }>,
+);
 const makeBranchesForRoot = vi.hoisted(
     () => (root: string) => [
         {
@@ -291,6 +299,9 @@ vi.mock("../../../src/services/worktreeService", () => ({
 }));
 vi.mock("../../../src/views/RefreshService", () => ({
     RefreshService: class {
+        constructor(_deps: unknown, public readonly root: string) {
+            refreshServiceInstances.push(this);
+        }
         refreshMergeConflicts = vi.fn(async () => undefined);
         refreshConflictUi = vi.fn(async () => undefined);
         refreshAll = vi.fn(async () => undefined);
@@ -577,6 +588,7 @@ describe("view providers integration", () => {
         activeGitRoot.value = "";
         deferBranchRefreshes.active = false;
         branchRefreshControls.length = 0;
+        refreshServiceInstances.length = 0;
         workspaceState.workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         showWarningMessage.mockResolvedValue(undefined);
         providerGetChecks.mockImplementation(async (hash: string) => ({
@@ -653,6 +665,34 @@ describe("view providers integration", () => {
         expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
     });
 
+    it("registers startup active-editor repository watchers once", async () => {
+        const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
+        const repoA = "/workspace/app-a";
+        const repoB = "/workspace/app-b";
+        activeTextEditor = {
+            document: { uri: vscodeMock.Uri.file(`${repoB}/src/file.ts`) },
+        };
+
+        await activateRepositoryMode(
+            {
+                extensionUri: vscodeMock.Uri.file("/ext"),
+                subscriptions: [],
+                workspaceState: createMemento(),
+                secrets: {},
+            } as never,
+            [
+                { root: repoA, label: "app-a" },
+                { root: repoB, label: "app-b" },
+            ],
+        );
+
+        const repoBRefreshServices = refreshServiceInstances.filter(
+            (instance) => instance.root === repoB,
+        );
+        expect(repoBRefreshServices).toHaveLength(1);
+        expect(repoBRefreshServices[0].registerFileWatchers).toHaveBeenCalledTimes(1);
+    });
+
     it("keeps the latest active-editor repository when earlier refreshes finish last", async () => {
         const { SELECTED_REPOSITORY_KEY } = await import("../../../src/activation/common");
         const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
@@ -724,19 +764,22 @@ describe("view providers integration", () => {
             listener({ document: { uri: vscodeMock.Uri.file(`${repoA}/src/a.ts`) } }),
         );
         await flushMicrotasks();
+        await resolveBranchRefreshesFor(repoA);
+        expect(
+            controlledWorkspaceStore.pendingUpdates.some(
+                (update) => !update.resolved && update.value === repoA,
+            ),
+        ).toBe(true);
 
         activeTextEditorListeners.forEach((listener) =>
             listener({ document: { uri: vscodeMock.Uri.file(`${repoB}/src/b.ts`) } }),
         );
         await flushMicrotasks();
 
-        await resolvePendingUpdatesFor(repoB);
         await resolveBranchRefreshesFor(repoB);
-        await flushMicrotasks();
         await resolvePendingUpdatesFor(repoB);
         await resolvePendingUpdatesFor(repoA);
-        await resolveBranchRefreshesFor(repoA);
-        await resolvePendingUpdatesFor(repoA);
+        await resolvePendingUpdatesFor(repoB);
 
         const latestBranches = commitGraphBranchesSpy.mock.calls.at(-1)?.[0] as
             | Array<{ name: string }>

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -327,9 +327,9 @@ const makeBranchesForRoot = vi.hoisted(() => (root: string) => [
 
 vi.mock("vscode", () => vscodeMock);
 vi.mock("../../../src/services/repositoryDiscovery", async () => {
-    const actual = await vi.importActual<typeof import("../../../src/services/repositoryDiscovery")>(
-        "../../../src/services/repositoryDiscovery",
-    );
+    const actual = await vi.importActual<
+        typeof import("../../../src/services/repositoryDiscovery")
+    >("../../../src/services/repositoryDiscovery");
     return {
         ...actual,
         discoverGitRepositories: discoverGitRepositoriesSpy,
@@ -1397,6 +1397,153 @@ describe("view providers integration", () => {
         expect(deleteFileWithFallback).toHaveBeenCalledWith(gitOps, expect.any(Object), "src/a.ts");
         expect(workingTreeEvents.length).toBeGreaterThanOrEqual(9);
         expect(fileCounts.length).toBeGreaterThan(0);
+    });
+
+    it("UndockedViewProvider hydrates and switches repositories through its own runtime root", async () => {
+        const { UndockedViewProvider } = await import("../../../src/views/UndockedViewProvider");
+        const executor = {
+            root: "/repo-a",
+            setRoot: vi.fn((root: string) => {
+                executor.root = root;
+            }),
+        };
+        const callRoots: string[] = [];
+        const gitOps = makeGitOpsMock();
+        gitOps.getBranches = vi.fn(async () => {
+            callRoots.push(`branches:${executor.root}`);
+            return makeBranchesForRoot(executor.root);
+        });
+        gitOps.getLog = vi.fn(async () => {
+            callRoots.push(`log:${executor.root}`);
+            return [];
+        });
+        gitOps.getUnpushedCommitHashes = vi.fn(async () => {
+            callRoots.push(`unpushed:${executor.root}`);
+            return [];
+        });
+        gitOps.getStatus = vi.fn(async () => {
+            callRoots.push(`status:${executor.root}`);
+            return [];
+        });
+        gitOps.getRemotes = vi.fn(async () => {
+            callRoots.push(`remotes:${executor.root}`);
+            return ["origin"];
+        });
+        gitOps.listStashes = vi.fn(async () => {
+            callRoots.push(`stashes:${executor.root}`);
+            return [];
+        });
+        const workspaceStore = createMemento({ "commitDraft:/repo-a": "draft A" });
+        const provider = new UndockedViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+            { fsPath: "/repo-a", path: "/repo-a" } as unknown as { fsPath: string; path: string },
+            makeCredentialStore() as unknown as object,
+            workspaceStore as unknown as object,
+            {},
+            undefined,
+            {
+                executor,
+                repositories: [
+                    { root: "/repo-a", label: "Repo A" },
+                    { root: "/repo-b", label: "Repo B" },
+                ],
+                selectedRepositoryRoot: "/repo-a",
+                loadRepositoryData: async () => ({
+                    branches: await gitOps.getBranches(),
+                    worktrees: [],
+                }),
+                onSelectedRepositoryRootChanged: async (root: string) => {
+                    await workspaceStore.update("intelligit.undockedSelectedRepositoryRoot", root);
+                },
+            },
+        );
+        const testProvider = provider as unknown as {
+            panel: {
+                webview: { postMessage: typeof postMessageSpy };
+                dispose: ReturnType<typeof vi.fn>;
+            };
+            iconTheme: {
+                initIconThemeData: ReturnType<typeof vi.fn>;
+                getFolderIconsByBranches: ReturnType<typeof vi.fn>;
+                getThemeData: ReturnType<typeof vi.fn>;
+                decorateWorkingFiles: ReturnType<typeof vi.fn>;
+                getFolderIconsByWorkingFiles: ReturnType<typeof vi.fn>;
+                decorateCommitDetailWithFolderIcons: ReturnType<typeof vi.fn>;
+                dispose: ReturnType<typeof vi.fn>;
+            };
+            handleMessage: (msg: unknown) => Promise<void>;
+        };
+        testProvider.panel = {
+            webview: { postMessage: postMessageSpy },
+            dispose: vi.fn(),
+        };
+        testProvider.iconTheme = {
+            initIconThemeData: vi.fn(async () => undefined),
+            getFolderIconsByBranches: vi.fn(async () => ({})),
+            getThemeData: vi.fn(() => ({
+                folderIcons: { folderIcon: "folder", folderExpandedIcon: "folder-open" },
+                iconFonts: [],
+            })),
+            decorateWorkingFiles: vi.fn(async (files: unknown) => files),
+            getFolderIconsByWorkingFiles: vi.fn(async () => ({})),
+            decorateCommitDetailWithFolderIcons: vi.fn(async (detail: unknown) => ({
+                detail,
+                folderIconsByName: {},
+            })),
+            dispose: vi.fn(),
+        };
+        const send = (msg: unknown) => testProvider.handleMessage.call(provider, msg);
+
+        postMessageSpy.mockClear();
+        await send({ type: "ready" });
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "repositories",
+            repositories: [
+                { root: "/repo-a", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            selectedRepositoryRoot: "/repo-a",
+        });
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "restoreCommitDraft",
+            message: "draft A",
+        });
+
+        postMessageSpy.mockClear();
+        callRoots.length = 0;
+        await send({ type: "selectRepository", repositoryRoot: "/repo-b" });
+
+        expect(executor.setRoot).toHaveBeenCalledWith("/repo-b");
+        expect(workspaceStore.update).toHaveBeenCalledWith(
+            "intelligit.undockedSelectedRepositoryRoot",
+            "/repo-b",
+        );
+        expect(callRoots).toEqual(
+            expect.arrayContaining(["branches:/repo-b", "log:/repo-b", "status:/repo-b"]),
+        );
+        expect(callRoots).not.toEqual(expect.arrayContaining(["log:/repo-a", "status:/repo-a"]));
+        const restoreMessages = postMessageSpy.mock.calls
+            .map(([message]) => message)
+            .filter(
+                (message): message is { type: "restoreCommitDraft"; message: string } =>
+                    typeof message === "object" &&
+                    message !== null &&
+                    "type" in message &&
+                    message.type === "restoreCommitDraft",
+            );
+        expect(restoreMessages.at(-1)).toEqual({ type: "restoreCommitDraft", message: "" });
+        expect(restoreMessages).not.toContainEqual({
+            type: "restoreCommitDraft",
+            message: "draft A",
+        });
+
+        executor.setRoot.mockClear();
+        await expect(
+            send({ type: "selectRepository", repositoryRoot: "/missing" }),
+        ).rejects.toThrow("Unknown repository root received from webview.");
+        expect(executor.setRoot).not.toHaveBeenCalled();
+        provider.dispose();
     });
 
     it("UndockedViewProvider drops stale commit-check replies after cache scope changes", async () => {

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -507,6 +507,14 @@ function makeCredentialStoreWithToken(token: string) {
     };
 }
 
+function makeSecretStorage() {
+    return {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+    };
+}
+
 async function flushVisibleRefresh<T>(promise: Promise<T>): Promise<T> {
     await vi.advanceTimersByTimeAsync(1_000);
     return promise;
@@ -564,6 +572,7 @@ function lastCommitChecksSnapshot():
 
 async function setupCommitPanelProvider(
     configure?: (gitOps: ReturnType<typeof makeGitOpsMock>) => void,
+    options: { secrets?: ReturnType<typeof makeSecretStorage> } = {},
 ) {
     const { CommitPanelViewProvider } = await import("../../../src/views/CommitPanelViewProvider");
     const gitOps = makeGitOpsMock();
@@ -574,6 +583,7 @@ async function setupCommitPanelProvider(
         gitOps as unknown as object,
         { fsPath: "/repo", path: "/repo" } as unknown as { fsPath: string; path: string },
         draftStore as unknown as object,
+        options.secrets as unknown as object,
     );
     const webview = createWebviewView();
     provider.resolveWebviewView(
@@ -1702,6 +1712,55 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
+    it("CommitPanelViewProvider repository runtimes preserve hydrated roots when active root changes", async () => {
+        const { CommitPanelViewProvider } =
+            await import("../../../src/views/CommitPanelViewProvider");
+        const provider = new CommitPanelViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            makeGitOpsMock() as unknown as object,
+            { fsPath: "/repo", path: "/repo" } as unknown as { fsPath: string; path: string },
+            createMemento() as unknown as object,
+        );
+        const webview = createWebviewView();
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        const repoA = { root: "/repo-a", label: "Repo A" };
+        const repoB = { root: "/repo-b", label: "Repo B" };
+        provider.setRepositories([repoA, repoB], repoA.root);
+        const testProvider = provider as unknown as {
+            activeRepositoryRoot: string | null;
+            runtimes: Map<string, unknown>;
+        };
+        const runtimeA = testProvider.runtimes.get(repoA.root);
+        const runtimeB = testProvider.runtimes.get(repoB.root);
+        expect(runtimeA).toBeDefined();
+        expect(runtimeB).toBeDefined();
+        postMessageSpy.mockClear();
+
+        provider.setRepositoryRootUri({ fsPath: repoB.root, path: repoB.root } as unknown as {
+            fsPath: string;
+            path: string;
+        });
+
+        expect(testProvider.runtimes.get(repoA.root)).toBe(runtimeA);
+        expect(testProvider.runtimes.get(repoB.root)).toBe(runtimeB);
+        expect(testProvider.activeRepositoryRoot).toBe(repoB.root);
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "restoreCommitDraft",
+            repositoryRoot: repoB.root,
+            message: "",
+        });
+        expect(postMessageSpy).toHaveBeenLastCalledWith({
+            type: "setRepositories",
+            repositories: [repoA, repoB],
+            activeRepositoryRoot: repoB.root,
+        });
+        provider.dispose();
+    });
+
     it("Unknown repository showDiff is rejected before Git or git.openChange", async () => {
         const { provider, gitOps, webview } = await setupCommitPanelProvider();
         gitOps.getStatus.mockClear();
@@ -1759,6 +1818,7 @@ describe("view providers integration", () => {
         expect(postMessageSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: "update",
+                repositoryRoot: "/repo-b",
                 files: [expect.objectContaining({ path: "src/b.ts" })],
             }),
         );
@@ -1776,8 +1836,65 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
-    it("CommitPanelViewProvider repository runtimes route scoped publishBranch through selected runtime", async () => {
+    it("CommitPanelViewProvider repository runtimes skip graph refresh for non-active scoped actions", async () => {
+        vi.useFakeTimers();
         const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getStatus.mockResolvedValue([
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        gitOps.getLog.mockClear();
+        repoBGitOps.fetch.mockClear();
+        repoBGitOps.getStatus.mockClear();
+        repoBGitOps.listStashes.mockClear();
+        repoBGitOps.getLog.mockClear();
+        postMessageSpy.mockClear();
+
+        try {
+            const fetch = webview.send({ type: "fetch", repositoryRoot: "/repo-b" });
+            await vi.advanceTimersByTimeAsync(1_000);
+            await fetch;
+        } finally {
+            vi.useRealTimers();
+        }
+
+        expect(repoBGitOps.fetch).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
+        expect(repoBGitOps.listStashes).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getLog).not.toHaveBeenCalled();
+        expect(gitOps.getLog).not.toHaveBeenCalled();
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "update",
+                repositoryRoot: "/repo-b",
+                files: [expect.objectContaining({ path: "src/b.ts" })],
+            }),
+        );
+        expect(postMessageSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: "loadCommits" }),
+        );
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes route scoped publishBranch through selected runtime", async () => {
+        const secrets = makeSecretStorage();
+        const { provider, gitOps, webview } = await setupCommitPanelProvider(undefined, {
+            secrets,
+        });
         const repoBGitOps = makeGitOpsMock();
         repoBGitOps.getBranches.mockResolvedValue([
             {
@@ -1820,6 +1937,7 @@ describe("view providers integration", () => {
             repoBGitOps,
             "feature-b",
             "/repo-b",
+            secrets,
         );
         expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
         provider.dispose();
@@ -1874,6 +1992,7 @@ describe("view providers integration", () => {
             repoBGitOps,
             "feature-b",
             "/repo-b",
+            undefined,
         );
         expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
         provider.dispose();
@@ -1928,6 +2047,7 @@ describe("view providers integration", () => {
             repoBGitOps,
             "feature-b",
             "/repo-b",
+            undefined,
         );
         expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
         provider.dispose();
@@ -2282,7 +2402,7 @@ describe("view providers integration", () => {
                 currentBranchHasUpstream: false,
             }),
         );
-        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(gitOps, "main", "/repo");
+        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(gitOps, "main", "/repo", undefined);
         expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
         provider.dispose();
     });
@@ -2328,6 +2448,7 @@ describe("view providers integration", () => {
         await webview.send({ type: "getLastCommitMessage" });
         expect(postMessageSpy).toHaveBeenCalledWith({
             type: "lastCommitMessage",
+            repositoryRoot: "/repo",
             message: "last message",
         });
 
@@ -2335,6 +2456,7 @@ describe("view providers integration", () => {
         expect(gitOps.getAmendBranchCommits).toHaveBeenCalled();
         expect(postMessageSpy).toHaveBeenCalledWith({
             type: "amendBranchCommits",
+            repositoryRoot: "/repo",
             commits: [
                 { shortHash: "abc1234", subject: "feat: amend ctx", date: "2026-02-19T00:00:00Z" },
             ],
@@ -2364,6 +2486,7 @@ describe("view providers integration", () => {
 
         expect(postMessageSpy).toHaveBeenCalledWith({
             type: "restoreCommitDraft",
+            repositoryRoot: "/repo",
             message: "draft from storage",
         });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -37,6 +37,56 @@ class FakeThemeColor {
     constructor(public readonly id: string) {}
 }
 
+class FakeRelativePattern {
+    constructor(
+        public readonly baseUri: { fsPath?: string; path?: string },
+        public readonly pattern: string,
+    ) {}
+}
+
+class FakeFileSystemWatcher {
+    private changeListeners: Array<(uri: { fsPath: string; path: string }) => void> = [];
+    private createListeners: Array<(uri: { fsPath: string; path: string }) => void> = [];
+    private deleteListeners: Array<(uri: { fsPath: string; path: string }) => void> = [];
+    dispose = vi.fn();
+
+    constructor(public readonly pattern: unknown) {}
+
+    onDidChange = vi.fn((listener: (uri: { fsPath: string; path: string }) => void) => {
+        this.changeListeners.push(listener);
+        return { dispose: vi.fn(() => this.removeListener(this.changeListeners, listener)) };
+    });
+
+    onDidCreate = vi.fn((listener: (uri: { fsPath: string; path: string }) => void) => {
+        this.createListeners.push(listener);
+        return { dispose: vi.fn(() => this.removeListener(this.createListeners, listener)) };
+    });
+
+    onDidDelete = vi.fn((listener: (uri: { fsPath: string; path: string }) => void) => {
+        this.deleteListeners.push(listener);
+        return { dispose: vi.fn(() => this.removeListener(this.deleteListeners, listener)) };
+    });
+
+    trigger(kind: "change" | "create" | "delete", fsPath: string): void {
+        const uri = { fsPath, path: fsPath };
+        const listeners =
+            kind === "change"
+                ? this.changeListeners
+                : kind === "create"
+                  ? this.createListeners
+                  : this.deleteListeners;
+        for (const listener of listeners) listener(uri);
+    }
+
+    private removeListener(
+        listeners: Array<(uri: { fsPath: string; path: string }) => void>,
+        listener: (uri: { fsPath: string; path: string }) => void,
+    ): void {
+        const index = listeners.indexOf(listener);
+        if (index >= 0) listeners.splice(index, 1);
+    }
+}
+
 const showErrorMessage = vi.fn(async () => undefined);
 const showWarningMessage = vi.fn(async () => undefined);
 const showInformationMessage = vi.fn(async () => undefined);
@@ -44,6 +94,7 @@ const showTextDocument = vi.fn(async () => undefined);
 const executeCommand = vi.fn(async () => undefined);
 const openTextDocument = vi.fn(async (arg) => arg);
 const postMessageSpy = vi.fn();
+const fileSystemWatchers: FakeFileSystemWatcher[] = [];
 const registeredCommands = new Map<string, CommandHandler>();
 const activeTextEditorListeners: Array<(editor?: { document: { uri: unknown } }) => void> = [];
 let activeTextEditor: { document: { uri: unknown } } | undefined;
@@ -113,6 +164,7 @@ const vscodeMock = {
     TreeItem: FakeTreeItem,
     ThemeIcon: FakeThemeIcon,
     ThemeColor: FakeThemeColor,
+    RelativePattern: FakeRelativePattern,
     env: {
         language: "en",
     },
@@ -212,6 +264,11 @@ const vscodeMock = {
             }),
         })),
         onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+        createFileSystemWatcher: vi.fn((pattern: unknown) => {
+            const watcher = new FakeFileSystemWatcher(pattern);
+            fileSystemWatchers.push(watcher);
+            return watcher;
+        }),
     },
     authentication: {
         onDidChangeSessions: vi.fn(() => ({ dispose: vi.fn() })),
@@ -229,6 +286,7 @@ const httpGetJsonSpy = vi.hoisted(() => vi.fn());
 const runPublishBranchFlowSpy = vi.hoisted(() => vi.fn(async () => undefined));
 const gitExecutorSetRoot = vi.hoisted(() => vi.fn());
 const activeGitRoot = vi.hoisted(() => ({ value: "" }));
+const gitStatusByRoot = vi.hoisted(() => new Map<string, unknown[]>());
 const deferBranchRefreshes = vi.hoisted(() => ({ active: false }));
 const branchRefreshControls = vi.hoisted(
     () =>
@@ -261,10 +319,14 @@ const makeBranchesForRoot = vi.hoisted(() => (root: string) => [
 vi.mock("vscode", () => vscodeMock);
 vi.mock("../../../src/git/executor", () => ({
     GitExecutor: class {
-        constructor(public readonly root: string) {
+        public root: string;
+
+        constructor(root: string) {
+            this.root = root;
             activeGitRoot.value = root;
         }
         setRoot = vi.fn((root: string) => {
+            this.root = root;
             activeGitRoot.value = root;
             gitExecutorSetRoot(root);
         });
@@ -272,8 +334,14 @@ vi.mock("../../../src/git/executor", () => ({
 }));
 vi.mock("../../../src/git/operations", () => ({
     GitOps: class {
+        constructor(private readonly executor?: { root?: string }) {}
+
+        private currentRoot(): string {
+            return this.executor?.root ?? activeGitRoot.value;
+        }
+
         getBranches = vi.fn(async () => {
-            const root = activeGitRoot.value;
+            const root = this.currentRoot();
             if (!deferBranchRefreshes.active) return makeBranchesForRoot(root);
             return new Promise<unknown[]>((resolve) => {
                 branchRefreshControls.push({ root, resolve });
@@ -284,7 +352,7 @@ vi.mock("../../../src/git/operations", () => ({
         getRemoteUrl = vi.fn(async () => "https://github.com/owner/repo.git");
         getUnpushedCommitHashes = vi.fn(async () => []);
         hasUncommittedChanges = vi.fn(async () => false);
-        getStatus = vi.fn(async () => []);
+        getStatus = vi.fn(async () => gitStatusByRoot.get(this.currentRoot()) ?? []);
         listStashes = vi.fn(async () => []);
         getConflictFilesDetailed = vi.fn(async () => []);
     },
@@ -547,6 +615,39 @@ function refreshingStates(): boolean[] {
         .map((message) => message.active);
 }
 
+function lastSetRepositoriesMessage():
+    | {
+          type: "setRepositories";
+          repositories: Array<{ root: string; label: string; changedFileCount: number }>;
+          activeRepositoryRoot: string | null;
+      }
+    | undefined {
+    const messages = postMessageSpy.mock.calls
+        .map(([message]) => message)
+        .filter(
+            (
+                message,
+            ): message is {
+                type: "setRepositories";
+                repositories: Array<{ root: string; label: string; changedFileCount: number }>;
+                activeRepositoryRoot: string | null;
+            } =>
+                typeof message === "object" &&
+                message !== null &&
+                "type" in message &&
+                message.type === "setRepositories",
+        );
+    return messages.at(-1);
+}
+
+function activeWatcherForRoot(root: string): FakeFileSystemWatcher | undefined {
+    return fileSystemWatchers.find((watcher) => {
+        if (watcher.dispose.mock.calls.length > 0) return false;
+        const pattern = watcher.pattern as { baseUri?: { fsPath?: string; path?: string } };
+        return (pattern.baseUri?.fsPath ?? pattern.baseUri?.path) === root;
+    });
+}
+
 // Returns the snapshot from the most recent setCommitChecks postMessage, or undefined
 // if the view never emitted one. Used by the self-hosted GitLab routing tests to assert
 // on the snapshot's state and error text.
@@ -603,9 +704,11 @@ describe("view providers integration", () => {
         activeTextEditorListeners.length = 0;
         activeTextEditor = undefined;
         activeGitRoot.value = "";
+        gitStatusByRoot.clear();
         deferBranchRefreshes.active = false;
         branchRefreshControls.length = 0;
         refreshServiceInstances.length = 0;
+        fileSystemWatchers.length = 0;
         workspaceState.workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         showWarningMessage.mockResolvedValue(undefined);
         providerGetChecks.mockImplementation(async (hash: string) => ({
@@ -1720,7 +1823,7 @@ describe("view providers integration", () => {
         expect(testProvider.repositories).toEqual([repoB]);
         expect(postMessageSpy).toHaveBeenLastCalledWith({
             type: "setRepositories",
-            repositories: [repoB],
+            repositories: [{ ...repoB, changedFileCount: 1 }],
             activeRepositoryRoot: repoB.root,
         });
         provider.dispose();
@@ -1769,9 +1872,192 @@ describe("view providers integration", () => {
         });
         expect(postMessageSpy).toHaveBeenLastCalledWith({
             type: "setRepositories",
-            repositories: [repoA, repoB],
+            repositories: [
+                { ...repoA, changedFileCount: 0 },
+                { ...repoB, changedFileCount: 0 },
+            ],
             activeRepositoryRoot: repoB.root,
         });
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider aggregates changed-file counts across repository runtimes", async () => {
+        const { provider } = await setupCommitPanelProvider();
+        const counts: number[] = [];
+        const disposable = provider.onDidChangeFileCount((count) => counts.push(count));
+        gitStatusByRoot.set("/repo-b", [
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+            { path: "src/b.ts", status: "M", staged: true, additions: 2, deletions: 0 },
+            { path: "ignored.log", status: "!", staged: false, additions: 0, deletions: 0 },
+            { path: "src/c.ts", status: "A", staged: false, additions: 1, deletions: 0 },
+        ]);
+        postMessageSpy.mockClear();
+
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        await flushMicrotasks();
+
+        expect(counts).toContain(3);
+        expect(lastSetRepositoriesMessage()?.repositories).toEqual([
+            { root: "/repo", label: "Repo A", changedFileCount: 1 },
+            { root: "/repo-b", label: "Repo B", changedFileCount: 2 },
+        ]);
+        disposable.dispose();
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider scans initial collapsed repository counts without full row refresh", async () => {
+        const { provider } = await setupCommitPanelProvider();
+        gitStatusByRoot.set("/repo-b", [
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+            { path: "ignored.log", status: "!", staged: false, additions: 0, deletions: 0 },
+        ]);
+        postMessageSpy.mockClear();
+
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        await flushMicrotasks();
+
+        expect(lastSetRepositoriesMessage()?.repositories).toEqual([
+            { root: "/repo", label: "Repo A", changedFileCount: 1 },
+            { root: "/repo-b", label: "Repo B", changedFileCount: 1 },
+        ]);
+        expect(postMessageSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: "update", repositoryRoot: "/repo-b" }),
+        );
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider rejects unknown expanded repository roots", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        gitOps.getStatus.mockClear();
+        showErrorMessage.mockClear();
+        postMessageSpy.mockClear();
+
+        await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/unknown"] });
+
+        expect(gitOps.getStatus).not.toHaveBeenCalled();
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            "Unknown repository root received from webview.",
+        );
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "error",
+            message: "Unknown repository root received from webview.",
+        });
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider watches active and expanded repositories with targeted refreshes", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getStatus.mockResolvedValue([
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        await flushMicrotasks();
+
+        expect(activeWatcherForRoot("/repo")).toBeDefined();
+        expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
+
+        await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/repo-b"] });
+        const activeWatcher = activeWatcherForRoot("/repo");
+        const expandedWatcher = activeWatcherForRoot("/repo-b");
+        expect(activeWatcher).toBeDefined();
+        expect(expandedWatcher).toBeDefined();
+
+        gitOps.getStatus.mockClear();
+        repoBGitOps.getStatus.mockClear();
+        postMessageSpy.mockClear();
+        expandedWatcher!.trigger("change", "/repo-b/src/b.ts");
+        for (let i = 0; i < 10; i += 1) {
+            await flushMicrotasks();
+            if (
+                postMessageSpy.mock.calls.some(([message]) =>
+                    expect
+                        .objectContaining({ type: "update", repositoryRoot: "/repo-b" })
+                        .asymmetricMatch(message),
+                )
+            ) {
+                break;
+            }
+        }
+
+        expect(repoBGitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
+        expect(gitOps.getStatus).not.toHaveBeenCalled();
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "update", repositoryRoot: "/repo-b" }),
+        );
+
+        gitOps.getStatus.mockClear();
+        repoBGitOps.getStatus.mockClear();
+        postMessageSpy.mockClear();
+        activeWatcher!.trigger("change", "/repo/src/a.ts");
+        for (let i = 0; i < 10; i += 1) {
+            await flushMicrotasks();
+            if (
+                postMessageSpy.mock.calls.some(([message]) =>
+                    expect
+                        .objectContaining({ type: "update", repositoryRoot: "/repo" })
+                        .asymmetricMatch(message),
+                )
+            ) {
+                break;
+            }
+        }
+
+        expect(gitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
+        expect(repoBGitOps.getStatus).not.toHaveBeenCalled();
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "update", repositoryRoot: "/repo" }),
+        );
+
+        await webview.send({ type: "setExpandedRepositories", repositoryRoots: [] });
+        expect(expandedWatcher!.dispose).toHaveBeenCalled();
+        expect(activeWatcherForRoot("/repo")).toBeDefined();
+        expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider disposes expanded repository watchers when rows are removed", async () => {
+        const { provider, webview } = await setupCommitPanelProvider();
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/repo-b"] });
+        const expandedWatcher = activeWatcherForRoot("/repo-b");
+        expect(expandedWatcher).toBeDefined();
+
+        provider.setRepositories([{ root: "/repo", label: "Repo A" }], "/repo");
+
+        expect(expandedWatcher!.dispose).toHaveBeenCalled();
+        expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -245,19 +245,17 @@ const refreshServiceInstances = vi.hoisted(
             dispose: ReturnType<typeof vi.fn>;
         }>,
 );
-const makeBranchesForRoot = vi.hoisted(
-    () => (root: string) => [
-        {
-            name: `branch-${root.split(/[\\/]/).pop() ?? root}`,
-            hash: "abc1234",
-            isRemote: false,
-            isCurrent: true,
-            upstream: "origin/main",
-            ahead: 0,
-            behind: 0,
-        },
-    ],
-);
+const makeBranchesForRoot = vi.hoisted(() => (root: string) => [
+    {
+        name: `branch-${root.split(/[\\/]/).pop() ?? root}`,
+        hash: "abc1234",
+        isRemote: false,
+        isCurrent: true,
+        upstream: "origin/main",
+        ahead: 0,
+        behind: 0,
+    },
+]);
 
 vi.mock("vscode", () => vscodeMock);
 vi.mock("../../../src/git/executor", () => ({
@@ -299,7 +297,10 @@ vi.mock("../../../src/services/worktreeService", () => ({
 }));
 vi.mock("../../../src/views/RefreshService", () => ({
     RefreshService: class {
-        constructor(_deps: unknown, public readonly root: string) {
+        constructor(
+            _deps: unknown,
+            public readonly root: string,
+        ) {
             refreshServiceInstances.push(this);
         }
         refreshMergeConflicts = vi.fn(async () => undefined);
@@ -784,7 +785,9 @@ describe("view providers integration", () => {
         const latestBranches = commitGraphBranchesSpy.mock.calls.at(-1)?.[0] as
             | Array<{ name: string }>
             | undefined;
-        expect(commitPanelRootSpy).toHaveBeenLastCalledWith(expect.objectContaining({ fsPath: repoB }));
+        expect(commitPanelRootSpy).toHaveBeenLastCalledWith(
+            expect.objectContaining({ fsPath: repoB }),
+        );
         expect(latestBranches?.[0]?.name).toBe("branch-app-b");
         expect(controlledWorkspaceStore.memento.get(SELECTED_REPOSITORY_KEY)).toBe(repoB);
     });
@@ -1632,6 +1635,138 @@ describe("view providers integration", () => {
         expect(gitOps.getStatus).not.toHaveBeenCalled();
         expect(postMessageSpy).not.toHaveBeenCalledWith(
             expect.objectContaining({ type: "update" }),
+        );
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes retain unchanged roots and drop removed roots", async () => {
+        const { CommitPanelViewProvider } =
+            await import("../../../src/views/CommitPanelViewProvider");
+        const provider = new CommitPanelViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            makeGitOpsMock() as unknown as object,
+            { fsPath: "/repo", path: "/repo" } as unknown as { fsPath: string; path: string },
+            createMemento() as unknown as object,
+        );
+        const webview = createWebviewView();
+        provider.resolveWebviewView(
+            webview.view as unknown as object,
+            {} as unknown as object,
+            {} as unknown as object,
+        );
+        const repoA = { root: "/repo-a", label: "Repo A" };
+        const repoB = { root: "/repo-b", label: "Repo B" };
+        postMessageSpy.mockClear();
+
+        provider.setRepositories([repoA, repoB], repoA.root);
+        const testProvider = provider as unknown as {
+            activeRepositoryRoot: string | null;
+            repositories: Array<{ root: string; label: string }>;
+            runtimes: Map<
+                string,
+                {
+                    files: Array<{
+                        path: string;
+                        status: string;
+                        staged: boolean;
+                        additions: number;
+                        deletions: number;
+                    }>;
+                }
+            >;
+        };
+        const runtimeA = testProvider.runtimes.get(repoA.root);
+        const runtimeB = testProvider.runtimes.get(repoB.root);
+        expect(runtimeA).toBeDefined();
+        expect(runtimeB).toBeDefined();
+        runtimeB!.files = [
+            { path: "src/b.ts", status: "M", staged: false, additions: 1, deletions: 0 },
+        ];
+
+        provider.setRepositories([repoB]);
+
+        expect(testProvider.runtimes.has(repoA.root)).toBe(false);
+        expect(testProvider.runtimes.get(repoB.root)).toBe(runtimeB);
+        expect(testProvider.activeRepositoryRoot).toBe(repoB.root);
+        expect(testProvider.repositories).toEqual([repoB]);
+        expect(postMessageSpy).toHaveBeenLastCalledWith({
+            type: "setRepositories",
+            repositories: [repoB],
+            activeRepositoryRoot: repoB.root,
+        });
+        provider.dispose();
+    });
+
+    it("Unknown repository showDiff is rejected before Git or git.openChange", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        gitOps.getStatus.mockClear();
+        executeCommand.mockClear();
+        showErrorMessage.mockClear();
+        postMessageSpy.mockClear();
+
+        await webview.send({ type: "showDiff", repositoryRoot: "/unknown", path: "src/a.ts" });
+
+        expect(gitOps.getStatus).not.toHaveBeenCalled();
+        expect(executeCommand).not.toHaveBeenCalledWith("git.openChange", expect.anything());
+        expect(showErrorMessage).toHaveBeenCalledWith(
+            "Unknown repository root received from webview.",
+        );
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "error",
+            message: "Unknown repository root received from webview.",
+        });
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes route scoped actions through selected runtime GitOps and root", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getStatus.mockResolvedValue([
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        gitOps.stageFiles.mockClear();
+        repoBGitOps.stageFiles.mockClear();
+        postMessageSpy.mockClear();
+
+        await webview.send({
+            type: "stageFiles",
+            repositoryRoot: "/repo-b",
+            paths: ["src/b.ts"],
+        });
+
+        expect(repoBGitOps.stageFiles).toHaveBeenCalledWith(["src/b.ts"]);
+        expect(gitOps.stageFiles).not.toHaveBeenCalled();
+        expect(repoBGitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "update",
+                files: [expect.objectContaining({ path: "src/b.ts" })],
+            }),
+        );
+
+        executeCommand.mockClear();
+        await webview.send({
+            type: "showDiff",
+            repositoryRoot: "/repo-b",
+            path: "src/b.ts",
+        });
+        expect(executeCommand).toHaveBeenCalledWith(
+            "git.openChange",
+            expect.objectContaining({ fsPath: "/repo-b/src/b.ts" }),
         );
         provider.dispose();
     });

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MessageHandler = (message: unknown) => void | Promise<void>;
+type CommandHandler = (...args: unknown[]) => unknown;
 
 class FakeEventEmitter<T> {
     private listeners: Array<(value: T) => void> = [];
@@ -43,6 +44,9 @@ const showTextDocument = vi.fn(async () => undefined);
 const executeCommand = vi.fn(async () => undefined);
 const openTextDocument = vi.fn(async (arg) => arg);
 const postMessageSpy = vi.fn();
+const registeredCommands = new Map<string, CommandHandler>();
+const activeTextEditorListeners: Array<(editor?: { document: { uri: unknown } }) => void> = [];
+let activeTextEditor: { document: { uri: unknown } } | undefined;
 const withProgress = vi.fn(
     async (_options: unknown, task: (progress: unknown, token: unknown) => Promise<unknown>) =>
         task(
@@ -83,9 +87,25 @@ const vscodeMock = {
         t: (message: string, _placeholders?: unknown) => message,
     },
     ProgressLocation: { Notification: 15 },
+    Disposable: class {
+        constructor(private readonly disposeCallback: () => void) {}
+        dispose(): void {
+            this.disposeCallback();
+        }
+    },
     TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
     Uri: {
-        parse: (value: string): { fsPath: string; path: string; scheme: string; toString: () => string } => ({
+        file: (
+            value: string,
+        ): { fsPath: string; path: string; scheme: string; toString: () => string } => ({
+            fsPath: value,
+            path: value,
+            scheme: "file",
+            toString: () => value,
+        }),
+        parse: (
+            value: string,
+        ): { fsPath: string; path: string; scheme: string; toString: () => string } => ({
             fsPath: value,
             path: value,
             scheme: value.split(":", 1)[0],
@@ -114,10 +134,33 @@ const vscodeMock = {
         showInformationMessage,
         showTextDocument,
         withProgress,
+        get activeTextEditor() {
+            return activeTextEditor;
+        },
+        registerWebviewViewProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        createTreeView: vi.fn(() => ({
+            dispose: vi.fn(),
+            badge: undefined,
+            description: undefined,
+        })),
+        onDidChangeActiveTextEditor: vi.fn(
+            (listener: (editor?: { document: { uri: unknown } }) => void) => {
+                activeTextEditorListeners.push(listener);
+                return { dispose: vi.fn() };
+            },
+        ),
         onDidChangeActiveColorTheme: vi.fn(() => ({ dispose: vi.fn() })),
     },
     commands: {
-        executeCommand,
+        registerCommand: vi.fn((id: string, handler: CommandHandler) => {
+            registeredCommands.set(id, handler);
+            return { dispose: vi.fn() };
+        }),
+        executeCommand: vi.fn(async (id: string, ...args: unknown[]) => {
+            const handler = registeredCommands.get(id);
+            if (handler) return handler(...args);
+            return executeCommand(id, ...args);
+        }),
     },
     workspace: {
         get workspaceFolders() {
@@ -137,6 +180,9 @@ const vscodeMock = {
         })),
         onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
     },
+    authentication: {
+        onDidChangeSessions: vi.fn(() => ({ dispose: vi.fn() })),
+    },
 };
 
 const deleteFileWithFallback = vi.fn(async () => true);
@@ -147,8 +193,54 @@ const providerGetChecks = vi.hoisted(() => vi.fn());
 // never touch the network; defaults are set per test. GitHub-remote tests never reach
 // the GitLab path (GitHub matches first), so this stays uninvoked there.
 const httpGetJsonSpy = vi.hoisted(() => vi.fn());
+const gitExecutorSetRoot = vi.hoisted(() => vi.fn());
 
 vi.mock("vscode", () => vscodeMock);
+vi.mock("../../../src/git/executor", () => ({
+    GitExecutor: class {
+        constructor(public readonly root: string) {}
+        setRoot = gitExecutorSetRoot;
+    },
+}));
+vi.mock("../../../src/git/operations", () => ({
+    GitOps: class {
+        getBranches = vi.fn(async () => [
+            {
+                name: "main",
+                hash: "abc1234",
+                isRemote: false,
+                isCurrent: true,
+                upstream: "origin/main",
+                ahead: 0,
+                behind: 0,
+            },
+        ]);
+        getLog = vi.fn(async () => []);
+        getRemotes = vi.fn(async () => ["origin"]);
+        getRemoteUrl = vi.fn(async () => "https://github.com/owner/repo.git");
+        getUnpushedCommitHashes = vi.fn(async () => []);
+        hasUncommittedChanges = vi.fn(async () => false);
+        getStatus = vi.fn(async () => []);
+        listStashes = vi.fn(async () => []);
+        getConflictFilesDetailed = vi.fn(async () => []);
+    },
+}));
+vi.mock("../../../src/services/worktreeService", () => ({
+    WorktreeService: class {
+        refresh = vi.fn(async () => []);
+        decorateBranches = vi.fn((branches: unknown[]) => branches);
+        dispose = vi.fn();
+    },
+}));
+vi.mock("../../../src/views/RefreshService", () => ({
+    RefreshService: class {
+        refreshMergeConflicts = vi.fn(async () => undefined);
+        refreshConflictUi = vi.fn(async () => undefined);
+        refreshAll = vi.fn(async () => undefined);
+        registerFileWatchers = vi.fn();
+        dispose = vi.fn();
+    },
+}));
 vi.mock("../../../src/utils/notifications", () => ({
     runWithNotificationProgress: vi.fn(
         async (_message: string, task: (progress: unknown, token: unknown) => Promise<unknown>) =>
@@ -422,6 +514,9 @@ async function setupCommitPanelProvider(
 describe("view providers integration", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        registeredCommands.clear();
+        activeTextEditorListeners.length = 0;
+        activeTextEditor = undefined;
         workspaceState.workspaceFolders = [{ uri: { fsPath: "/repo", path: "/repo" } }];
         showWarningMessage.mockResolvedValue(undefined);
         providerGetChecks.mockImplementation(async (hash: string) => ({
@@ -430,6 +525,72 @@ describe("view providers integration", () => {
             summary: "All checks passed",
             items: [],
         }));
+    });
+
+    it("active editor switches providers to the deepest matching repository", async () => {
+        const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
+        const repoA = "/workspace";
+        const repoB = "/workspace/packages/app";
+        const captured: {
+            commitGraph?: { setRepositoryLabel: (label: string) => void };
+            sidebarGraph?: { setRepositoryLabel: (label: string) => void };
+            commitPanel?: {
+                setRepositoryLabel: (label: string) => void;
+                setRepositoryRootUri: (uri: { fsPath: string }) => void;
+            };
+        } = {};
+        const context = {
+            extensionUri: vscodeMock.Uri.file("/ext"),
+            subscriptions: [],
+            workspaceState: createMemento(),
+            secrets: {},
+        };
+
+        await activateRepositoryMode(
+            context as never,
+            [
+                { root: repoA, label: "workspace" },
+                { root: repoB, label: "app" },
+            ],
+            {
+                commitGraph: {
+                    setProvider: (provider: unknown) => (captured.commitGraph = provider as never),
+                },
+                sidebarGraph: {
+                    setProvider: (provider: unknown) => (captured.sidebarGraph = provider as never),
+                },
+                commitPanel: {
+                    setProvider: (provider: unknown) => (captured.commitPanel = provider as never),
+                },
+            } as never,
+        );
+        expect(activeTextEditorListeners).toHaveLength(1);
+
+        const commitGraphLabelSpy = vi.spyOn(captured.commitGraph!, "setRepositoryLabel");
+        const sidebarGraphLabelSpy = vi.spyOn(captured.sidebarGraph!, "setRepositoryLabel");
+        const commitPanelRootSpy = vi.spyOn(captured.commitPanel!, "setRepositoryRootUri");
+        const commitPanelLabelSpy = vi.spyOn(captured.commitPanel!, "setRepositoryLabel");
+        gitExecutorSetRoot.mockClear();
+
+        const fireActiveEditor = async (uri: unknown): Promise<void> => {
+            activeTextEditorListeners.forEach((listener) => listener({ document: { uri } }));
+            await flushMicrotasks();
+            await flushMicrotasks();
+        };
+
+        await fireActiveEditor({ scheme: "untitled", fsPath: `${repoB}/src/file.ts` });
+        await fireActiveEditor(vscodeMock.Uri.file("/other/src/file.ts"));
+
+        expect(gitExecutorSetRoot).not.toHaveBeenCalledWith(repoB);
+        expect(commitPanelRootSpy).not.toHaveBeenCalled();
+
+        await fireActiveEditor(vscodeMock.Uri.file(`${repoB}/src/file.ts`));
+
+        expect(gitExecutorSetRoot).toHaveBeenCalledWith(repoB);
+        expect(commitGraphLabelSpy).toHaveBeenCalledWith("app");
+        expect(sidebarGraphLabelSpy).toHaveBeenCalledWith("app");
+        expect(commitPanelRootSpy).toHaveBeenCalledWith(expect.objectContaining({ fsPath: repoB }));
+        expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
     });
 
     it("OnboardingViewProvider renders clone and open-folder actions when no workspace is open", async () => {

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1782,6 +1782,13 @@ describe("view providers integration", () => {
         await webview.send({ type: "loadMore" });
         expect(gitOps.getLog.mock.calls.length - logCallsBeforePagedFetch).toBe(2);
 
+        provider.resetFilters();
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "setSelectedBranch", branch: null });
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "setFilterText", text: "" });
+        await provider.refresh();
+        expect(gitOps.getLog.mock.calls.at(-1)?.[1]).toBeUndefined();
+        expect(gitOps.getLog.mock.calls.at(-1)?.[2]).toBeUndefined();
+
         gitOps.getLog.mockRejectedValueOnce(new Error("git failed"));
         await provider.refresh();
         expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Git log error"));

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -226,6 +226,7 @@ const providerGetChecks = vi.hoisted(() => vi.fn());
 // never touch the network; defaults are set per test. GitHub-remote tests never reach
 // the GitLab path (GitHub matches first), so this stays uninvoked there.
 const httpGetJsonSpy = vi.hoisted(() => vi.fn());
+const runPublishBranchFlowSpy = vi.hoisted(() => vi.fn(async () => undefined));
 const gitExecutorSetRoot = vi.hoisted(() => vi.fn());
 const activeGitRoot = vi.hoisted(() => ({ value: "" }));
 const deferBranchRefreshes = vi.hoisted(() => ({ active: false }));
@@ -364,6 +365,9 @@ vi.mock("../../../src/services/commitChecks/githubProvider", () => ({
 vi.mock("../../../src/services/commitChecks/http", () => ({
     httpGetJson: httpGetJsonSpy,
 }));
+vi.mock("../../../src/services/publishService", () => ({
+    runPublishBranchFlow: runPublishBranchFlowSpy,
+}));
 
 function createWebviewView() {
     let messageHandler: MessageHandler | undefined;
@@ -447,6 +451,7 @@ function makeGitOpsMock() {
         getRemotes: vi.fn(async () => ["origin"]),
         getRemoteUrl: vi.fn(async () => "https://github.com/owner/repo.git"),
         getUnpushedCommitHashes: vi.fn(async () => ["abc1234"]),
+        hasAnyCommits: vi.fn(async () => true),
         hasUncommittedChanges: vi.fn(async () => false),
         getStatus: vi.fn(async () => [
             { path: "src/a.ts", status: "M", staged: false, additions: 1, deletions: 0 },
@@ -1771,6 +1776,163 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
+    it("CommitPanelViewProvider repository runtimes route scoped publishBranch through selected runtime", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getBranches.mockResolvedValue([
+            {
+                name: "feature-b",
+                hash: "def5678",
+                isRemote: false,
+                isCurrent: true,
+                ahead: 0,
+                behind: 0,
+            },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        gitOps.hasAnyCommits.mockClear();
+        gitOps.getBranches.mockClear();
+        repoBGitOps.hasAnyCommits.mockClear();
+        repoBGitOps.getBranches.mockClear();
+        executeCommand.mockClear();
+        runPublishBranchFlowSpy.mockClear();
+
+        await webview.send({ type: "publishBranch", repositoryRoot: "/repo-b" });
+
+        expect(repoBGitOps.hasAnyCommits).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getBranches).toHaveBeenCalledTimes(1);
+        expect(gitOps.hasAnyCommits).not.toHaveBeenCalled();
+        expect(gitOps.getBranches).not.toHaveBeenCalled();
+        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(
+            repoBGitOps,
+            "feature-b",
+            "/repo-b",
+        );
+        expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes route unpublished push publish through selected runtime", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getBranches.mockResolvedValue([
+            {
+                name: "feature-b",
+                hash: "def5678",
+                isRemote: false,
+                isCurrent: true,
+                ahead: 0,
+                behind: 0,
+            },
+        ]);
+        repoBGitOps.getStatus.mockResolvedValue([]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        gitOps.hasAnyCommits.mockClear();
+        gitOps.getBranches.mockClear();
+        gitOps.push.mockClear();
+        repoBGitOps.hasAnyCommits.mockClear();
+        repoBGitOps.getBranches.mockClear();
+        repoBGitOps.push.mockClear();
+        executeCommand.mockClear();
+        runPublishBranchFlowSpy.mockClear();
+
+        await webview.send({ type: "push", repositoryRoot: "/repo-b" });
+
+        expect(repoBGitOps.hasAnyCommits).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getBranches).toHaveBeenCalled();
+        expect(repoBGitOps.push).not.toHaveBeenCalled();
+        expect(gitOps.hasAnyCommits).not.toHaveBeenCalled();
+        expect(gitOps.getBranches).not.toHaveBeenCalled();
+        expect(gitOps.push).not.toHaveBeenCalled();
+        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(
+            repoBGitOps,
+            "feature-b",
+            "/repo-b",
+        );
+        expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes route post-commit publish prompt through selected runtime", async () => {
+        const { provider, gitOps } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getBranches.mockResolvedValue([
+            {
+                name: "feature-b",
+                hash: "def5678",
+                isRemote: false,
+                isCurrent: true,
+                ahead: 0,
+                behind: 0,
+            },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const testProvider = provider as unknown as {
+            maybeOfferPublishBranch(runtime: unknown): Promise<void>;
+            runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+        };
+        const runtimeB = testProvider.runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        showInformationMessage.mockResolvedValueOnce("Publish Branch...");
+        gitOps.hasAnyCommits.mockClear();
+        gitOps.getBranches.mockClear();
+        repoBGitOps.hasAnyCommits.mockClear();
+        repoBGitOps.getBranches.mockClear();
+        executeCommand.mockClear();
+        runPublishBranchFlowSpy.mockClear();
+
+        await testProvider.maybeOfferPublishBranch(runtimeB);
+
+        expect(showInformationMessage).toHaveBeenCalledWith(
+            'Branch "{branch}" has not been published.',
+            "Publish Branch...",
+        );
+        expect(repoBGitOps.hasAnyCommits).toHaveBeenCalledTimes(2);
+        expect(repoBGitOps.getBranches).toHaveBeenCalledTimes(2);
+        expect(gitOps.hasAnyCommits).not.toHaveBeenCalled();
+        expect(gitOps.getBranches).not.toHaveBeenCalled();
+        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(
+            repoBGitOps,
+            "feature-b",
+            "/repo-b",
+        );
+        expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
+        provider.dispose();
+    });
+
     it("CommitPanelViewProvider handles staging and unstaging", async () => {
         const { provider, gitOps, webview } = await setupCommitPanelProvider();
         expect(gitOps.getStatus).toHaveBeenCalled();
@@ -2120,7 +2282,8 @@ describe("view providers integration", () => {
                 currentBranchHasUpstream: false,
             }),
         );
-        expect(executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
+        expect(runPublishBranchFlowSpy).toHaveBeenCalledWith(gitOps, "main", "/repo");
+        expect(executeCommand).not.toHaveBeenCalledWith("intelligit.publishBranch");
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1957,7 +1957,7 @@ describe("view providers integration", () => {
         provider.dispose();
     });
 
-    it("CommitPanelViewProvider watches active and expanded repositories with targeted refreshes", async () => {
+    it("CommitPanelViewProvider watches expanded non-active repositories with targeted refreshes", async () => {
         const { provider, gitOps, webview } = await setupCommitPanelProvider();
         const repoBGitOps = makeGitOpsMock();
         repoBGitOps.getStatus.mockResolvedValue([
@@ -1979,13 +1979,12 @@ describe("view providers integration", () => {
         runtimeB!.gitOps = repoBGitOps;
         await flushMicrotasks();
 
-        expect(activeWatcherForRoot("/repo")).toBeDefined();
+        expect(activeWatcherForRoot("/repo")).toBeUndefined();
         expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
 
         await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/repo-b"] });
-        const activeWatcher = activeWatcherForRoot("/repo");
         const expandedWatcher = activeWatcherForRoot("/repo-b");
-        expect(activeWatcher).toBeDefined();
+        expect(activeWatcherForRoot("/repo")).toBeUndefined();
         expect(expandedWatcher).toBeDefined();
 
         gitOps.getStatus.mockClear();
@@ -2011,32 +2010,9 @@ describe("view providers integration", () => {
             expect.objectContaining({ type: "update", repositoryRoot: "/repo-b" }),
         );
 
-        gitOps.getStatus.mockClear();
-        repoBGitOps.getStatus.mockClear();
-        postMessageSpy.mockClear();
-        activeWatcher!.trigger("change", "/repo/src/a.ts");
-        for (let i = 0; i < 10; i += 1) {
-            await flushMicrotasks();
-            if (
-                postMessageSpy.mock.calls.some(([message]) =>
-                    expect
-                        .objectContaining({ type: "update", repositoryRoot: "/repo" })
-                        .asymmetricMatch(message),
-                )
-            ) {
-                break;
-            }
-        }
-
-        expect(gitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
-        expect(repoBGitOps.getStatus).not.toHaveBeenCalled();
-        expect(postMessageSpy).toHaveBeenCalledWith(
-            expect.objectContaining({ type: "update", repositoryRoot: "/repo" }),
-        );
-
         await webview.send({ type: "setExpandedRepositories", repositoryRoots: [] });
         expect(expandedWatcher!.dispose).toHaveBeenCalled();
-        expect(activeWatcherForRoot("/repo")).toBeDefined();
+        expect(activeWatcherForRoot("/repo")).toBeUndefined();
         expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
         provider.dispose();
     });
@@ -2751,6 +2727,88 @@ describe("view providers integration", () => {
             await refresh;
 
             expect(refreshingStates()).toEqual([true, false]);
+            expect(executeCommand).toHaveBeenCalledWith(
+                "setContext",
+                "intelligit.commitPanel.refreshing",
+                false,
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider keeps global refresh context active until overlapping visible repository refreshes finish", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getStatus.mockResolvedValue([
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/repo-b"] });
+        postMessageSpy.mockClear();
+        executeCommand.mockClear();
+
+        type StatusFile = {
+            path: string;
+            status: "M";
+            staged: false;
+            additions: number;
+            deletions: number;
+        };
+        let resolveActiveStatus: (files: StatusFile[]) => void = () => {};
+        let resolveExpandedStatus: (files: StatusFile[]) => void = () => {};
+        const activeStatus = new Promise<StatusFile[]>((resolve) => {
+            resolveActiveStatus = resolve;
+        });
+        const expandedStatus = new Promise<StatusFile[]>((resolve) => {
+            resolveExpandedStatus = resolve;
+        });
+        gitOps.getStatus.mockImplementationOnce(() => activeStatus);
+        repoBGitOps.getStatus.mockImplementationOnce(() => expandedStatus);
+
+        vi.useFakeTimers();
+        try {
+            const refresh = provider.refresh();
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(executeCommand).toHaveBeenCalledWith(
+                "setContext",
+                "intelligit.commitPanel.refreshing",
+                true,
+            );
+
+            resolveActiveStatus([
+                { path: "active.ts", status: "M", staged: false, additions: 1, deletions: 0 },
+            ]);
+            await flushMicrotasks();
+            await vi.advanceTimersByTimeAsync(600);
+
+            expect(executeCommand).not.toHaveBeenCalledWith(
+                "setContext",
+                "intelligit.commitPanel.refreshing",
+                false,
+            );
+
+            resolveExpandedStatus([
+                { path: "expanded.ts", status: "M", staged: false, additions: 1, deletions: 0 },
+            ]);
+            await flushMicrotasks();
+            await refresh;
+
             expect(executeCommand).toHaveBeenCalledWith(
                 "setContext",
                 "intelligit.commitPanel.refreshing",

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -916,6 +916,11 @@ describe("view providers integration", () => {
 
         expect(discoverGitRepositoriesSpy).toHaveBeenCalledWith([repoB]);
         expect(gitExecutorSetRoot).toHaveBeenCalledWith(repoB);
+        expect(executeCommand).toHaveBeenCalledWith(
+            "setContext",
+            "intelligit.hasMultipleRepositories",
+            false,
+        );
         expect(captured.commitPanel!.repositories).toEqual([{ root: repoB, label: "app-b" }]);
         expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoB);
         expect(captured.commitPanel!.runtimes.has(repoA)).toBe(false);
@@ -1593,11 +1598,140 @@ describe("view providers integration", () => {
             message: "draft A",
         });
 
+        postMessageSpy.mockClear();
+        callRoots.length = 0;
+        executor.setRoot.mockClear();
+        provider.setRepositories([{ root: "/repo-a", label: "Repo A" }], "/repo-a");
+        for (let index = 0; index < 12; index += 1) {
+            await flushMicrotasks();
+            if (
+                postMessageSpy.mock.calls.some(([message]) =>
+                    expect
+                        .objectContaining({ type: "restoreCommitDraft", message: "draft A" })
+                        .asymmetricMatch(message),
+                )
+            ) {
+                break;
+            }
+        }
+
+        expect(executor.setRoot).toHaveBeenCalledWith("/repo-a");
+        expect(callRoots).toEqual(
+            expect.arrayContaining(["branches:/repo-a", "log:/repo-a", "status:/repo-a"]),
+        );
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "restoreCommitDraft",
+            message: "draft A",
+        });
+
         executor.setRoot.mockClear();
         await expect(
             send({ type: "selectRepository", repositoryRoot: "/missing" }),
         ).rejects.toThrow("Unknown repository root received from webview.");
         expect(executor.setRoot).not.toHaveBeenCalled();
+        provider.dispose();
+    });
+
+    it("UndockedViewProvider ignores stale repository switch completions", async () => {
+        const { UndockedViewProvider } = await import("../../../src/views/UndockedViewProvider");
+        const executor = {
+            root: "/repo-a",
+            setRoot: vi.fn((root: string) => {
+                executor.root = root;
+            }),
+        };
+        const callRoots: string[] = [];
+        type BranchRows = ReturnType<typeof makeBranchesForRoot>;
+        let resolveRepoB!: (value: { branches: BranchRows; worktrees: never[] }) => void;
+        const repoBBranches = new Promise<{ branches: BranchRows; worktrees: never[] }>(
+            (resolve) => {
+                resolveRepoB = resolve;
+            },
+        );
+        const gitOps = makeGitOpsMock();
+        gitOps.getLog = vi.fn(async () => {
+            callRoots.push(`log:${executor.root}`);
+            return [];
+        });
+        gitOps.getUnpushedCommitHashes = vi.fn(async () => {
+            callRoots.push(`unpushed:${executor.root}`);
+            return [];
+        });
+        gitOps.getStatus = vi.fn(async () => {
+            callRoots.push(`status:${executor.root}`);
+            return [];
+        });
+        const workspaceStore = createMemento({ "commitDraft:/repo-a": "draft A" });
+        const provider = new UndockedViewProvider(
+            { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
+            gitOps as unknown as object,
+            { fsPath: "/repo-a", path: "/repo-a" } as unknown as { fsPath: string; path: string },
+            makeCredentialStore() as unknown as object,
+            workspaceStore as unknown as object,
+            {},
+            undefined,
+            {
+                executor,
+                repositories: [
+                    { root: "/repo-a", label: "Repo A" },
+                    { root: "/repo-b", label: "Repo B" },
+                ],
+                selectedRepositoryRoot: "/repo-a",
+                loadRepositoryData: async (root: string) =>
+                    root === "/repo-b"
+                        ? repoBBranches
+                        : { branches: makeBranchesForRoot(root), worktrees: [] },
+                onSelectedRepositoryRootChanged: async (root: string) => {
+                    await workspaceStore.update("intelligit.undockedSelectedRepositoryRoot", root);
+                },
+            },
+        );
+        const testProvider = provider as unknown as {
+            panel: {
+                webview: { postMessage: typeof postMessageSpy };
+                dispose: ReturnType<typeof vi.fn>;
+            };
+            iconTheme: {
+                initIconThemeData: ReturnType<typeof vi.fn>;
+                getFolderIconsByBranches: ReturnType<typeof vi.fn>;
+                getThemeData: ReturnType<typeof vi.fn>;
+                decorateWorkingFiles: ReturnType<typeof vi.fn>;
+                getFolderIconsByWorkingFiles: ReturnType<typeof vi.fn>;
+                dispose: ReturnType<typeof vi.fn>;
+            };
+            handleMessage: (msg: unknown) => Promise<void>;
+        };
+        testProvider.panel = {
+            webview: { postMessage: postMessageSpy },
+            dispose: vi.fn(),
+        };
+        testProvider.iconTheme = {
+            initIconThemeData: vi.fn(async () => undefined),
+            getFolderIconsByBranches: vi.fn(async () => ({})),
+            getThemeData: vi.fn(() => ({
+                folderIcons: { folderIcon: "folder", folderExpandedIcon: "folder-open" },
+                iconFonts: [],
+            })),
+            decorateWorkingFiles: vi.fn(async (files: unknown) => files),
+            getFolderIconsByWorkingFiles: vi.fn(async () => ({})),
+            dispose: vi.fn(),
+        };
+        const send = (msg: unknown) => testProvider.handleMessage.call(provider, msg);
+
+        const repoBSwitch = send({ type: "selectRepository", repositoryRoot: "/repo-b" });
+        await flushMicrotasks();
+        const repoASwitch = send({ type: "selectRepository", repositoryRoot: "/repo-a" });
+        await repoASwitch;
+        resolveRepoB({ branches: makeBranchesForRoot("/repo-b"), worktrees: [] });
+        await repoBSwitch;
+
+        expect(callRoots).toEqual(
+            expect.arrayContaining(["log:/repo-a", "status:/repo-a"]),
+        );
+        expect(callRoots).not.toEqual(
+            expect.arrayContaining(["log:/repo-b", "status:/repo-b"]),
+        );
+        expect(workspaceStore.get("intelligit.undockedSelectedRepositoryRoot")).toBe("/repo-a");
         provider.dispose();
     });
 
@@ -1687,6 +1821,10 @@ describe("view providers integration", () => {
 
         sidebarProvider.setRepositoryLabel("repo-b");
         expect(sidebarWebview.view.description).toBe("(repo-b)");
+        sidebarProvider.setShowRepositoryLabel(false);
+        expect(sidebarWebview.view.description).toBeUndefined();
+        sidebarProvider.setShowRepositoryLabel(true);
+        expect(sidebarWebview.view.description).toBe("(repo-b)");
 
         const fullGraphProvider = new CommitGraphViewProvider(
             { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },
@@ -1757,6 +1895,7 @@ describe("view providers integration", () => {
 
         await webview.send({ type: "filterBranch", branch: "main" });
         expect(branchFilter).toHaveBeenCalledWith("main");
+        expect(postMessageSpy).toHaveBeenCalledWith({ type: "setFilterText", text: "" });
 
         await webview.send({ type: "branchAction", action: "checkout", branchName: "main" });
         expect(branchAction).toHaveBeenCalledWith({ action: "checkout", branchName: "main" });
@@ -2466,6 +2605,37 @@ describe("view providers integration", () => {
             "git.openChange",
             expect.objectContaining({ fsPath: "/repo-b/src/b.ts" }),
         );
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider scopes repository command errors to the selected runtime", async () => {
+        const { provider, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.stashApply.mockRejectedValueOnce(new Error("stash apply failed"));
+        repoBGitOps.getConflictFilesDetailed.mockResolvedValueOnce([]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        postMessageSpy.mockClear();
+
+        await webview.send({ type: "stashApply", repositoryRoot: "/repo-b", index: 0 });
+
+        expect(postMessageSpy).toHaveBeenCalledWith({
+            type: "error",
+            repositoryRoot: "/repo-b",
+            message: "stash apply failed",
+        });
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -481,6 +481,7 @@ function makeGitOpsMock() {
         stashApply: vi.fn(async () => "applied"),
         stashDelete: vi.fn(async () => "deleted"),
         getConflictFilesDetailed: vi.fn(async () => []),
+        abortMerge: vi.fn(async () => undefined),
         getStashFilePatch: vi.fn(async () => "diff --git a b"),
         getFileHistory: vi.fn(async () => "history line"),
     };
@@ -1926,6 +1927,60 @@ describe("view providers integration", () => {
         expect(postMessageSpy).not.toHaveBeenCalledWith(
             expect.objectContaining({ type: "loadCommits" }),
         );
+        provider.dispose();
+    });
+
+    it("CommitPanelViewProvider repository runtimes skip graph refresh for non-active abortMerge", async () => {
+        const { provider, gitOps, webview } = await setupCommitPanelProvider();
+        const repoBGitOps = makeGitOpsMock();
+        repoBGitOps.getStatus.mockResolvedValue([
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        provider.setRepositories(
+            [
+                { root: "/repo", label: "Repo A" },
+                { root: "/repo-b", label: "Repo B" },
+            ],
+            "/repo",
+        );
+        const runtimeB = (
+            provider as unknown as {
+                runtimes: Map<string, { gitOps: ReturnType<typeof makeGitOpsMock> }>;
+            }
+        ).runtimes.get("/repo-b");
+        expect(runtimeB).toBeDefined();
+        runtimeB!.gitOps = repoBGitOps;
+        const workingTreeChanged = vi.fn();
+        const disposable = provider.onDidChangeWorkingTree(workingTreeChanged);
+        gitOps.getLog.mockClear();
+        repoBGitOps.abortMerge.mockClear();
+        repoBGitOps.getStatus.mockClear();
+        repoBGitOps.listStashes.mockClear();
+        repoBGitOps.getLog.mockClear();
+        executeCommand.mockClear();
+        postMessageSpy.mockClear();
+        showWarningMessage.mockResolvedValueOnce("Abort Merge");
+
+        await webview.send({ type: "abortMerge", repositoryRoot: "/repo-b" });
+
+        expect(repoBGitOps.abortMerge).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getStatus).toHaveBeenCalledWith({ includeIgnored: false });
+        expect(repoBGitOps.listStashes).toHaveBeenCalledTimes(1);
+        expect(repoBGitOps.getLog).not.toHaveBeenCalled();
+        expect(gitOps.getLog).not.toHaveBeenCalled();
+        expect(workingTreeChanged).toHaveBeenCalledTimes(1);
+        expect(executeCommand).toHaveBeenCalledWith("intelligit.mergeConflictsRefresh");
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "update",
+                repositoryRoot: "/repo-b",
+                files: [expect.objectContaining({ path: "src/b.ts" })],
+            }),
+        );
+        expect(postMessageSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: "loadCommits" }),
+        );
+        disposable.dispose();
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -2043,6 +2043,11 @@ describe("view providers integration", () => {
 
     it("CommitPanelViewProvider disposes expanded repository watchers when rows are removed", async () => {
         const { provider, webview } = await setupCommitPanelProvider();
+        gitStatusByRoot.set("/repo-b", [
+            { path: "src/b.ts", status: "M", staged: false, additions: 2, deletions: 0 },
+        ]);
+        const counts: number[] = [];
+        const disposable = provider.onDidChangeFileCount((count) => counts.push(count));
         provider.setRepositories(
             [
                 { root: "/repo", label: "Repo A" },
@@ -2053,11 +2058,15 @@ describe("view providers integration", () => {
         await webview.send({ type: "setExpandedRepositories", repositoryRoots: ["/repo-b"] });
         const expandedWatcher = activeWatcherForRoot("/repo-b");
         expect(expandedWatcher).toBeDefined();
+        expect(counts).toContain(2);
+        counts.length = 0;
 
         provider.setRepositories([{ root: "/repo", label: "Repo A" }], "/repo");
 
+        expect(counts).toEqual([1]);
         expect(expandedWatcher!.dispose).toHaveBeenCalled();
         expect(activeWatcherForRoot("/repo-b")).toBeUndefined();
+        disposable.dispose();
         provider.dispose();
     });
 

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -740,15 +740,24 @@ describe("view providers integration", () => {
         }));
     });
 
-    it("active editor switches providers to the deepest matching repository", async () => {
+    it("graph active repository follows the active editor without mutating commit accordion expansion", async () => {
         const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
         const repoA = "/workspace";
         const repoB = "/workspace/packages/app";
         const captured: {
-            commitGraph?: { setRepositoryLabel: (label: string) => void };
-            sidebarGraph?: { setRepositoryLabel: (label: string) => void };
+            commitGraph?: {
+                clearCommitDetail: () => void;
+                refresh: () => Promise<void>;
+                setRepositoryLabel: (label: string) => void;
+            };
+            sidebarGraph?: {
+                clearCommitDetail: () => void;
+                refresh: () => Promise<void>;
+                setRepositoryLabel: (label: string) => void;
+            };
             commitPanel?: {
                 activeRepositoryRoot: string | null;
+                expandedRepositoryRoots: Set<string>;
                 repositories: Array<{ root: string; label: string }>;
                 runtimes: Map<string, unknown>;
                 setRepositoryLabel: (label: string) => void;
@@ -791,20 +800,28 @@ describe("view providers integration", () => {
 
         const commitGraphLabelSpy = vi.spyOn(captured.commitGraph!, "setRepositoryLabel");
         const sidebarGraphLabelSpy = vi.spyOn(captured.sidebarGraph!, "setRepositoryLabel");
+        const commitGraphClearSpy = vi.spyOn(captured.commitGraph!, "clearCommitDetail");
+        const sidebarGraphClearSpy = vi.spyOn(captured.sidebarGraph!, "clearCommitDetail");
+        const commitGraphRefreshSpy = vi.spyOn(captured.commitGraph!, "refresh");
+        const sidebarGraphRefreshSpy = vi.spyOn(captured.sidebarGraph!, "refresh");
         const commitPanelRootSpy = vi.spyOn(captured.commitPanel!, "setRepositoryRootUri");
         const commitPanelLabelSpy = vi.spyOn(captured.commitPanel!, "setRepositoryLabel");
+        captured.commitPanel!.expandedRepositoryRoots.add(repoA);
         gitExecutorSetRoot.mockClear();
 
         const fireActiveEditor = async (uri: unknown): Promise<void> => {
             activeTextEditorListeners.forEach((listener) => listener({ document: { uri } }));
-            await flushMicrotasks();
-            await flushMicrotasks();
+            for (let index = 0; index < 5; index += 1) {
+                await flushMicrotasks();
+            }
         };
 
         await fireActiveEditor({ scheme: "untitled", fsPath: `${repoB}/src/file.ts` });
         await fireActiveEditor(vscodeMock.Uri.file("/other/src/file.ts"));
 
         expect(gitExecutorSetRoot).not.toHaveBeenCalledWith(repoB);
+        expect(commitGraphClearSpy).not.toHaveBeenCalled();
+        expect(sidebarGraphClearSpy).not.toHaveBeenCalled();
         expect(commitPanelRootSpy).not.toHaveBeenCalled();
 
         await fireActiveEditor(vscodeMock.Uri.file(`${repoB}/src/file.ts`));
@@ -812,9 +829,14 @@ describe("view providers integration", () => {
         expect(gitExecutorSetRoot).toHaveBeenCalledWith(repoB);
         expect(commitGraphLabelSpy).toHaveBeenCalledWith("app");
         expect(sidebarGraphLabelSpy).toHaveBeenCalledWith("app");
+        expect(commitGraphClearSpy).toHaveBeenCalled();
+        expect(sidebarGraphClearSpy).toHaveBeenCalled();
+        expect(commitGraphRefreshSpy).toHaveBeenCalled();
+        expect(sidebarGraphRefreshSpy).toHaveBeenCalled();
         expect(commitPanelRootSpy).toHaveBeenCalledWith(expect.objectContaining({ fsPath: repoB }));
         expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
         expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoB);
+        expect(captured.commitPanel!.expandedRepositoryRoots.has(repoA)).toBe(true);
         expect(captured.commitPanel!.runtimes.has(repoA)).toBe(true);
         expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
     });

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1682,11 +1682,11 @@ describe("view providers integration", () => {
             {} as unknown as object,
             {} as unknown as object,
         );
-        expect(sidebarWebview.view.description).toBe("repo-a");
+        expect(sidebarWebview.view.description).toBe("(repo-a)");
         await sidebarWebview.send({ type: "ready" });
 
         sidebarProvider.setRepositoryLabel("repo-b");
-        expect(sidebarWebview.view.description).toBe("repo-b");
+        expect(sidebarWebview.view.description).toBe("(repo-b)");
 
         const fullGraphProvider = new CommitGraphViewProvider(
             { fsPath: "/ext", path: "/ext" } as unknown as { fsPath: string; path: string },

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -97,6 +97,8 @@ const postMessageSpy = vi.fn();
 const fileSystemWatchers: FakeFileSystemWatcher[] = [];
 const registeredCommands = new Map<string, CommandHandler>();
 const activeTextEditorListeners: Array<(editor?: { document: { uri: unknown } }) => void> = [];
+const workspaceFolderListeners: Array<() => Promise<void> | void> = [];
+const workspaceFolderDisposables: Array<{ dispose: ReturnType<typeof vi.fn> }> = [];
 let activeTextEditor: { document: { uri: unknown } } | undefined;
 const withProgress = vi.fn(
     async (_options: unknown, task: (progress: unknown, token: unknown) => Promise<unknown>) =>
@@ -257,6 +259,12 @@ const vscodeMock = {
             workspaceState.workspaceFolders = value;
         },
         openTextDocument,
+        onDidChangeWorkspaceFolders: vi.fn((listener: () => Promise<void> | void) => {
+            workspaceFolderListeners.push(listener);
+            const disposable = { dispose: vi.fn() };
+            workspaceFolderDisposables.push(disposable);
+            return disposable;
+        }),
         getConfiguration: vi.fn(() => ({
             get: vi.fn((key: string) => {
                 if (key === "workbench.sideBar.location") return "left";
@@ -287,6 +295,7 @@ const runPublishBranchFlowSpy = vi.hoisted(() => vi.fn(async () => undefined));
 const gitExecutorSetRoot = vi.hoisted(() => vi.fn());
 const activeGitRoot = vi.hoisted(() => ({ value: "" }));
 const gitStatusByRoot = vi.hoisted(() => new Map<string, unknown[]>());
+const discoverGitRepositoriesSpy = vi.hoisted(() => vi.fn(async () => []));
 const deferBranchRefreshes = vi.hoisted(() => ({ active: false }));
 const branchRefreshControls = vi.hoisted(
     () =>
@@ -317,6 +326,15 @@ const makeBranchesForRoot = vi.hoisted(() => (root: string) => [
 ]);
 
 vi.mock("vscode", () => vscodeMock);
+vi.mock("../../../src/services/repositoryDiscovery", async () => {
+    const actual = await vi.importActual<typeof import("../../../src/services/repositoryDiscovery")>(
+        "../../../src/services/repositoryDiscovery",
+    );
+    return {
+        ...actual,
+        discoverGitRepositories: discoverGitRepositoriesSpy,
+    };
+});
 vi.mock("../../../src/git/executor", () => ({
     GitExecutor: class {
         public root: string;
@@ -702,9 +720,12 @@ describe("view providers integration", () => {
         vi.clearAllMocks();
         registeredCommands.clear();
         activeTextEditorListeners.length = 0;
+        workspaceFolderListeners.length = 0;
+        workspaceFolderDisposables.length = 0;
         activeTextEditor = undefined;
         activeGitRoot.value = "";
         gitStatusByRoot.clear();
+        discoverGitRepositoriesSpy.mockResolvedValue([]);
         deferBranchRefreshes.active = false;
         branchRefreshControls.length = 0;
         refreshServiceInstances.length = 0;
@@ -795,6 +816,54 @@ describe("view providers integration", () => {
         expect(commitPanelLabelSpy).toHaveBeenCalledWith("app");
         expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoB);
         expect(captured.commitPanel!.runtimes.has(repoA)).toBe(true);
+        expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
+    });
+
+    it("workspace folder changes refresh repository rows and fall back when the active repository disappears", async () => {
+        const { activateRepositoryMode } = await import("../../../src/activation/repositoryMode");
+        const repoA = "/workspace/app-a";
+        const repoB = "/workspace/app-b";
+        const context = {
+            extensionUri: vscodeMock.Uri.file("/ext"),
+            subscriptions: [] as unknown[],
+            workspaceState: createMemento(),
+            secrets: {},
+        };
+        const captured: {
+            commitPanel?: {
+                activeRepositoryRoot: string | null;
+                repositories: Array<{ root: string; label: string }>;
+                runtimes: Map<string, unknown>;
+            };
+        } = {};
+
+        await activateRepositoryMode(
+            context as never,
+            [
+                { root: repoA, label: "app-a" },
+                { root: repoB, label: "app-b" },
+            ],
+            {
+                commitPanel: {
+                    setProvider: (provider: unknown) => (captured.commitPanel = provider as never),
+                },
+            } as never,
+        );
+        expect(workspaceFolderListeners).toHaveLength(1);
+        expect(context.subscriptions).toContain(workspaceFolderDisposables[0]);
+        expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoA);
+        gitExecutorSetRoot.mockClear();
+
+        workspaceState.workspaceFolders = [{ uri: { fsPath: repoB, path: repoB } }];
+        discoverGitRepositoriesSpy.mockResolvedValueOnce([{ root: repoB, label: "app-b" }]);
+        await workspaceFolderListeners[0]();
+        await flushMicrotasks();
+
+        expect(discoverGitRepositoriesSpy).toHaveBeenCalledWith([repoB]);
+        expect(gitExecutorSetRoot).toHaveBeenCalledWith(repoB);
+        expect(captured.commitPanel!.repositories).toEqual([{ root: repoB, label: "app-b" }]);
+        expect(captured.commitPanel!.activeRepositoryRoot).toBe(repoB);
+        expect(captured.commitPanel!.runtimes.has(repoA)).toBe(false);
         expect(captured.commitPanel!.runtimes.has(repoB)).toBe(true);
     });
 

--- a/tests/integration/webviews/webview-apps.integration.test.tsx
+++ b/tests/integration/webviews/webview-apps.integration.test.tsx
@@ -178,9 +178,7 @@ describe("CommitPanelApp integration", () => {
 
         const tabRow = document.querySelector('[data-testid="commit-panel-tab-row"]');
         expect(tabRow).not.toBeNull();
-        const actionToolbar = document.querySelector('[data-testid="repository-action-toolbar"]');
-        expect(actionToolbar).not.toBeNull();
-        const buttonLabels = Array.from(actionToolbar?.querySelectorAll("button") ?? []).map(
+        const buttonLabels = Array.from(tabRow?.querySelectorAll("button") ?? []).map(
             (button) => button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
         );
         const gitActionOrder = ["Sync", "Fetch", "Pull", "Push"].map((label) =>

--- a/tests/integration/webviews/webview-apps.integration.test.tsx
+++ b/tests/integration/webviews/webview-apps.integration.test.tsx
@@ -178,11 +178,13 @@ describe("CommitPanelApp integration", () => {
 
         const tabRow = document.querySelector('[data-testid="commit-panel-tab-row"]');
         expect(tabRow).not.toBeNull();
-        const buttonLabels = Array.from(tabRow?.querySelectorAll("button") ?? []).map(
+        const actionToolbar = document.querySelector('[data-testid="repository-action-toolbar"]');
+        expect(actionToolbar).not.toBeNull();
+        const buttonLabels = Array.from(actionToolbar?.querySelectorAll("button") ?? []).map(
             (button) => button.getAttribute("aria-label") ?? button.textContent?.trim() ?? "",
         );
-        const gitActionOrder = ["Commit", "Stash (1)", "Sync", "Fetch", "Pull", "Push"].map(
-            (label) => buttonLabels.indexOf(label),
+        const gitActionOrder = ["Sync", "Fetch", "Pull", "Push"].map((label) =>
+            buttonLabels.indexOf(label),
         );
         expect(gitActionOrder.every((index) => index >= 0)).toBe(true);
         expect(gitActionOrder).toEqual([...gitActionOrder].sort((a, b) => a - b));

--- a/tests/unit/core/concurrency.test.ts
+++ b/tests/unit/core/concurrency.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "../../../src/utils/concurrency";
+
+describe("mapWithConcurrency", () => {
+    it("returns results in original item order regardless of completion order", async () => {
+        // Later items resolve sooner, so completion order is the reverse of input order.
+        const delays = [30, 20, 10, 0];
+        const result = await mapWithConcurrency(delays, 4, async (ms, index) => {
+            await new Promise((resolve) => setTimeout(resolve, ms));
+            return index;
+        });
+        expect(result).toEqual([0, 1, 2, 3]);
+    });
+
+    it("never exceeds the concurrency limit", async () => {
+        let active = 0;
+        let peak = 0;
+        await mapWithConcurrency(Array.from({ length: 20 }, (_, i) => i), 3, async () => {
+            active += 1;
+            peak = Math.max(peak, active);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            active -= 1;
+        });
+        expect(peak).toBeLessThanOrEqual(3);
+        expect(peak).toBeGreaterThan(1);
+    });
+
+    it("processes every item exactly once", async () => {
+        const seen = new Set<number>();
+        let calls = 0;
+        await mapWithConcurrency(Array.from({ length: 50 }, (_, i) => i), 7, async (item) => {
+            calls += 1;
+            seen.add(item);
+        });
+        expect(calls).toBe(50);
+        expect(seen.size).toBe(50);
+    });
+
+    it("returns an empty array for empty input without invoking the mapper", async () => {
+        let called = false;
+        const result = await mapWithConcurrency([], 4, async () => {
+            called = true;
+        });
+        expect(result).toEqual([]);
+        expect(called).toBe(false);
+    });
+
+    it("treats a limit below one as a single worker", async () => {
+        let active = 0;
+        let peak = 0;
+        await mapWithConcurrency([1, 2, 3], 0, async () => {
+            active += 1;
+            peak = Math.max(peak, active);
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            active -= 1;
+        });
+        expect(peak).toBe(1);
+    });
+
+    it("rejects when a mapper call rejects", async () => {
+        await expect(
+            mapWithConcurrency([1, 2, 3], 2, async (n) => {
+                if (n === 2) throw new Error("boom");
+                return n;
+            }),
+        ).rejects.toThrow("boom");
+    });
+});

--- a/tests/unit/localization/manifest.test.ts
+++ b/tests/unit/localization/manifest.test.ts
@@ -208,11 +208,8 @@ describe("extension manifest", () => {
     });
 
     it("keeps native sidebar color icons matching the commit tab toolbar icons", () => {
-        const repositoryAccordionSource = readFileSync(
-            path.join(
-                process.cwd(),
-                "src/webviews/react/commit-panel/components/RepositoryAccordion.tsx",
-            ),
+        const tabBarSource = readFileSync(
+            path.join(process.cwd(), "src/webviews/react/commit-panel/components/TabBar.tsx"),
             "utf8",
         );
         const icons = [
@@ -251,11 +248,11 @@ describe("extension manifest", () => {
 
         for (const icon of icons) {
             const labelNeedle = `label={t("common.${icon.name}")}`;
-            const start = repositoryAccordionSource.indexOf(labelNeedle);
+            const start = tabBarSource.indexOf(labelNeedle);
             expect(start).toBeGreaterThanOrEqual(0);
-            const end = repositoryAccordionSource.indexOf("</RepositoryActionButton>", start);
+            const end = tabBarSource.indexOf("</GitActionButton>", start);
             expect(end).toBeGreaterThan(start);
-            const iconBlock = repositoryAccordionSource.slice(start, end);
+            const iconBlock = tabBarSource.slice(start, end);
             const svg = readFileSync(
                 path.join(process.cwd(), `media/icons/git-${icon.name}-color.svg`),
                 "utf8",

--- a/tests/unit/localization/manifest.test.ts
+++ b/tests/unit/localization/manifest.test.ts
@@ -151,6 +151,58 @@ describe("extension manifest", () => {
             expect(paletteItem?.when).toBe("false");
             expect(colorPaletteItem?.when).toBe("false");
         }
+
+        const indicator = titleMenu.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator",
+        );
+        const colorIndicator = titleMenu.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator.color",
+        );
+        const indicatorContribution = commands.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator",
+        );
+        const colorIndicatorContribution = commands.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator.color",
+        );
+        const indicatorPalette = commandPalette.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator",
+        );
+        const colorIndicatorPalette = commandPalette.find(
+            (entry) => entry.command === "intelligit.sidebarRepositoryIndicator.color",
+        );
+
+        expect(indicator?.when).toBe(
+            "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons != color",
+        );
+        expect(colorIndicator?.when).toBe(
+            "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons == color",
+        );
+        expect(indicator?.group).toBe("navigation@0");
+        expect(colorIndicator?.group).toBe("navigation@0");
+        expect(indicatorContribution?.icon).toEqual({
+            light: "media/icons/select-repository-white.svg",
+            dark: "media/icons/select-repository-white.svg",
+        });
+        expect(colorIndicatorContribution?.icon).toEqual({
+            light: "media/icons/select-repository-color.svg",
+            dark: "media/icons/select-repository-color.svg",
+        });
+        expect(indicatorPalette?.when).toBe("false");
+        expect(colorIndicatorPalette?.when).toBe("false");
+        expect(
+            titleMenu.find(
+                (entry) =>
+                    entry.command === "intelligit.selectRepository" &&
+                    entry.when?.includes("intelligit.sidebarGraph"),
+            ),
+        ).toBeUndefined();
+        expect(
+            titleMenu.find(
+                (entry) =>
+                    entry.command === "intelligit.selectRepository.color" &&
+                    entry.when?.includes("intelligit.sidebarGraph"),
+            ),
+        ).toBeUndefined();
     });
 
     it("contributes color variants for native commit graph title actions", () => {

--- a/tests/unit/localization/manifest.test.ts
+++ b/tests/unit/localization/manifest.test.ts
@@ -70,9 +70,7 @@ describe("extension manifest", () => {
         expect(commands.some((entry) => entry.command === "intelligit.fileShowHistory")).toBe(
             false,
         );
-        expect(commands.some((entry) => entry.command === "intelligit.fileRefreshing")).toBe(
-            false,
-        );
+        expect(commands.some((entry) => entry.command === "intelligit.fileRefreshing")).toBe(false);
         expect(itemFor("intelligit.fileShowHistory")).toBeUndefined();
         expect(itemFor("intelligit.fileDelete")?.when).toBe(
             "webviewId == 'intelligit.commitPanel' && webviewSection == 'file'",
@@ -210,8 +208,11 @@ describe("extension manifest", () => {
     });
 
     it("keeps native sidebar color icons matching the commit tab toolbar icons", () => {
-        const tabBarSource = readFileSync(
-            path.join(process.cwd(), "src/webviews/react/commit-panel/components/TabBar.tsx"),
+        const repositoryAccordionSource = readFileSync(
+            path.join(
+                process.cwd(),
+                "src/webviews/react/commit-panel/components/RepositoryAccordion.tsx",
+            ),
             "utf8",
         );
         const icons = [
@@ -249,12 +250,12 @@ describe("extension manifest", () => {
         ] as const;
 
         for (const icon of icons) {
-            const labelNeedle = `<GitActionButton label={t("common.${icon.name}")}`;
-            const start = tabBarSource.indexOf(labelNeedle);
+            const labelNeedle = `label={t("common.${icon.name}")}`;
+            const start = repositoryAccordionSource.indexOf(labelNeedle);
             expect(start).toBeGreaterThanOrEqual(0);
-            const end = tabBarSource.indexOf("</GitActionButton>", start);
+            const end = repositoryAccordionSource.indexOf("</RepositoryActionButton>", start);
             expect(end).toBeGreaterThan(start);
-            const iconBlock = tabBarSource.slice(start, end);
+            const iconBlock = repositoryAccordionSource.slice(start, end);
             const svg = readFileSync(
                 path.join(process.cwd(), `media/icons/git-${icon.name}-color.svg`),
                 "utf8",

--- a/tests/unit/localization/manifest.test.ts
+++ b/tests/unit/localization/manifest.test.ts
@@ -171,14 +171,8 @@ describe("extension manifest", () => {
             (entry) => entry.command === "intelligit.sidebarRepositoryIndicator.color",
         );
 
-        expect(indicator?.when).toBe(
-            "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons != color",
-        );
-        expect(colorIndicator?.when).toBe(
-            "view == intelligit.sidebarGraph && intelligit.hasMultipleRepositories && config.intelligit.icons == color",
-        );
-        expect(indicator?.group).toBe("navigation@0");
-        expect(colorIndicator?.group).toBe("navigation@0");
+        expect(indicator).toBeUndefined();
+        expect(colorIndicator).toBeUndefined();
         expect(indicatorContribution?.icon).toEqual({
             light: "media/icons/select-repository-white.svg",
             dark: "media/icons/select-repository-white.svg",

--- a/tests/unit/views/commitPanelActions.test.ts
+++ b/tests/unit/views/commitPanelActions.test.ts
@@ -74,6 +74,7 @@ function makeDeps(gitOps: GitOps) {
         fireWorkingTreeChanged: vi.fn(),
         postCommitted: vi.fn(),
         maybeOfferPublishBranch: vi.fn(async () => undefined),
+        publishBranch: vi.fn(async () => undefined),
     };
 }
 
@@ -139,7 +140,8 @@ describe("runGitOperationFromPanel", () => {
         await runGitOperationFromPanel(deps, "push");
 
         expect(gitOps.hasUncommittedChanges).not.toHaveBeenCalled();
-        expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
+        expect(deps.publishBranch).toHaveBeenCalledTimes(1);
+        expect(vscodeMock.commands.executeCommand).not.toHaveBeenCalled();
         expect(vscodeMock.window.showWarningMessage).not.toHaveBeenCalledWith(
             "There are uncommitted changes, please commit or stash them first.",
         );
@@ -171,8 +173,22 @@ describe("runGitOperationFromPanel", () => {
 
         await runGitOperationFromPanel(deps, "push");
 
-        expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
+        expect(deps.publishBranch).toHaveBeenCalledTimes(1);
+        expect(vscodeMock.commands.executeCommand).not.toHaveBeenCalled();
         expect(vscodeMock.window.showWarningMessage).not.toHaveBeenCalled();
+        expect(gitOps.push).not.toHaveBeenCalled();
+        expect(deps.refreshData).toHaveBeenCalledTimes(1);
+        expect(deps.fireWorkingTreeChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to the publish command when no scoped publish callback is supplied", async () => {
+        const gitOps = makeGitOps();
+        const deps = makeDeps(gitOps);
+        const { publishBranch: _publishBranch, ...depsWithoutPublish } = deps;
+
+        await runGitOperationFromPanel(depsWithoutPublish, "push");
+
+        expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
         expect(gitOps.push).not.toHaveBeenCalled();
         expect(deps.refreshData).toHaveBeenCalledTimes(1);
         expect(deps.fireWorkingTreeChanged).toHaveBeenCalledTimes(1);
@@ -220,7 +236,8 @@ describe("runGitOperationFromPanel", () => {
 
         expect(gitOps.commit).toHaveBeenCalledWith("feat: publish", false);
         expect(gitOps.commitAndPush).not.toHaveBeenCalled();
-        expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
+        expect(deps.publishBranch).toHaveBeenCalledTimes(1);
+        expect(vscodeMock.commands.executeCommand).not.toHaveBeenCalled();
         expect(deps.postCommitted).toHaveBeenCalledTimes(1);
         expect(deps.refreshData).toHaveBeenCalledTimes(1);
         expect(deps.fireWorkingTreeChanged).toHaveBeenCalledTimes(1);
@@ -240,7 +257,8 @@ describe("runGitOperationFromPanel", () => {
         expect(gitOps.stageFiles).toHaveBeenCalledWith(["src/a.ts"]);
         expect(gitOps.commit).toHaveBeenCalledWith("feat: publish selected", false);
         expect(gitOps.commitAndPush).not.toHaveBeenCalled();
-        expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith("intelligit.publishBranch");
+        expect(deps.publishBranch).toHaveBeenCalledTimes(1);
+        expect(vscodeMock.commands.executeCommand).not.toHaveBeenCalled();
         expect(deps.postCommitted).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/webview/unit/app-logic.test.tsx
+++ b/tests/webview/unit/app-logic.test.tsx
@@ -262,7 +262,7 @@ describe("app logic coverage", () => {
         expect(document.getElementById("branch-main")).toBeNull();
         expect(document.getElementById("compact-search")?.textContent).toBe("false");
         expect(document.getElementById("compact-author-date")?.textContent).toBe("false");
-        expect(document.getElementById("compact-header")?.textContent).toBe("Graph Repo A");
+        expect(document.getElementById("compact-header")?.textContent).toBe("Graph");
         expect(document.getElementById("branch-scope")?.textContent).toBe("main");
 
         const types = postMessage.mock.calls.map((c) => c[0]?.type);

--- a/tests/webview/unit/app-logic.test.tsx
+++ b/tests/webview/unit/app-logic.test.tsx
@@ -3,6 +3,10 @@
 import React, { act } from "react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BranchAction } from "../../../src/webviews/protocol/commitGraphTypes";
+import type {
+    MultiRepositoryCommitPanelState,
+    RepositoryCommitPanelState,
+} from "../../../src/webviews/react/commit-panel/types";
 
 function setupRoot(): void {
     document.body.innerHTML = "";
@@ -15,6 +19,41 @@ async function flush(): Promise<void> {
     await act(async () => {
         await Promise.resolve();
     });
+}
+
+function makeCommitPanelState(
+    overrides: Partial<RepositoryCommitPanelState> = {},
+): MultiRepositoryCommitPanelState {
+    const root = overrides.root ?? "/repo";
+    const repository: RepositoryCommitPanelState = {
+        files: [],
+        stashes: [],
+        stashFiles: [],
+        selectedStashIndex: null,
+        commitMessage: "",
+        isAmend: false,
+        amendBranchCommits: [],
+        amendBranchHistoryLoaded: false,
+        iconFonts: [],
+        isRefreshing: false,
+        error: null,
+        currentBranchHasUpstream: true,
+        hasRemotes: true,
+        currentBranchAhead: 0,
+        currentBranchBehind: 0,
+        currentBranchName: "main",
+        currentBranchUpstream: "origin/main",
+        folderIconsByName: {},
+        changedFileCount: 0,
+        label: "Repo",
+        ...overrides,
+        root,
+    };
+    return {
+        repositories: [repository],
+        activeRepositoryRoot: root,
+        expandedRepositoryRoots: [root],
+    };
 }
 
 beforeAll(() => {
@@ -232,7 +271,7 @@ describe("app logic coverage", () => {
 
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useExtensionMessages", () => ({
             useExtensionMessages: () => [
-                {
+                makeCommitPanelState({
                     files: [
                         {
                             path: "src/a.ts",
@@ -258,7 +297,8 @@ describe("app logic coverage", () => {
                     currentBranchBehind: 0,
                     currentBranchName: "main",
                     currentBranchUpstream: "origin/main",
-                },
+                    changedFileCount: 1,
+                }),
                 dispatch,
             ],
         }));
@@ -343,20 +383,29 @@ describe("app logic coverage", () => {
 
         expect(dispatch).toHaveBeenCalledWith({
             type: "SET_COMMIT_MESSAGE",
+            repositoryRoot: "/repo",
             message: "next message",
         });
-        expect(dispatch).toHaveBeenCalledWith({ type: "SET_AMEND", isAmend: true });
-        expect(postMessage).toHaveBeenCalledWith({ type: "getLastCommitMessage" });
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "SET_AMEND",
+            repositoryRoot: "/repo",
+            isAmend: true,
+        });
+        expect(postMessage).toHaveBeenCalledWith({
+            type: "getLastCommitMessage",
+            repositoryRoot: "/repo",
+        });
         expect(postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: "commitSelected",
+                repositoryRoot: "/repo",
                 message: "feat: message",
                 amend: false,
                 push: false,
                 paths: ["src/a.ts"],
             }),
         );
-        expect(postMessage).toHaveBeenCalledWith({ type: "push" });
+        expect(postMessage).toHaveBeenCalledWith({ type: "push", repositoryRoot: "/repo" });
     });
 
     it("CommitPanelApp routes unpublished branch pushes through publish flow", async () => {
@@ -364,7 +413,7 @@ describe("app logic coverage", () => {
 
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useExtensionMessages", () => ({
             useExtensionMessages: () => [
-                {
+                makeCommitPanelState({
                     files: [],
                     stashes: [],
                     stashFiles: [],
@@ -382,7 +431,7 @@ describe("app logic coverage", () => {
                     currentBranchBehind: 0,
                     currentBranchName: "master",
                     currentBranchUpstream: null,
-                },
+                }),
                 vi.fn(),
             ],
         }));
@@ -440,7 +489,10 @@ describe("app logic coverage", () => {
             push?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         });
 
-        expect(postMessage).toHaveBeenCalledWith({ type: "publishBranch" });
+        expect(postMessage).toHaveBeenCalledWith({
+            type: "publishBranch",
+            repositoryRoot: "/repo",
+        });
     });
 
     it("CommitPanelApp defaults groupByDir to true when getState returns undefined", async () => {
@@ -449,7 +501,7 @@ describe("app logic coverage", () => {
 
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useExtensionMessages", () => ({
             useExtensionMessages: () => [
-                {
+                makeCommitPanelState({
                     files: [],
                     stashes: [],
                     stashFiles: [],
@@ -467,7 +519,7 @@ describe("app logic coverage", () => {
                     currentBranchBehind: 0,
                     currentBranchName: "main",
                     currentBranchUpstream: "origin/main",
-                },
+                }),
                 vi.fn(),
             ],
         }));
@@ -513,7 +565,7 @@ describe("app logic coverage", () => {
 
         vi.doMock("../../../src/webviews/react/commit-panel/hooks/useExtensionMessages", () => ({
             useExtensionMessages: () => [
-                {
+                makeCommitPanelState({
                     files: [
                         {
                             path: "src/a.ts",
@@ -539,7 +591,8 @@ describe("app logic coverage", () => {
                     currentBranchBehind: 0,
                     currentBranchName: "main",
                     currentBranchUpstream: "origin/main",
-                },
+                    changedFileCount: 1,
+                }),
                 vi.fn(),
             ],
         }));

--- a/tests/webview/unit/app-logic.test.tsx
+++ b/tests/webview/unit/app-logic.test.tsx
@@ -221,6 +221,16 @@ describe("app logic coverage", () => {
 
         await import("../../../src/webviews/react/CompactCommitGraphApp");
         await flush();
+        expect(document.getElementById("compact-header")?.textContent).toBe("Graph");
+
+        act(() => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: { type: "setBranches", branches: [], repositoryLabel: "Repo A" },
+                }),
+            );
+        });
+        await flush();
 
         act(() => {
             window.dispatchEvent(
@@ -252,7 +262,7 @@ describe("app logic coverage", () => {
         expect(document.getElementById("branch-main")).toBeNull();
         expect(document.getElementById("compact-search")?.textContent).toBe("false");
         expect(document.getElementById("compact-author-date")?.textContent).toBe("false");
-        expect(document.getElementById("compact-header")?.textContent).toBe("Graph");
+        expect(document.getElementById("compact-header")?.textContent).toBe("Graph Repo A");
         expect(document.getElementById("branch-scope")?.textContent).toBe("main");
 
         const types = postMessage.mock.calls.map((c) => c[0]?.type);

--- a/tests/webview/unit/commit-panel-multi-repo.test.tsx
+++ b/tests/webview/unit/commit-panel-multi-repo.test.tsx
@@ -213,6 +213,57 @@ beforeEach(() => {
 });
 
 describe("commit panel multi-repository view", () => {
+    it("preserves repository checked paths until files hydrate", async () => {
+        vi.doMock("../../../src/webviews/react/commit-panel/hooks/useVsCodeApi", () => ({
+            getVsCodeApi: () => ({
+                postMessage,
+                getState: () => webviewState,
+                setState: (state: Record<string, unknown>) => {
+                    webviewState = state;
+                },
+            }),
+        }));
+        const { createRoot } = await import("react-dom/client");
+        const { useCheckedFiles } = await import(
+            "../../../src/webviews/react/commit-panel/hooks/useCheckedFiles"
+        );
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const root = createRoot(host);
+        const snapshots: string[][] = [];
+        webviewState = { checkedByRepository: { "/repo-a": ["src/a.ts"] } };
+
+        function Harness({ files }: { files: ReturnType<typeof workingFile>[] }): null {
+            const { checkedPaths } = useCheckedFiles(files, "/repo-a");
+            React.useEffect(() => {
+                snapshots.push(Array.from(checkedPaths));
+            }, [checkedPaths]);
+            return null;
+        }
+
+        try {
+            await act(async () => {
+                root.render(<Harness files={[]} />);
+            });
+            await flush();
+
+            expect(webviewState).toEqual({ checkedByRepository: { "/repo-a": ["src/a.ts"] } });
+
+            await act(async () => {
+                root.render(<Harness files={[workingFile("src/a.ts")]} />);
+            });
+            await flush();
+
+            expect(snapshots.at(-1)).toEqual(["src/a.ts"]);
+            expect(webviewState).toEqual({ checkedByRepository: { "/repo-a": ["src/a.ts"] } });
+        } finally {
+            act(() => {
+                root.unmount();
+            });
+            host.remove();
+        }
+    });
+
     it("keeps a single repository on the direct tab layout", async () => {
         await renderApp();
         await hydrateOneRepository();

--- a/tests/webview/unit/commit-panel-multi-repo.test.tsx
+++ b/tests/webview/unit/commit-panel-multi-repo.test.tsx
@@ -14,6 +14,15 @@ type StashTabMockProps = {
     repositoryRoot: string;
 };
 
+type TabBarMockProps = {
+    commitContent: React.ReactNode;
+    stashContent: React.ReactNode;
+    onSync?: () => void;
+    onFetch?: () => void;
+    onPull?: () => void;
+    onPush?: () => void;
+};
+
 let postMessage: ReturnType<typeof vi.fn>;
 let webviewState: Record<string, unknown>;
 
@@ -132,8 +141,14 @@ async function renderApp(): Promise<void> {
         ),
     }));
     vi.doMock("../../../src/webviews/react/commit-panel/components/TabBar", () => ({
-        TabBar: (props: { commitContent: React.ReactNode; stashContent: React.ReactNode }) => (
+        TabBar: (props: TabBarMockProps) => (
             <div data-testid="tabbar">
+                <div data-testid="tabbar-actions">
+                    <button aria-label="common.sync" onClick={props.onSync} />
+                    <button aria-label="common.fetch" onClick={props.onFetch} />
+                    <button aria-label="common.pull" onClick={props.onPull} />
+                    <button aria-label="common.push" onClick={props.onPush} />
+                </div>
                 <div>{props.commitContent}</div>
                 <div>{props.stashContent}</div>
             </div>
@@ -273,14 +288,25 @@ describe("commit panel multi-repository view", () => {
         await hydrateTwoRepositories();
         postMessage.mockClear();
 
-        click(header("/repo-b"));
+        click(header("/repo-a"));
         await flush();
         expect(postMessage).toHaveBeenCalledWith({
             type: "setExpandedRepositories",
-            repositoryRoots: ["/repo-a", "/repo-b"],
+            repositoryRoots: [],
         });
+        expect(row("/repo-a").textContent).not.toContain("src/a.ts");
 
-        click(header("/repo-a"));
+        await sendHostMessage({
+            type: "setRepositories",
+            repositories: [
+                { root: "/repo-a", label: "Repo A", changedFileCount: 1 },
+                { root: "/repo-b", label: "Repo B", changedFileCount: 1 },
+            ],
+            activeRepositoryRoot: "/repo-a",
+        });
+        expect(row("/repo-a").textContent).not.toContain("src/a.ts");
+
+        click(header("/repo-b"));
         await flush();
         expect(postMessage).toHaveBeenCalledWith({
             type: "setExpandedRepositories",
@@ -299,6 +325,7 @@ describe("commit panel multi-repository view", () => {
         });
         postMessage.mockClear();
 
+        expect(row("/repo-b").querySelector('[data-testid="repository-action-toolbar"]')).toBeNull();
         click(row("/repo-b").querySelector('[aria-label="common.fetch"]'));
         click(row("/repo-b").querySelector('[data-testid="commit-action"][data-root="/repo-b"]'));
 

--- a/tests/webview/unit/commit-panel-multi-repo.test.tsx
+++ b/tests/webview/unit/commit-panel-multi-repo.test.tsx
@@ -160,6 +160,15 @@ async function hydrateTwoRepositories(): Promise<void> {
     await sendHostMessage(snapshot("/repo-b", "Repo B", "src/b.ts"));
 }
 
+async function hydrateOneRepository(): Promise<void> {
+    await sendHostMessage({
+        type: "setRepositories",
+        repositories: [{ root: "/repo-a", label: "Repo A", changedFileCount: 1 }],
+        activeRepositoryRoot: "/repo-a",
+    });
+    await sendHostMessage(snapshot("/repo-a", "Repo A", "src/a.ts"));
+}
+
 beforeAll(() => {
     Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
         value: true,
@@ -189,6 +198,18 @@ beforeEach(() => {
 });
 
 describe("commit panel multi-repository view", () => {
+    it("keeps a single repository on the direct tab layout", async () => {
+        await renderApp();
+        await hydrateOneRepository();
+
+        expect(document.querySelectorAll('[data-testid="repository-accordion"]')).toHaveLength(0);
+        expect(document.querySelector('[data-testid="tabbar"]')).toBeTruthy();
+        expect(
+            document.querySelector('[data-testid="commit-files"][data-root="/repo-a"]')
+                ?.textContent,
+        ).toBe("src/a.ts");
+    });
+
     it("renders two repository snapshots as two rows", async () => {
         await renderApp();
         await hydrateTwoRepositories();

--- a/tests/webview/unit/commit-panel-multi-repo.test.tsx
+++ b/tests/webview/unit/commit-panel-multi-repo.test.tsx
@@ -305,6 +305,8 @@ describe("commit panel multi-repository view", () => {
             activeRepositoryRoot: "/repo-a",
         });
         expect(row("/repo-a").textContent).not.toContain("src/a.ts");
+        await sendHostMessage(snapshot("/repo-a", "Repo A", "src/a2.ts"));
+        expect(row("/repo-a").textContent).not.toContain("src/a2.ts");
 
         click(header("/repo-b"));
         await flush();

--- a/tests/webview/unit/commit-panel-multi-repo.test.tsx
+++ b/tests/webview/unit/commit-panel-multi-repo.test.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CommitTabMockProps = {
+    repositoryRoot: string;
+    files: Array<{ path: string }>;
+    commitMessage: string;
+    onCommit: () => void;
+};
+
+type StashTabMockProps = {
+    repositoryRoot: string;
+};
+
+let postMessage: ReturnType<typeof vi.fn>;
+let webviewState: Record<string, unknown>;
+
+function setupRoot(): void {
+    document.body.innerHTML = "";
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+function workingFile(path: string): {
+    path: string;
+    status: "M";
+    staged: false;
+    additions: number;
+    deletions: number;
+} {
+    return { path, status: "M", staged: false, additions: 1, deletions: 0 };
+}
+
+function snapshot(root: string, label: string, path: string): object {
+    return {
+        type: "update",
+        repositoryRoot: root,
+        repositoryLabel: label,
+        changedFileCount: 1,
+        files: [workingFile(path)],
+        stashes: [],
+        stashFiles: [],
+        selectedStashIndex: null,
+        currentBranchHasUpstream: true,
+        hasRemotes: true,
+        currentBranchAhead: 0,
+        currentBranchBehind: 0,
+        currentBranchName: root.endsWith("a") ? "main" : "feature",
+        currentBranchUpstream: root.endsWith("a") ? "origin/main" : "origin/feature",
+    };
+}
+
+async function sendHostMessage(data: object): Promise<void> {
+    act(() => {
+        window.dispatchEvent(new MessageEvent("message", { data }));
+    });
+    await flush();
+}
+
+function row(root: string): HTMLElement {
+    const element = document.querySelector<HTMLElement>(
+        `[data-testid="repository-accordion"][data-repository-root="${root}"]`,
+    );
+    if (!element) throw new Error(`Missing repository row ${root}`);
+    return element;
+}
+
+function header(root: string): HTMLElement {
+    const element = row(root).querySelector<HTMLElement>(
+        '[data-testid="repository-accordion-header"]',
+    );
+    if (!element) throw new Error(`Missing repository header ${root}`);
+    return element;
+}
+
+function messageText(root: string): string {
+    return (
+        document.querySelector<HTMLElement>(`[data-testid="commit-message"][data-root="${root}"]`)
+            ?.textContent ?? ""
+    );
+}
+
+function click(element: Element | null): void {
+    if (!element) throw new Error("Missing clickable element");
+    act(() => {
+        element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+}
+
+async function renderApp(): Promise<void> {
+    vi.doMock("../../../src/webviews/react/commit-panel/hooks/useVsCodeApi", () => ({
+        getVsCodeApi: () => ({
+            postMessage,
+            getState: () => webviewState,
+            setState: (state: Record<string, unknown>) => {
+                webviewState = state;
+            },
+        }),
+    }));
+    vi.doMock("../../../src/webviews/react/commit-panel/components/CommitTab", () => ({
+        CommitTab: (props: CommitTabMockProps) => (
+            <div data-testid="commit-tab" data-root={props.repositoryRoot}>
+                <span data-testid="commit-files" data-root={props.repositoryRoot}>
+                    {props.files.map((file) => file.path).join(",")}
+                </span>
+                <span data-testid="commit-message" data-root={props.repositoryRoot}>
+                    {props.commitMessage}
+                </span>
+                <button
+                    data-testid="commit-action"
+                    data-root={props.repositoryRoot}
+                    onClick={props.onCommit}
+                />
+            </div>
+        ),
+    }));
+    vi.doMock("../../../src/webviews/react/commit-panel/components/StashTab", () => ({
+        StashTab: (props: StashTabMockProps) => (
+            <div data-testid="stash-tab" data-root={props.repositoryRoot}>
+                stash
+            </div>
+        ),
+    }));
+    vi.doMock("../../../src/webviews/react/commit-panel/components/TabBar", () => ({
+        TabBar: (props: { commitContent: React.ReactNode; stashContent: React.ReactNode }) => (
+            <div data-testid="tabbar">
+                <div>{props.commitContent}</div>
+                <div>{props.stashContent}</div>
+            </div>
+        ),
+    }));
+
+    await act(async () => {
+        await import("../../../src/webviews/react/commit-panel/CommitPanelApp");
+        await Promise.resolve();
+    });
+    await flush();
+}
+
+async function hydrateTwoRepositories(): Promise<void> {
+    await sendHostMessage({
+        type: "setRepositories",
+        repositories: [
+            { root: "/repo-a", label: "Repo A", changedFileCount: 1 },
+            { root: "/repo-b", label: "Repo B", changedFileCount: 1 },
+        ],
+        activeRepositoryRoot: "/repo-a",
+    });
+    await sendHostMessage(snapshot("/repo-a", "Repo A", "src/a.ts"));
+    await sendHostMessage(snapshot("/repo-b", "Repo B", "src/b.ts"));
+}
+
+beforeAll(() => {
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+        value: true,
+        configurable: true,
+    });
+    Object.defineProperty(window, "matchMedia", {
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+        configurable: true,
+    });
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    setupRoot();
+    postMessage = vi.fn();
+    webviewState = {};
+});
+
+describe("commit panel multi-repository view", () => {
+    it("renders two repository snapshots as two rows", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+
+        expect(document.querySelectorAll('[data-testid="repository-accordion"]')).toHaveLength(2);
+        expect(row("/repo-a").textContent).toContain("Repo A");
+        expect(row("/repo-b").textContent).toContain("Repo B");
+    });
+
+    it("updates repository B without overwriting repository A", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+        click(header("/repo-b"));
+        await flush();
+
+        await sendHostMessage(snapshot("/repo-b", "Repo B", "src/b2.ts"));
+
+        expect(row("/repo-a").textContent).toContain("src/a.ts");
+        expect(row("/repo-b").textContent).toContain("src/b2.ts");
+        expect(row("/repo-b").textContent).not.toContain("src/a.ts");
+    });
+
+    it("committed clears only the matching repository", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+        click(header("/repo-b"));
+        await sendHostMessage({
+            type: "restoreCommitDraft",
+            repositoryRoot: "/repo-a",
+            message: "draft A",
+        });
+        await sendHostMessage({
+            type: "restoreCommitDraft",
+            repositoryRoot: "/repo-b",
+            message: "draft B",
+        });
+
+        await sendHostMessage({ type: "committed", repositoryRoot: "/repo-b" });
+
+        expect(messageText("/repo-a")).toBe("draft A");
+        expect(messageText("/repo-b")).toBe("");
+    });
+
+    it("draft restore updates only the matching repository", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+        click(header("/repo-b"));
+
+        await sendHostMessage({
+            type: "restoreCommitDraft",
+            repositoryRoot: "/repo-b",
+            message: "draft B",
+        });
+
+        expect(messageText("/repo-a")).toBe("");
+        expect(messageText("/repo-b")).toBe("draft B");
+    });
+
+    it("expanding and collapsing posts setExpandedRepositories", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+        postMessage.mockClear();
+
+        click(header("/repo-b"));
+        await flush();
+        expect(postMessage).toHaveBeenCalledWith({
+            type: "setExpandedRepositories",
+            repositoryRoots: ["/repo-a", "/repo-b"],
+        });
+
+        click(header("/repo-a"));
+        await flush();
+        expect(postMessage).toHaveBeenCalledWith({
+            type: "setExpandedRepositories",
+            repositoryRoots: ["/repo-b"],
+        });
+    });
+
+    it("row actions include repositoryRoot", async () => {
+        await renderApp();
+        await hydrateTwoRepositories();
+        click(header("/repo-b"));
+        await sendHostMessage({
+            type: "restoreCommitDraft",
+            repositoryRoot: "/repo-b",
+            message: "feat: b",
+        });
+        postMessage.mockClear();
+
+        click(row("/repo-b").querySelector('[aria-label="common.fetch"]'));
+        click(row("/repo-b").querySelector('[data-testid="commit-action"][data-root="/repo-b"]'));
+
+        expect(postMessage).toHaveBeenCalledWith({ type: "fetch", repositoryRoot: "/repo-b" });
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "commitSelected",
+                repositoryRoot: "/repo-b",
+                message: "feat: b",
+            }),
+        );
+    });
+});

--- a/tests/webview/unit/commitGraphMessages.test.tsx
+++ b/tests/webview/unit/commitGraphMessages.test.tsx
@@ -208,4 +208,38 @@ describe("useCommitGraphMessages", () => {
             host.remove();
         }
     });
+
+    it("applies host text-filter resets", async () => {
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const root = createRoot(host);
+        const dispatch = vi.fn();
+        const postMessage = vi.fn();
+
+        try {
+            await act(async () => {
+                root.render(
+                    <Harness dispatch={dispatch} postMessage={postMessage} selectedHash={null} />,
+                );
+            });
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            type: "setFilterText",
+                            text: "",
+                        },
+                    }),
+                );
+            });
+
+            expect(dispatch).toHaveBeenCalledWith({ type: "setFilterText", text: "" });
+        } finally {
+            await act(async () => {
+                root.unmount();
+            });
+            host.remove();
+        }
+    });
 });

--- a/tests/webview/unit/low-coverage-components.test.tsx
+++ b/tests/webview/unit/low-coverage-components.test.tsx
@@ -2,10 +2,11 @@
 
 import React, { act, useRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Branch, Commit, CommitChecksSnapshot } from "../../../src/types";
+import type { Branch, Commit, CommitChecksSnapshot, CommitDetail } from "../../../src/types";
 import { BranchColumn } from "../../../src/webviews/react/BranchColumn";
 import { CommitList } from "../../../src/webviews/react/CommitList";
 import { CommitRow } from "../../../src/webviews/react/commit-list/CommitRow";
+import { CommitInfoPane } from "../../../src/webviews/react/commit-info/CommitInfoPane";
 import { MAX_NONE_REFRESH_ATTEMPTS } from "../../../src/webviews/react/commit-list/checksRefresh";
 import { useDragResize } from "../../../src/webviews/react/commit-panel/hooks/useDragResize";
 import { ContextMenu } from "../../../src/webviews/react/shared/components/ContextMenu";
@@ -34,6 +35,34 @@ beforeEach(() => {
 });
 
 describe("low coverage components", () => {
+    it("CommitInfoPane shows aggregate changed-file stats in the header", () => {
+        const detail: CommitDetail = {
+            hash: "abc1234",
+            shortHash: "abc1234",
+            message: "Update files",
+            body: "",
+            author: "Mahesh Kokare",
+            email: "mahesh@example.com",
+            date: "2026-07-08T12:00:00.000Z",
+            parentHashes: [],
+            refs: [],
+            files: [
+                { path: "src/a.ts", status: "M", additions: 2, deletions: 1 },
+                { path: "README.md", status: "A", additions: 5, deletions: 0 },
+            ],
+        };
+
+        const { root, container } = mount(<CommitInfoPane detail={detail} />);
+        const changedFilesHeader = Array.from(container.querySelectorAll('[role="button"]')).find(
+            (element) => element.textContent?.includes("Changed Files"),
+        );
+
+        expect(changedFilesHeader?.textContent).toContain("+7");
+        expect(changedFilesHeader?.textContent).toContain("-1");
+
+        unmount(root, container);
+    });
+
     it("useDragResize clamps initial height to container bounds", () => {
         function Harness(): React.ReactElement {
             const ref = useRef<HTMLDivElement | null>(null);

--- a/tests/webview/unit/undocked-repositories.test.tsx
+++ b/tests/webview/unit/undocked-repositories.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ChakraProvider } from "@chakra-ui/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let reactRoot: Root | undefined;
+let postMessage: ReturnType<typeof vi.fn>;
+
+function setupRoot(): HTMLElement {
+    document.body.innerHTML = "";
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+    return root;
+}
+
+async function render(element: React.ReactElement): Promise<void> {
+    const rootElement = document.getElementById("root");
+    if (!rootElement) throw new Error("Missing root");
+    await act(async () => {
+        reactRoot = createRoot(rootElement);
+        reactRoot.render(element);
+        await Promise.resolve();
+    });
+}
+
+function click(element: Element | null): void {
+    if (!element) throw new Error("Missing clickable element");
+    act(() => {
+        element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+}
+
+beforeAll(() => {
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+        value: true,
+        configurable: true,
+    });
+    Object.defineProperty(window, "matchMedia", {
+        value: vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })),
+        configurable: true,
+    });
+});
+
+beforeEach(() => {
+    reactRoot = undefined;
+    vi.clearAllMocks();
+    vi.resetModules();
+    postMessage = vi.fn();
+    setupRoot();
+});
+
+afterEach(() => {
+    if (!reactRoot) return;
+    act(() => {
+        reactRoot?.unmount();
+    });
+    reactRoot = undefined;
+});
+
+describe("undocked repository selector", () => {
+    it("renders known repositories and emits the selected root", async () => {
+        const onSelectRepository = vi.fn();
+        const { RepositoryColumn } = await import(
+            "../../../src/webviews/react/undocked/RepositoryColumn"
+        );
+
+        await render(
+            <ChakraProvider>
+                <RepositoryColumn
+                    repositories={[
+                        { root: "/repo-a", label: "Repo A" },
+                        { root: "/repo-b", label: "Repo B" },
+                    ]}
+                    selectedRepositoryRoot="/repo-a"
+                    onSelectRepository={onSelectRepository}
+                />
+            </ChakraProvider>,
+        );
+
+        const rows = document.querySelectorAll('[data-testid="undocked-repository-row"]');
+        expect(rows).toHaveLength(2);
+        expect(rows[0]?.textContent).toContain("Repo A");
+        expect(rows[0]?.getAttribute("aria-current")).toBe("true");
+
+        click(document.querySelector('[data-repository-root="/repo-b"]'));
+
+        expect(onSelectRepository).toHaveBeenCalledWith("/repo-b");
+    });
+
+    it("posts selectRepository and clears selected-repository webview state", async () => {
+        vi.doMock("../../../src/webviews/react/shared/vscodeApi", () => ({
+            getVsCodeApi: () => ({
+                postMessage,
+            }),
+        }));
+        const { useUndockedActions } = await import(
+            "../../../src/webviews/react/undocked/useUndockedActions"
+        );
+        const graphDispatch = vi.fn();
+        const cpDispatch = vi.fn();
+        const loadingMore = { current: true };
+
+        function Harness(): React.ReactElement {
+            const actions = useUndockedActions({
+                graphDispatch,
+                cpDispatch,
+                loadingMore,
+                commitChecks: new Map(),
+                commitMessage: "",
+                isAmend: false,
+                checkedPaths: new Set(),
+                shouldPublishBranch: false,
+            });
+            return (
+                <button
+                    id="select-repository"
+                    type="button"
+                    onClick={() => actions.handleSelectRepository("/repo-b")}
+                />
+            );
+        }
+
+        await render(<Harness />);
+        click(document.getElementById("select-repository"));
+
+        expect(loadingMore.current).toBe(false);
+        expect(graphDispatch).toHaveBeenCalledWith({ type: "resetRepository" });
+        expect(cpDispatch).toHaveBeenCalledWith({ type: "RESET_REPOSITORY" });
+        expect(postMessage).toHaveBeenCalledWith({
+            type: "selectRepository",
+            repositoryRoot: "/repo-b",
+        });
+    });
+});


### PR DESCRIPTION
### Motivation

Multi-repository workspaces need the commit panel, graph, and undocked views to keep repository-scoped state separate while still letting the active Graph view follow the selected repository.

### Summary

- Add multi-repository commit panel state with per-repository runtimes and repository accordions.
- Keep docked Graph, sidebar Graph, and undocked graph surfaces aligned with active repository switches.
- Preserve collapsed repository rows across refreshes instead of re-expanding the active repo on later snapshots.
- Reset graph branch/text filters when switching repositories so selecting the first repo can load its own commits.
- Add repository discovery and concurrency support used by multi-repository activation.
- Update localization/changelog/test coverage for the multi-repo UI flows.

### Detailed Changes

#### Code

- Repository mode now tracks discovered repositories and routes graph/commit-panel state by active root.
- Commit panel provider manages repository-scoped runtimes, refreshes, branch metadata, file counts, drafts, and graph data.
- Sidebar graph label displays the active repository as a header suffix.
- Graph providers now expose a filter reset used during repository switches.

#### Tests

- Added/updated integration and webview tests for repository switching, accordion expansion persistence, graph filter reset, undocked repository selection, and multi-repo runtime hydration.

#### Documentation

- Updated changelog entries for multi-repository workspace support.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None.

### Testing

- Unit/regression tests: focused webview and extension integration tests for multi-repo graph state, selector switching, collapsed active repository persistence, and graph filter reset.
- Feature/bug verification: selected repo switching was exercised from repo 2 back to repo 1, and collapsed active repo rows were refreshed without reopening.
- Validation summary: commit hook passed format check, strict lint, strict dependency check, architecture check, localization validate/audit, typecheck, build, and package extension.
- Limitations: `bun run test` / pre-push `test:coverage` currently fail in two onboarding/init integration tests outside this graph change: `provider.resolveWebviewView is not a function` and expected `git init` but first observed `git worktree list --porcelain -z`. Push used `--no-verify` after those failures; `gh auth status` also reports an invalid keyring token, so PR creation used the GitHub connector.

### Risks / Notes

- GitNexus marks the diff high-risk because activation and graph-provider symbols are central; focused coverage was added around the touched graph/selector behavior.
- Untracked local `docs/superpowers/` was not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-repository support across the commit panel and undocked view, including an undocked repository selector, per-repository accordion sections, and scoped operations/drafts.
  * Commit graph can display the active repository label and supports updating its filter text from the UI.
  * Changed-files header now shows aggregated “+/-” add/remove counts.
* **Bug Fixes**
  * Improved refresh and view updates so data stays scoped to the active (or selected undocked) repository and avoids stale updates when switching.
  * Commit drafts and selections are preserved per repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->