### PR TITLE
fix(commit-checks): back off GitHub rate-limit retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-07-09
+
+### Fixed
+
+- Honored GitHub API rate-limit reset headers for commit-check requests, preventing repeated GitHub calls while the account is cooling down.
+- Reused in-flight commit-check fetches for the same commit hash to avoid duplicate API calls during webview refresh bursts.
+
 ## [0.16.0] - 2026-07-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.16.0",
+    "version": "0.16.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/services/commitChecks/coordinator.ts
+++ b/src/services/commitChecks/coordinator.ts
@@ -52,6 +52,7 @@ export interface CommitChecksCoordinatorOptions {
 /** Resolves a provider per request and caches commit-check snapshots by hash. */
 export class CommitChecksCoordinator {
     private readonly cache = new Map<string, CacheEntry>();
+    private readonly inflight = new Map<string, Promise<CommitChecksSnapshot>>();
     private readonly enabled: boolean;
     private readonly providerEnabled: Partial<Record<ProviderId, boolean>>;
     private readonly ttlMs: number;
@@ -80,6 +81,7 @@ export class CommitChecksCoordinator {
     /** Drops all cached snapshots; called when the active repository changes. */
     clear(): void {
         this.cache.clear();
+        this.inflight.clear();
     }
 
     /** Returns the snapshot for a commit, serving a fresh cache hit or re-fetching. */
@@ -93,9 +95,18 @@ export class CommitChecksCoordinator {
         if (cached && this.isFresh(cached)) {
             return cached.snapshot;
         }
-        const snapshot = await this.fetchFresh(hash);
-        this.cache.set(hash, { snapshot, fetchedAt: this.now() });
-        return snapshot;
+        const inflight = this.inflight.get(hash);
+        if (inflight) return inflight;
+        const request = this.fetchFresh(hash)
+            .then((snapshot) => {
+                this.cache.set(hash, { snapshot, fetchedAt: this.now() });
+                return snapshot;
+            })
+            .finally(() => {
+                this.inflight.delete(hash);
+            });
+        this.inflight.set(hash, request);
+        return request;
     }
 
     /**

--- a/src/services/commitChecks/githubProvider.ts
+++ b/src/services/commitChecks/githubProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from "vscode";
 import type { CommitCheckItem, CommitChecksSnapshot, CommitCheckState } from "../../types";
 import { getErrorMessage } from "../../utils/errors";
-import { httpGetJson, type FetchJson } from "./http";
+import { HttpError, httpGetJson, type FetchJson } from "./http";
 import {
     aggregateState,
     compactText,
@@ -79,6 +79,8 @@ export function normalizeGithubChecks(
 /** GitHub commit-check provider backed by the built-in VS Code GitHub session. */
 export class GitHubProvider implements CommitChecksProvider {
     readonly id = "github" as const;
+    private rateLimitedUntil = 0;
+    private rateLimitError = "";
 
     /**
      * Accepts an injected HTTP boundary and an optional CI/CD include override.
@@ -87,10 +89,12 @@ export class GitHubProvider implements CommitChecksProvider {
      * @param ciCdPattern - Optional include pattern from `commitChecks.ciCdFilter`; when
      *   omitted the built-in `CICD_CHECK_PATTERN` is used. The review-bot exclusion always
      *   applies regardless of this override.
+     * @param now - Injectable clock for tests.
      */
     constructor(
         private readonly fetchJson: FetchJson = httpGetJson,
         private readonly ciCdPattern?: RegExp,
+        private readonly now: () => number = Date.now,
     ) {}
 
     /** Matches any github.com remote; the host map is not consulted for GitHub. */
@@ -118,6 +122,9 @@ export class GitHubProvider implements CommitChecksProvider {
         if (!session) {
             return { hash, state: "none", summary: summaryForState("none"), items: [] };
         }
+        if (this.now() < this.rateLimitedUntil) {
+            return unavailableSnapshot(hash, this.rateLimitError);
+        }
 
         const headers = {
             Accept: "application/vnd.github+json",
@@ -134,6 +141,10 @@ export class GitHubProvider implements CommitChecksProvider {
             this.fetchJson(`${base}/statuses?per_page=100`, headers),
         ]);
 
+        for (const result of [checkRunsResult, statusesResult]) {
+            if (result.status === "rejected") this.rememberRateLimit(result.reason);
+        }
+
         if (checkRunsResult.status === "rejected" && statusesResult.status === "rejected") {
             return unavailableSnapshot(hash, getErrorMessage(checkRunsResult.reason));
         }
@@ -145,6 +156,46 @@ export class GitHubProvider implements CommitChecksProvider {
             this.ciCdPattern,
         );
     }
+
+    private rememberRateLimit(reason: unknown): void {
+        const until = readRateLimitUntil(reason, this.now());
+        if (until <= this.rateLimitedUntil) return;
+        this.rateLimitedUntil = until;
+        this.rateLimitError = getErrorMessage(reason);
+    }
+}
+
+function readRateLimitUntil(reason: unknown, now: number): number {
+    if (
+        !(reason instanceof HttpError) ||
+        (reason.statusCode !== 403 && reason.statusCode !== 429)
+    ) {
+        return 0;
+    }
+    const retryAfter = readRetryAfter(headerValue(reason.headers, "retry-after"), now);
+    if (retryAfter > now) return retryAfter;
+    if (headerValue(reason.headers, "x-ratelimit-remaining") === "0") {
+        const resetSeconds = Number(headerValue(reason.headers, "x-ratelimit-reset"));
+        const resetMs = Number.isFinite(resetSeconds) ? resetSeconds * 1000 : 0;
+        if (resetMs > now) return resetMs;
+    }
+    return reason.statusCode === 429 ? now + 60_000 : 0;
+}
+
+function headerValue(
+    headers: Record<string, string | string[] | undefined>,
+    name: string,
+): string | undefined {
+    const value = headers[name.toLowerCase()];
+    return Array.isArray(value) ? value[0] : value;
+}
+
+function readRetryAfter(value: string | undefined, now: number): number {
+    if (!value) return 0;
+    const seconds = Number(value);
+    if (Number.isFinite(seconds)) return now + seconds * 1000;
+    const dateMs = Date.parse(value);
+    return Number.isFinite(dateMs) ? dateMs : 0;
 }
 
 function cleanRepoRef(owner: string, repo: string): GitHubRepoRef | null {

--- a/src/services/commitChecks/http.ts
+++ b/src/services/commitChecks/http.ts
@@ -9,6 +9,25 @@ import * as https from "https";
 /** Network boundary used by providers; the only thing tests mock. */
 export type FetchJson = (url: string, headers: Record<string, string>) => Promise<unknown>;
 
+/** HTTP failure that keeps response metadata needed for provider backoff. */
+export class HttpError extends Error {
+    /**
+     * Builds an HTTP failure with response headers preserved for callers.
+     *
+     * @param statusCode - Numeric HTTP status code from the response.
+     * @param message - Token-free display/error message.
+     * @param headers - Lower-cased Node response headers.
+     */
+    constructor(
+        readonly statusCode: number,
+        message: string,
+        readonly headers: Record<string, string | string[] | undefined>,
+    ) {
+        super(message);
+        this.name = "HttpError";
+    }
+}
+
 /** Performs an HTTPS GET with a 15s timeout, rejecting on any non-2xx status or invalid JSON. */
 export const httpGetJson: FetchJson = (url, headers) => {
     return new Promise((resolve, reject) => {
@@ -22,7 +41,13 @@ export const httpGetJson: FetchJson = (url, headers) => {
                 const data = Buffer.concat(chunks).toString("utf8");
                 const statusCode = res.statusCode ?? 0;
                 if (statusCode < 200 || statusCode >= 300) {
-                    reject(new Error(`HTTP ${statusCode}: ${data.slice(0, 200)}`));
+                    reject(
+                        new HttpError(
+                            statusCode,
+                            `HTTP ${statusCode}: ${data.slice(0, 200)}`,
+                            res.headers,
+                        ),
+                    );
                     return;
                 }
                 try {

--- a/tests/unit/services/commitChecks/coordinator.test.ts
+++ b/tests/unit/services/commitChecks/coordinator.test.ts
@@ -450,6 +450,30 @@ describe("CommitChecksCoordinator — TTL throttle (fake clock)", () => {
         expect(third.state).toBe("success");
     });
 
+    it("shares concurrent fetches for the same hash", async () => {
+        const getChecks = vi.fn(
+            () =>
+                new Promise<CommitChecksSnapshot>((resolve) => {
+                    setTimeout(() => resolve(snapshot("pending")), 0);
+                }),
+        );
+        const provider = makeProvider("github", "github.com", getChecks);
+        const coordinator = new CommitChecksCoordinator(
+            makeGitOps({ origin: "git@github.com:owner/repo.git" }),
+            [provider],
+            {},
+            { ttlMs: 15_000 },
+        );
+
+        const [first, second] = await Promise.all([
+            coordinator.getChecks("abc1234"),
+            coordinator.getChecks("abc1234"),
+        ]);
+
+        expect(first).toBe(second);
+        expect(getChecks).toHaveBeenCalledTimes(1);
+    });
+
     it("auto-recovers an unavailable snapshot after the TTL (simulated 429 clears)", async () => {
         let clock = 0;
         const getChecks = vi

--- a/tests/unit/services/commitChecks/githubProvider.test.ts
+++ b/tests/unit/services/commitChecks/githubProvider.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { interpolateL10n } from "../../../helpers/l10nTestHelper";
-import type { FetchJson } from "../../../../src/services/commitChecks/http";
+import { HttpError, type FetchJson } from "../../../../src/services/commitChecks/http";
 import type { ProviderRepoRef } from "../../../../src/services/commitChecks/types";
 
 const mocks = vi.hoisted(() => ({
@@ -278,6 +278,30 @@ describe("GitHubProvider", () => {
 
         expect(snapshot.state).toBe("success");
         expect(snapshot.items).toHaveLength(1);
+    });
+
+    it("backs off after GitHub returns a primary rate-limit response", async () => {
+        let clock = 1_000;
+        const error = new HttpError(403, "HTTP 403: API rate limit exceeded", {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "61",
+        });
+        const fetchJson: FetchJson = vi.fn(async () => {
+            throw error;
+        });
+        const provider = new GitHubProvider(fetchJson, undefined, () => clock);
+
+        const first = await provider.getChecks(githubRef, "abc1234");
+        const cached = await provider.getChecks(githubRef, "def5678");
+
+        expect(first.state).toBe("unavailable");
+        expect(cached.state).toBe("unavailable");
+        expect(cached.error).toBe("HTTP 403: API rate limit exceeded");
+        expect(fetchJson).toHaveBeenCalledTimes(2);
+
+        clock = 61_001;
+        await provider.getChecks(githubRef, "fedcba9");
+        expect(fetchJson).toHaveBeenCalledTimes(4);
     });
 
     it("admits a row the default filter drops when a custom ciCdPattern matches it", async () => {

--- a/tests/unit/services/commitChecks/http.test.ts
+++ b/tests/unit/services/commitChecks/http.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock specifier must match the source import ("https", not "node:https").
 vi.mock("https");
 
-import { httpGetJson } from "../../../../src/services/commitChecks/http";
+import { HttpError, httpGetJson } from "../../../../src/services/commitChecks/http";
 
 interface FakeRequest extends EventEmitter {
     setTimeout: ReturnType<typeof vi.fn>;
@@ -28,9 +28,16 @@ function makeRequest(): FakeRequest {
     return req;
 }
 
-function makeResponse(statusCode: number | undefined): EventEmitter & { statusCode?: number } {
-    const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+function makeResponse(
+    statusCode: number | undefined,
+    headers: Record<string, string | string[] | undefined> = {},
+): EventEmitter & { statusCode?: number; headers: Record<string, string | string[] | undefined> } {
+    const res = new EventEmitter() as EventEmitter & {
+        statusCode?: number;
+        headers: Record<string, string | string[] | undefined>;
+    };
     res.statusCode = statusCode;
+    res.headers = headers;
     return res;
 }
 
@@ -79,9 +86,9 @@ describe("httpGetJson", () => {
         await expect(promise).resolves.toEqual({});
     });
 
-    it("rejects on a non-2xx status with a truncated body and no headers", async () => {
+    it("rejects on a non-2xx status with a truncated body and response headers", async () => {
         const req = makeRequest();
-        const res = makeResponse(404);
+        const res = makeResponse(404, { "x-ratelimit-remaining": "0" });
         stubGet(req, res);
 
         const promise = httpGetJson("https://api.test/x", { Authorization: "Bearer secret" });
@@ -89,6 +96,10 @@ describe("httpGetJson", () => {
         res.emit("end");
 
         await expect(promise).rejects.toThrow("HTTP 404: Not Found");
+        await expect(promise).rejects.toMatchObject({
+            statusCode: 404,
+            headers: { "x-ratelimit-remaining": "0" },
+        } satisfies Partial<HttpError>);
         // The token must never appear in the rejection.
         await expect(promise).rejects.not.toThrow(/secret/);
     });


### PR DESCRIPTION
### Title

fix(commit-checks): back off GitHub rate-limit retries

### Motivation

GitHub commit-check requests treated rate-limit 403/429 responses as generic failures, so webview refreshes could keep calling GitHub during the reset window and burn more quota.

### Summary

- Preserve HTTP status and response headers on non-2xx commit-check requests.
- Honor GitHub `retry-after` and `x-ratelimit-reset` cooldowns before issuing more check/status requests.
- Reuse concurrent same-hash commit-check fetches to avoid duplicate provider calls during refresh bursts.
- Bump extension version to `0.16.1`.
- Document the fix in `CHANGELOG.md`.

### Detailed Changes

#### Code

- Added `HttpError` for commit-check HTTP failures with response headers preserved.
- Added GitHub provider cooldown state driven by `retry-after`, `x-ratelimit-remaining`, and `x-ratelimit-reset`.
- Added coordinator in-flight request sharing keyed by commit hash.

#### Tests

- Added regression coverage for HTTP header preservation, GitHub rate-limit cooldown, and coordinator in-flight request sharing.

#### Documentation

- Added `CHANGELOG.md` entry for `0.16.1`.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None.

### Testing

- Unit/regression tests: `bun run test -- tests/unit/services/commitChecks/http.test.ts tests/unit/services/commitChecks/githubProvider.test.ts tests/unit/services/commitChecks/coordinator.test.ts` passed, 46 tests.
- Feature/bug verification: GitHub provider returns cached unavailable state during API cooldown and retries after reset; coordinator de-dupes concurrent same-hash requests.
- Validation summary: `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run build`, and full `bun run test` passed, 1326 tests across 67 files. Commit hooks passed format, strict lint, strict dependency check, architecture check, localization validate/audit, typecheck, build, and package extension. Push hooks passed react doctor and tests with coverage.
- Limitations: Existing untracked `docs/superpowers/` is unrelated and not included.

### Risks / Notes

- GitHub checks can still legitimately change after a commit SHA is created, so this PR only backs off during rate-limit windows; longer-lived persistent caching should be handled in a follow-up branch.