### PR TITLE
feat: add JetBrains external merge-tool support

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,18 @@
                 "icon": "$(go-to-file)"
             },
             {
+                "command": "intelligit.detectJetBrainsMergeTool",
+                "title": "Detect JetBrains Merge Tool",
+                "category": "IntelliGit",
+                "icon": "$(search)"
+            },
+            {
+                "command": "intelligit.openMergeConflictInJetBrains",
+                "title": "Open in JetBrains Merge Tool",
+                "category": "IntelliGit",
+                "icon": "$(link-external)"
+            },
+            {
                 "command": "intelligit.conflictAcceptYours",
                 "title": "Accept Yours",
                 "category": "IntelliGit",
@@ -250,6 +262,11 @@
                     "group": "navigation@1"
                 },
                 {
+                    "command": "intelligit.openMergeConflictInJetBrains",
+                    "when": "view == intelligit.mergeConflicts && viewItem == intelligit.conflictFile",
+                    "group": "navigation@2"
+                },
+                {
                     "command": "intelligit.conflictAcceptYours",
                     "when": "view == intelligit.mergeConflicts && viewItem == intelligit.conflictFile",
                     "group": "1_actions@1"
@@ -299,7 +316,22 @@
                 "key": "alt+9",
                 "mac": "alt+9"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "IntelliGit",
+            "properties": {
+                "intelligit.jetbrainsMergeTool.path": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "JetBrains IDE binary path/command (`pycharm`, `idea`, `webstorm`) or a macOS `.app` bundle path. IntelliGit auto-resolves `.app` bundles to the executable inside `Contents/MacOS`."
+                },
+                "intelligit.jetbrainsMergeTool.preferExternal": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Prefer the external JetBrains merge tool when opening merge conflicts. Falls back to VS Code's internal merge editor if no JetBrains path is configured or launch fails."
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "bun scripts/build.js --production",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,11 +11,17 @@ import { CommitGraphViewProvider } from "./views/CommitGraphViewProvider";
 import { CommitInfoViewProvider } from "./views/CommitInfoViewProvider";
 import { CommitPanelViewProvider } from "./views/CommitPanelViewProvider";
 import { MergeConflictsTreeProvider } from "./views/MergeConflictsTreeProvider";
-import { MergeEditorPanel } from "./views/MergeEditorPanel";
 import type { Branch } from "./types";
 import type { CommitAction } from "./webviews/react/commitGraphTypes";
 import { getErrorMessage, isBranchNotFullyMergedError } from "./utils/errors";
 import { deleteFileWithFallback } from "./utils/fileOps";
+import {
+    containsConflictMarkers,
+    detectInstalledJetBrainsMergeToolCandidates,
+    detectInstalledJetBrainsMergeToolPath,
+    launchJetBrainsMergeTool,
+    resolveJetBrainsMergeBinaryPath,
+} from "./utils/jetbrainsMergeTool";
 import { runWithNotificationProgress } from "./utils/notifications";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -71,6 +77,213 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     };
     const refreshMergeConflicts = async () => {
         updateConflictCount(await mergeConflicts.refresh());
+    };
+    const refreshConflictUi = async () => {
+        await commitPanel.refresh();
+        await refreshMergeConflicts();
+    };
+
+    const getJetBrainsMergeToolPath = (): string => {
+        return (
+            vscode.workspace
+                .getConfiguration("intelligit")
+                .get<string>("jetbrainsMergeTool.path", "")
+                .trim()
+        );
+    };
+
+    const getDefaultJetBrainsMergeToolPath = (): string => {
+        switch (process.platform) {
+            case "darwin":
+                return "/Applications/PyCharm.app";
+            case "win32":
+                return "C:\\Program Files\\JetBrains\\PyCharm\\bin\\pycharm64.exe";
+            default:
+                return "pycharm";
+        }
+    };
+
+    const saveJetBrainsMergeToolPath = async (rawPath: string): Promise<string | null> => {
+        const trimmed = rawPath.trim();
+        if (!trimmed) return null;
+
+        if (path.isAbsolute(trimmed) && !fs.existsSync(trimmed)) {
+            vscode.window.showErrorMessage(`JetBrains path not found: ${trimmed}`);
+            return null;
+        }
+
+        let resolvedBinaryPath: string;
+        try {
+            resolvedBinaryPath = await resolveJetBrainsMergeBinaryPath(trimmed);
+        } catch (err) {
+            const msg = getErrorMessage(err);
+            vscode.window.showErrorMessage(`Invalid JetBrains merge tool path: ${msg}`);
+            return null;
+        }
+
+        await vscode.workspace
+            .getConfiguration("intelligit")
+            .update("jetbrainsMergeTool.path", trimmed, vscode.ConfigurationTarget.Global);
+
+        const resolutionText =
+            resolvedBinaryPath === trimmed
+                ? `Executable: ${resolvedBinaryPath}`
+                : `Resolved executable: ${resolvedBinaryPath}`;
+        vscode.window.showInformationMessage(`Saved JetBrains merge tool path. ${resolutionText}`);
+        return trimmed;
+    };
+
+    const promptForJetBrainsMergeToolPath = async (): Promise<string | null> => {
+        const existing = getJetBrainsMergeToolPath();
+        const detected = existing ? null : await detectInstalledJetBrainsMergeToolPath();
+        const suggested = existing || detected || getDefaultJetBrainsMergeToolPath();
+        const input = await vscode.window.showInputBox({
+            title: "JetBrains Merge Tool Path",
+            prompt:
+                "Enter a JetBrains IDE binary path/command (pycharm, idea, webstorm) or a macOS .app bundle path.",
+            placeHolder: suggested,
+            value: suggested,
+            ignoreFocusOut: true,
+        });
+        if (!input) return null;
+
+        return saveJetBrainsMergeToolPath(input);
+    };
+
+    const detectAndPickJetBrainsMergeToolPath = async (): Promise<string | null> => {
+        const candidates = await detectInstalledJetBrainsMergeToolCandidates();
+        if (candidates.length === 0) {
+            vscode.window.showWarningMessage(
+                "No JetBrains IDE installations were auto-detected. Enter the path manually instead.",
+            );
+            return promptForJetBrainsMergeToolPath();
+        }
+
+        const quickPickItems = await Promise.all(
+            candidates.slice(0, 50).map(async (candidatePath) => {
+                let detail: string | undefined;
+                try {
+                    const resolved = await resolveJetBrainsMergeBinaryPath(candidatePath);
+                    detail = resolved === candidatePath ? undefined : `Resolved: ${resolved}`;
+                } catch {
+                    detail = undefined;
+                }
+                return {
+                    label: path.basename(candidatePath),
+                    description: candidatePath,
+                    detail,
+                    candidatePath,
+                };
+            }),
+        );
+
+        quickPickItems.push({
+            label: "$(edit) Enter path manually",
+            description: "Open the path prompt",
+            detail: undefined,
+            candidatePath: "__manual__",
+        });
+
+        const picked = await vscode.window.showQuickPick(quickPickItems, {
+            title: "Detect JetBrains Merge Tool",
+            placeHolder: "Select a detected JetBrains IDE to use as the merge tool",
+            ignoreFocusOut: true,
+            matchOnDescription: true,
+            matchOnDetail: true,
+        });
+        if (!picked) return null;
+        if (picked.candidatePath === "__manual__") {
+            return promptForJetBrainsMergeToolPath();
+        }
+        return saveJetBrainsMergeToolPath(picked.candidatePath);
+    };
+
+    const openBuiltInMergeEditorForFile = async (filePath: string): Promise<void> => {
+        const fileUri = vscode.Uri.file(path.join(repoRoot, filePath));
+        try {
+            await vscode.commands.executeCommand("git.openMergeEditor", fileUri);
+        } catch (error) {
+            const message = getErrorMessage(error);
+            vscode.window.showWarningMessage(
+                `VS Code merge editor command failed (${message}). Opening the file instead.`,
+            );
+            await vscode.commands.executeCommand("vscode.open", fileUri);
+        }
+    };
+
+    const openJetBrainsMergeToolForFile = async (filePath: string): Promise<boolean> => {
+        let jetBrainsPath = getJetBrainsMergeToolPath();
+        if (!jetBrainsPath) {
+            const action = await vscode.window.showInformationMessage(
+                "JetBrains merge tool path is not configured.",
+                "Configure",
+                "Open VS Code Merge Editor",
+            );
+            if (action === "Open VS Code Merge Editor") {
+                await openBuiltInMergeEditorForFile(filePath);
+                return true;
+            }
+            if (action !== "Configure") return false;
+            const configured = await promptForJetBrainsMergeToolPath();
+            if (!configured) return false;
+            jetBrainsPath = configured;
+        }
+
+        try {
+            const versions = await gitOps.getConflictFileVersions(filePath);
+            const outputFileFsPath = path.join(repoRoot, filePath);
+
+            await runWithNotificationProgress(
+                `Opening JetBrains merge tool for ${filePath}...`,
+                async () => {
+                    await launchJetBrainsMergeTool({
+                        binaryPath: jetBrainsPath,
+                        repoRootFsPath: repoRoot,
+                        relativeFilePath: filePath,
+                        outputFileFsPath,
+                        baseContent: versions.base,
+                        oursContent: versions.ours,
+                        theirsContent: versions.theirs,
+                    });
+                },
+            );
+
+            try {
+                const mergedText = await fs.promises.readFile(outputFileFsPath, "utf8");
+                if (!containsConflictMarkers(mergedText)) {
+                    await gitOps.stageFile(filePath);
+                    vscode.window.showInformationMessage(`Merged and staged: ${filePath}`);
+                } else {
+                    vscode.window.showInformationMessage(
+                        `Merge tool closed, but conflict markers remain in ${filePath}`,
+                    );
+                }
+            } catch (readErr) {
+                const msg = getErrorMessage(readErr);
+                vscode.window.showWarningMessage(
+                    `Could not inspect merged file '${filePath}' after JetBrains merge: ${msg}`,
+                );
+            }
+
+            await refreshConflictUi();
+            return true;
+        } catch (error) {
+            const message = getErrorMessage(error);
+            vscode.window.showErrorMessage(`JetBrains merge tool failed: ${message}`);
+            return false;
+        }
+    };
+
+    const openMergeConflictForFile = async (filePath: string): Promise<void> => {
+        const preferExternal = vscode.workspace
+            .getConfiguration("intelligit")
+            .get<boolean>("jetbrainsMergeTool.preferExternal", true);
+
+        if (preferExternal && getJetBrainsMergeToolPath()) {
+            const opened = await openJetBrainsMergeToolForFile(filePath);
+            if (opened) return;
+        }
+        await openBuiltInMergeEditorForFile(filePath);
     };
 
     context.subscriptions.push(
@@ -674,17 +887,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand("intelligit.openMergeConflict", async (ctx: unknown) => {
             const filePath = resolveConflictPath(ctx);
             if (!filePath) return;
-            MergeEditorPanel.open(
-                context.extensionUri,
-                gitOps,
-                workspaceFolder.uri,
-                filePath,
-                async () => {
-                    await commitPanel.refresh();
-                    await refreshMergeConflicts();
-                },
-            );
+            await openMergeConflictForFile(filePath);
         }),
+        vscode.commands.registerCommand("intelligit.detectJetBrainsMergeTool", async () => {
+            await detectAndPickJetBrainsMergeToolPath();
+        }),
+        vscode.commands.registerCommand(
+            "intelligit.openMergeConflictInJetBrains",
+            async (ctx: unknown) => {
+                const filePath = resolveConflictPath(ctx);
+                if (!filePath) return;
+                await openJetBrainsMergeToolForFile(filePath);
+            }
+        ),
         vscode.commands.registerCommand("intelligit.conflictAcceptYours", async (ctx: unknown) => {
             const filePath = resolveConflictPath(ctx);
             if (!filePath) return;
@@ -696,8 +911,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     },
                 );
                 vscode.window.showInformationMessage(`Accepted yours for ${filePath}`);
-                await commitPanel.refresh();
-                await refreshMergeConflicts();
+                await refreshConflictUi();
             } catch (error) {
                 const message = getErrorMessage(error);
                 vscode.window.showErrorMessage(`Accept yours failed: ${message}`);
@@ -714,8 +928,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     },
                 );
                 vscode.window.showInformationMessage(`Accepted theirs for ${filePath}`);
-                await commitPanel.refresh();
-                await refreshMergeConflicts();
+                await refreshConflictUi();
             } catch (error) {
                 const message = getErrorMessage(error);
                 vscode.window.showErrorMessage(`Accept theirs failed: ${message}`);

--- a/src/utils/jetbrainsMergeTool.ts
+++ b/src/utils/jetbrainsMergeTool.ts
@@ -1,0 +1,484 @@
+import * as os from "os";
+import * as path from "path";
+import { spawn } from "child_process";
+import { constants as fsConstants, promises as fsp } from "fs";
+
+export interface JetBrainsMergeToolLaunchInput {
+    binaryPath: string;
+    repoRootFsPath: string;
+    relativeFilePath: string;
+    outputFileFsPath: string;
+    baseContent: string;
+    oursContent: string;
+    theirsContent: string;
+}
+
+export interface JetBrainsMergeToolLaunchResult {
+    exitCode: number | null;
+    signal: NodeJS.Signals | null;
+}
+
+interface DetectedJetBrainsCandidate {
+    launchPath: string;
+    productKey: string | null;
+    mtimeMs: number;
+}
+
+const JETBRAINS_PRODUCT_PREFERENCES = [
+    "pycharm",
+    "idea",
+    "webstorm",
+    "goland",
+    "datagrip",
+    "phpstorm",
+    "rubymine",
+    "clion",
+    "rider",
+    "dataspell",
+    "aqua",
+] as const;
+
+const JETBRAINS_EXECUTABLE_NAMES_MAC = new Set<string>(JETBRAINS_PRODUCT_PREFERENCES);
+
+const JETBRAINS_EXECUTABLE_NAMES_WIN = new Set<string>([
+    ...JETBRAINS_PRODUCT_PREFERENCES.map((name) => `${name}64.exe`),
+    ...JETBRAINS_PRODUCT_PREFERENCES.map((name) => `${name}.exe`),
+]);
+
+async function pathExists(filePath: string): Promise<boolean> {
+    try {
+        await fsp.access(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function isExecutableFile(filePath: string): Promise<boolean> {
+    try {
+        const stat = await fsp.stat(filePath);
+        if (!stat.isFile()) return false;
+        await fsp.access(filePath, fsConstants.X_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function isMacAppBundlePath(inputPath: string): boolean {
+    return process.platform === "darwin" && inputPath.toLowerCase().endsWith(".app");
+}
+
+function parseBundleExecutableName(infoPlistContent: string): string | null {
+    const match = infoPlistContent.match(
+        /<key>\s*CFBundleExecutable\s*<\/key>\s*<string>([^<]+)<\/string>/s,
+    );
+    return match?.[1]?.trim() || null;
+}
+
+function parseBundleIdentifier(infoPlistContent: string): string | null {
+    const match = infoPlistContent.match(
+        /<key>\s*CFBundleIdentifier\s*<\/key>\s*<string>([^<]+)<\/string>/s,
+    );
+    return match?.[1]?.trim() || null;
+}
+
+function getProductPreferenceScore(productKey: string | null): number {
+    if (!productKey) return 0;
+    const idx = JETBRAINS_PRODUCT_PREFERENCES.indexOf(
+        productKey as (typeof JETBRAINS_PRODUCT_PREFERENCES)[number],
+    );
+    return idx === -1 ? 1 : 100 - idx;
+}
+
+function rankCandidates(a: DetectedJetBrainsCandidate, b: DetectedJetBrainsCandidate): number {
+    const scoreDelta = getProductPreferenceScore(b.productKey) - getProductPreferenceScore(a.productKey);
+    if (scoreDelta !== 0) return scoreDelta;
+    const mtimeDelta = b.mtimeMs - a.mtimeMs;
+    if (mtimeDelta !== 0) return mtimeDelta > 0 ? 1 : -1;
+    return a.launchPath.localeCompare(b.launchPath);
+}
+
+async function getFileMtimeMs(filePath: string): Promise<number> {
+    try {
+        const stat = await fsp.stat(filePath);
+        return stat.mtimeMs || 0;
+    } catch {
+        return 0;
+    }
+}
+
+async function readTextIfExists(filePath: string): Promise<string | null> {
+    try {
+        return await fsp.readFile(filePath, "utf8");
+    } catch {
+        return null;
+    }
+}
+
+async function listDirectories(rootDir: string): Promise<string[]> {
+    try {
+        const entries = await fsp.readdir(rootDir, { withFileTypes: true });
+        return entries
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => path.join(rootDir, entry.name));
+    } catch {
+        return [];
+    }
+}
+
+async function listFiles(rootDir: string): Promise<string[]> {
+    try {
+        const entries = await fsp.readdir(rootDir, { withFileTypes: true });
+        return entries.filter((entry) => entry.isFile()).map((entry) => path.join(rootDir, entry.name));
+    } catch {
+        return [];
+    }
+}
+
+async function walkDirectories(
+    rootDir: string,
+    options: {
+        maxDepth: number;
+        onDirectory?: (dirPath: string) => Promise<void> | void;
+        stopAfterDirs?: number;
+    },
+): Promise<void> {
+    const visited = new Set<string>();
+    let seenDirs = 0;
+
+    const visit = async (dirPath: string, depth: number): Promise<void> => {
+        if (depth > options.maxDepth) return;
+        if (visited.has(dirPath)) return;
+        visited.add(dirPath);
+        seenDirs += 1;
+        if (options.stopAfterDirs && seenDirs > options.stopAfterDirs) return;
+
+        await options.onDirectory?.(dirPath);
+
+        let entries: Array<{ isDirectory(): boolean; name: string }> | null = null;
+        try {
+            entries = (await fsp.readdir(dirPath, { withFileTypes: true })) as Array<{
+                isDirectory(): boolean;
+                name: string;
+            }>;
+        } catch {
+            return;
+        }
+        if (!entries) return;
+
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            if (entry.name.startsWith(".")) continue;
+            await visit(path.join(dirPath, entry.name), depth + 1);
+        }
+    };
+
+    await visit(rootDir, 0);
+}
+
+function inferProductKeyFromExecutableName(fileName: string): string | null {
+    const lower = fileName.toLowerCase();
+    const normalized = lower.endsWith(".exe") ? lower.replace(/64?\.exe$/, "") : lower;
+    return JETBRAINS_PRODUCT_PREFERENCES.includes(
+        normalized as (typeof JETBRAINS_PRODUCT_PREFERENCES)[number],
+    )
+        ? normalized
+        : null;
+}
+
+async function resolveExecutableFromMacAppBundle(appBundlePath: string): Promise<string> {
+    const contentsDir = path.join(appBundlePath, "Contents");
+    const macOsDir = path.join(contentsDir, "MacOS");
+    const infoPlistPath = path.join(contentsDir, "Info.plist");
+
+    if (!(await pathExists(appBundlePath))) {
+        throw new Error(`JetBrains app bundle not found: ${appBundlePath}`);
+    }
+
+    try {
+        const plist = await fsp.readFile(infoPlistPath, "utf8");
+        const executableName = parseBundleExecutableName(plist);
+        if (executableName) {
+            const executablePath = path.join(macOsDir, executableName);
+            if (await isExecutableFile(executablePath)) {
+                return executablePath;
+            }
+        }
+    } catch {
+        // Fall through to directory scan.
+    }
+
+    const entries = await fsp.readdir(macOsDir).catch(() => {
+        throw new Error(`Missing ${path.join(appBundlePath, "Contents/MacOS")} in app bundle.`);
+    });
+
+    const candidates = entries
+        .filter((name) => !name.startsWith("."))
+        .sort((a, b) => {
+            const aPreferred = JETBRAINS_EXECUTABLE_NAMES_MAC.has(a.toLowerCase()) ? 1 : 0;
+            const bPreferred = JETBRAINS_EXECUTABLE_NAMES_MAC.has(b.toLowerCase()) ? 1 : 0;
+            return bPreferred - aPreferred || a.localeCompare(b);
+        })
+        .map((name) => path.join(macOsDir, name));
+
+    for (const candidate of candidates) {
+        if (await isExecutableFile(candidate)) return candidate;
+    }
+
+    throw new Error(
+        `No executable file found in ${path.join(appBundlePath, "Contents/MacOS")}.`,
+    );
+}
+
+async function detectMacJetBrainsAppBundleCandidates(): Promise<DetectedJetBrainsCandidate[]> {
+    if (process.platform !== "darwin") return [];
+
+    const homeDir = os.homedir();
+    const roots = [
+        "/Applications",
+        path.join(homeDir, "Applications"),
+        path.join(homeDir, "Library", "Application Support", "JetBrains", "Toolbox", "apps"),
+    ];
+    const candidates: DetectedJetBrainsCandidate[] = [];
+    const seenAppPaths = new Set<string>();
+
+    const maybeAddAppBundle = async (appBundlePath: string): Promise<void> => {
+        if (!appBundlePath.toLowerCase().endsWith(".app")) return;
+        if (seenAppPaths.has(appBundlePath)) return;
+        seenAppPaths.add(appBundlePath);
+
+        const plistPath = path.join(appBundlePath, "Contents", "Info.plist");
+        const plist = await readTextIfExists(plistPath);
+        if (!plist) return;
+
+        const bundleIdentifier = parseBundleIdentifier(plist)?.toLowerCase() ?? "";
+        if (!bundleIdentifier.includes("jetbrains")) return;
+
+        let launchPath: string;
+        try {
+            launchPath = await resolveExecutableFromMacAppBundle(appBundlePath);
+        } catch {
+            return;
+        }
+
+        const executableName = path.basename(launchPath).toLowerCase();
+        candidates.push({
+            launchPath: appBundlePath,
+            productKey: inferProductKeyFromExecutableName(executableName),
+            mtimeMs: await getFileMtimeMs(launchPath),
+        });
+    };
+
+    await Promise.all(
+        roots.map(async (rootDir) => {
+            if (!(await pathExists(rootDir))) return;
+
+            if (rootDir.endsWith(path.join("Toolbox", "apps"))) {
+                await walkDirectories(rootDir, {
+                    maxDepth: 6,
+                    stopAfterDirs: 4000,
+                    onDirectory: async (dirPath) => {
+                        if (dirPath.toLowerCase().endsWith(".app")) {
+                            await maybeAddAppBundle(dirPath);
+                        }
+                    },
+                });
+                return;
+            }
+
+            const topLevelDirs = await listDirectories(rootDir);
+            for (const dirPath of topLevelDirs) {
+                if (dirPath.toLowerCase().endsWith(".app")) {
+                    await maybeAddAppBundle(dirPath);
+                }
+            }
+        }),
+    );
+
+    return candidates.sort(rankCandidates);
+}
+
+async function findWindowsExecutableCandidatesInRoot(
+    rootDir: string,
+    options: { maxDepth: number; stopAfterDirs?: number },
+): Promise<DetectedJetBrainsCandidate[]> {
+    if (process.platform !== "win32") return [];
+    if (!(await pathExists(rootDir))) return [];
+
+    const candidates: DetectedJetBrainsCandidate[] = [];
+    const seen = new Set<string>();
+
+    await walkDirectories(rootDir, {
+        maxDepth: options.maxDepth,
+        stopAfterDirs: options.stopAfterDirs,
+        onDirectory: async (dirPath) => {
+            if (path.basename(dirPath).toLowerCase() !== "bin") return;
+            const files = await listFiles(dirPath);
+            for (const filePath of files) {
+                const fileName = path.basename(filePath).toLowerCase();
+                if (!JETBRAINS_EXECUTABLE_NAMES_WIN.has(fileName)) continue;
+                if (seen.has(filePath)) continue;
+                seen.add(filePath);
+                const isFile = await isExecutableFile(filePath);
+                if (!isFile) continue;
+                candidates.push({
+                    launchPath: filePath,
+                    productKey: inferProductKeyFromExecutableName(fileName),
+                    mtimeMs: await getFileMtimeMs(filePath),
+                });
+            }
+        },
+    });
+
+    return candidates;
+}
+
+async function detectWindowsJetBrainsExecutableCandidates(): Promise<DetectedJetBrainsCandidate[]> {
+    if (process.platform !== "win32") return [];
+
+    const roots: Array<{ dir: string; maxDepth: number; stopAfterDirs?: number }> = [];
+    const addRoot = (dir: string | undefined, maxDepth: number, stopAfterDirs?: number) => {
+        if (!dir) return;
+        const trimmed = dir.trim();
+        if (!trimmed) return;
+        roots.push({ dir: trimmed, maxDepth, stopAfterDirs });
+    };
+
+    addRoot(path.join(process.env.ProgramFiles || "", "JetBrains"), 3, 1000);
+    addRoot(path.join(process.env["ProgramFiles(x86)"] || "", "JetBrains"), 3, 1000);
+    addRoot(path.join(process.env.LOCALAPPDATA || "", "Programs", "JetBrains"), 3, 1000);
+    addRoot(path.join(process.env.LOCALAPPDATA || "", "JetBrains", "Toolbox", "apps"), 6, 5000);
+    addRoot(path.join(process.env.APPDATA || "", "JetBrains", "Toolbox", "apps"), 6, 5000);
+    addRoot(
+        process.env.USERPROFILE
+            ? path.join(process.env.USERPROFILE, "AppData", "Local", "JetBrains", "Toolbox", "apps")
+            : "",
+        6,
+        5000,
+    );
+
+    const all = (
+        await Promise.all(
+            roots.map((root) =>
+                findWindowsExecutableCandidatesInRoot(root.dir, {
+                    maxDepth: root.maxDepth,
+                    stopAfterDirs: root.stopAfterDirs,
+                }),
+            ),
+        )
+    ).flat();
+
+    const unique = new Map<string, DetectedJetBrainsCandidate>();
+    for (const candidate of all) {
+        if (!unique.has(candidate.launchPath)) unique.set(candidate.launchPath, candidate);
+    }
+
+    return Array.from(unique.values()).sort(rankCandidates);
+}
+
+export async function detectInstalledJetBrainsMergeToolPath(): Promise<string | null> {
+    const candidates = await detectInstalledJetBrainsMergeToolCandidates();
+    return candidates[0] ?? null;
+}
+
+export async function detectInstalledJetBrainsMergeToolCandidates(): Promise<string[]> {
+    try {
+        if (process.platform === "darwin") {
+            const candidates = await detectMacJetBrainsAppBundleCandidates();
+            return candidates.map((candidate) => candidate.launchPath);
+        }
+        if (process.platform === "win32") {
+            const candidates = await detectWindowsJetBrainsExecutableCandidates();
+            return candidates.map((candidate) => candidate.launchPath);
+        }
+        return [];
+    } catch {
+        return [];
+    }
+}
+
+export async function resolveJetBrainsMergeBinaryPath(binaryPath: string): Promise<string> {
+    const trimmed = binaryPath.trim();
+    if (!trimmed) throw new Error("JetBrains merge tool path is empty.");
+    if (isMacAppBundlePath(trimmed)) {
+        return resolveExecutableFromMacAppBundle(trimmed);
+    }
+    return trimmed;
+}
+
+function sanitizeFileNamePart(value: string): string {
+    return value.replace(/[^\w.-]+/g, "_");
+}
+
+function buildTempFileNames(relativeFilePath: string): { base: string; ours: string; theirs: string } {
+    const ext = path.extname(relativeFilePath);
+    const baseName = path.basename(relativeFilePath, ext);
+    const safe = sanitizeFileNamePart(baseName || "merge");
+    const suffix = ext || ".txt";
+    return {
+        base: `.intelligit-base-${safe}${suffix}`,
+        ours: `.intelligit-ours-${safe}${suffix}`,
+        theirs: `.intelligit-theirs-${safe}${suffix}`,
+    };
+}
+
+export function containsConflictMarkers(text: string): boolean {
+    return /^(<{7}|={7}|>{7})/m.test(text);
+}
+
+export async function launchJetBrainsMergeTool(
+    input: JetBrainsMergeToolLaunchInput,
+): Promise<JetBrainsMergeToolLaunchResult> {
+    const resolvedBinaryPath = await resolveJetBrainsMergeBinaryPath(input.binaryPath);
+    const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "intelligit-merge-"));
+    const names = buildTempFileNames(input.relativeFilePath);
+    const basePath = path.join(tempRoot, names.base);
+    const oursPath = path.join(tempRoot, names.ours);
+    const theirsPath = path.join(tempRoot, names.theirs);
+
+    try {
+        await Promise.all([
+            fsp.writeFile(basePath, input.baseContent, "utf8"),
+            fsp.writeFile(oursPath, input.oursContent, "utf8"),
+            fsp.writeFile(theirsPath, input.theirsContent, "utf8"),
+        ]);
+
+        const args = ["merge", oursPath, theirsPath, basePath, input.outputFileFsPath];
+
+        return await new Promise<JetBrainsMergeToolLaunchResult>((resolve, reject) => {
+            const child = spawn(resolvedBinaryPath, args, {
+                cwd: input.repoRootFsPath,
+                stdio: ["ignore", "pipe", "pipe"],
+                shell: false,
+            });
+
+            let stderr = "";
+            child.stderr?.on("data", (chunk) => {
+                stderr += String(chunk);
+            });
+
+            child.on("error", (err) => {
+                reject(
+                    new Error(
+                        `Failed to launch JetBrains merge tool '${input.binaryPath}': ${err.message}`,
+                    ),
+                );
+            });
+
+            child.on("close", (exitCode, signal) => {
+                if (exitCode !== 0 && exitCode !== null && stderr.trim()) {
+                    reject(
+                        new Error(
+                            `JetBrains merge tool exited with code ${exitCode}: ${stderr.trim()}`,
+                        ),
+                    );
+                    return;
+                }
+                resolve({ exitCode, signal });
+            });
+        });
+    } finally {
+        await fsp.rm(tempRoot, { recursive: true, force: true }).catch(() => undefined);
+    }
+}

--- a/test-merge/config-manager.ts
+++ b/test-merge/config-manager.ts
@@ -6,11 +6,12 @@
 // ============================================================
 import * as fs from "fs";
 import * as path from "path";
+import * as yaml from "yaml";
 
-const CONFIG_FILE_NAME = "app.config.json";
-const ENV_PREFIX = "APP_";
-const MAX_CACHE_SIZE = 100;
-const DEFAULT_LOG_LEVEL = "info";
+const CONFIG_FILE_NAME = "app.config.yaml";
+const ENV_PREFIX = "MYAPP_";
+const MAX_CACHE_SIZE = 500;
+const DEFAULT_LOG_LEVEL = "debug";
 
 // ============================================================
 // SECTION 2: Types
@@ -48,22 +49,30 @@ export class ConfigManager {
   // ----------------------------------------------------------
   loadFromFile(): AppConfig {
     if (!fs.existsSync(this.configPath)) {
-      throw new Error(`Config file not found: ${this.configPath}`);
+      console.warn(`Config file not found, using defaults: ${this.configPath}`);
+      return this.config;
     }
 
     const raw = fs.readFileSync(this.configPath, "utf-8");
-    const parsed = JSON.parse(raw) as Partial<AppConfig>;
+    const parsed = yaml.parse(raw) as Partial<AppConfig>;
 
-    this.config = {
-      ...this.config,
-      ...parsed,
+    this.config = this.mergeConfig(this.config, parsed);
+    return this.config;
+  }
+
+  private mergeConfig(base: AppConfig, override: Partial<AppConfig>): AppConfig {
+    return {
+      ...base,
+      ...override,
       database: {
-        ...this.config.database,
-        ...(parsed.database ?? {}),
+        ...base.database,
+        ...(override.database ?? {}),
+      },
+      features: {
+        ...base.features,
+        ...(override.features ?? {}),
       },
     };
-
-    return this.config;
   }
 
   loadFromEnv(): void {
@@ -93,15 +102,18 @@ export class ConfigManager {
   // ----------------------------------------------------------
   private loadDefaults(): AppConfig {
     return {
-      port: 3000,
-      host: "localhost",
+      port: 8080,
+      host: "0.0.0.0",
       logLevel: DEFAULT_LOG_LEVEL as AppConfig["logLevel"],
       database: {
-        url: "postgres://localhost:5432/app",
-        poolSize: 10,
-        timeout: 5000,
+        url: "postgres://db.internal:5432/myapp_dev",
+        poolSize: 25,
+        timeout: 10000,
       },
-      features: {},
+      features: {
+        darkMode: true,
+        betaFeatures: false,
+      },
     };
   }
 
@@ -141,7 +153,18 @@ export class ConfigManager {
     return Object.freeze({ ...this.config.database });
   }
 
-  exportToJson(): string {
-    return JSON.stringify(this.config, null, 2);
+  exportToYaml(): string {
+    return yaml.stringify(this.config);
+  }
+
+  validate(): string[] {
+    const errors: string[] = [];
+    if (this.config.port < 1 || this.config.port > 65535) {
+      errors.push("Port must be between 1 and 65535");
+    }
+    if (this.config.database.poolSize < 1) {
+      errors.push("Database pool size must be at least 1");
+    }
+    return errors;
   }
 }

--- a/test-merge/user-service.ts
+++ b/test-merge/user-service.ts
@@ -7,11 +7,12 @@
 import { Database } from "./database";
 import { Logger } from "./logger";
 import { hashPassword, verifyPassword } from "./crypto";
+import { EventEmitter } from "./events";
 
-const MAX_LOGIN_ATTEMPTS = 5;
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
-const DEFAULT_ROLE = "viewer";
-const PASSWORD_MIN_LENGTH = 8;
+const MAX_LOGIN_ATTEMPTS = 3;
+const SESSION_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes (branch_a)
+const DEFAULT_ROLE = "editor";
+const PASSWORD_MIN_LENGTH = 10;
 
 // ============================================================
 // SECTION 2: Types
@@ -47,29 +48,37 @@ export class UserService {
   // SECTION 3a: Core authentication method
   // ----------------------------------------------------------
   async authenticate(email: string, password: string): Promise<Session | null> {
-    const user = await this.db.findUserByEmail(email);
+    const normalizedEmail = email.trim().toLowerCase();
+    const user = await this.db.findUserByEmail(normalizedEmail);
     if (!user) {
-      this.logger.warn(`Login attempt for unknown email: ${email}`);
+      this.logger.warn(`Login attempt for unknown email: ${normalizedEmail}`);
+      await this.db.recordFailedAttempt(normalizedEmail);
       return null;
     }
 
     const attempts = await this.db.getLoginAttempts(user.id);
     if (attempts >= MAX_LOGIN_ATTEMPTS) {
-      this.logger.error(`Account locked for user: ${user.id}`);
+      this.logger.error(`Account locked after ${MAX_LOGIN_ATTEMPTS} attempts: ${user.id}`);
+      await this.notifyAccountLocked(user);
       return null;
     }
 
     const valid = await verifyPassword(password, user.passwordHash);
     if (!valid) {
       await this.db.incrementLoginAttempts(user.id);
-      this.logger.warn(`Failed login for user: ${user.id}`);
+      this.logger.warn(`Failed login attempt ${attempts + 1} for user: ${user.id}`);
       return null;
     }
 
     await this.db.resetLoginAttempts(user.id);
     const session = await this.createSession(user.id);
-    this.logger.info(`User ${user.id} authenticated successfully`);
+    await this.db.updateLastLogin(user.id);
+    this.logger.info(`User ${user.id} authenticated via email/password`);
     return session;
+  }
+
+  private async notifyAccountLocked(user: User): Promise<void> {
+    this.logger.error(`Sending lock notification to ${user.email}`);
   }
 
   // ----------------------------------------------------------
@@ -111,17 +120,27 @@ export class UserService {
   }
 
   private generateToken(): string {
+    const segments: string[] = [];
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let result = "";
-    for (let i = 0; i < 64; i++) {
-      result += chars.charAt(Math.floor(Math.random() * chars.length));
+    for (let s = 0; s < 4; s++) {
+      let segment = "";
+      for (let i = 0; i < 16; i++) {
+        segment += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      segments.push(segment);
     }
-    return result;
+    return segments.join("-");
   }
 
   async validateSession(token: string): Promise<User | null> {
     const session = await this.db.findSession(token);
-    if (!session || session.expiresAt < new Date()) {
+    if (!session) {
+      this.logger.debug(`Session not found: ${token.slice(0, 8)}...`);
+      return null;
+    }
+    if (session.expiresAt < new Date()) {
+      await this.db.deleteSession(token);
+      this.logger.debug(`Session expired and cleaned up: ${token.slice(0, 8)}...`);
       return null;
     }
     return this.db.findUserById(session.userId);
@@ -141,10 +160,15 @@ export class UserService {
 
   hasPermission(user: User, action: string): boolean {
     const permissions: Record<User["role"], string[]> = {
-      admin: ["read", "write", "delete", "manage"],
-      editor: ["read", "write"],
+      admin: ["read", "write", "delete", "manage", "audit"],
+      editor: ["read", "write", "delete"],
       viewer: ["read"],
     };
-    return permissions[user.role]?.includes(action) ?? false;
+    const allowed = permissions[user.role] ?? [];
+    if (!allowed.includes(action)) {
+      this.logger.warn(`Permission denied: ${user.id} tried '${action}' with role '${user.role}'`);
+      return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

- Adds JetBrains IDEs as external merge tools for conflict resolution.
- Extends merge-conflict test coverage across all four conflict zones.

## Why

Developers can resolve conflicts in an installed JetBrains IDE while retaining IntelliGit conflict workflow support.

## Validation

- Commit-level merge-conflict test updates are included on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening merge conflicts with the JetBrains merge tool.
  - Added automatic JetBrains tool detection and configurable preference over VS Code’s merge editor.
  - Added a context-menu action for launching conflicts in JetBrains.

- **Bug Fixes**
  - Improved conflict resolution status updates and automatic staging after clean merges.
  - Enhanced handling of failed launches and unresolved conflict markers.

- **Configuration**
  - Added YAML-based configuration support, validation, and export options.
  - Improved login security, session handling, and permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->