### PR TITLE
fix: align merge editor display with PyCharm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-13
+
+### Changed
+
+- Aligned merge-editor conflict colors, empty-middle lines, one-sided hunks, gutter measurement, and connector ribbons with PyCharm presentation.
+- Added one-sided hunk coverage to the merge-editor preview fixture.
+
 ## [0.17.3] - 2026-07-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.17.4",
+    "version": "0.18.0",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.17.3",
+    "version": "0.17.4",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/scripts/preview-merge-editor.js
+++ b/scripts/preview-merge-editor.js
@@ -20,6 +20,10 @@ for (const asset of assets) {
     }
 }
 
+// Mirrors the user's real config.ts merge: an unchanged-on-one-side import
+// conflict, a 4-line constant conflict (both stacked reproduces the reported
+// contour issues), a tall one-sided green insertion (right-divider wedge), and
+// a theirs-only insertion (left-divider artifacts).
 const sampleConflictData = {
     filePath: "src/config.ts",
     oursLabel: "main",
@@ -30,75 +34,94 @@ const sampleConflictData = {
         {
             type: "common",
             lines: [
-                'getDatabaseConfig(): Readonly<AppConfig["database"]> {',
-                "  return Object.freeze({ ...this.config.database });",
-                "}",
-                "",
+                "// ============================================",
+                "// SECTION 1: Imports and Constants",
+                "// ============================================",
+                'import * as fs from "fs";',
+                'import * as path from "path";',
             ],
         },
         {
+            // Ours kept base's yaml import; theirs swapped it for toml.
             type: "conflict",
-            id: 8,
+            id: 1,
             changeKind: "conflict",
-            baseLines: ["exportConfig(): string {"],
+            baseLines: ['import * as yaml from "yaml";'],
+            oursLines: ['import * as yaml from "yaml";'],
+            theirsLines: ['import * as toml from "toml";'],
+        },
+        {
+            type: "common",
+            lines: [""],
+        },
+        {
+            type: "conflict",
+            id: 2,
+            changeKind: "conflict",
+            baseLines: [
+                'const CONFIG_FILE_NAME = "app.config.json";',
+                'const ENV_PREFIX = "APP_";',
+                "const MAX_CACHE_SIZE = 100;",
+                'const DEFAULT_LOG_LEVEL = "info";',
+            ],
             oursLines: [
-                "exportToYaml(): string { return yaml.stringify(this.config); } // long left line for horizontal scroll",
+                'const CONFIG_FILE_NAME = "app.config.yaml";',
+                'const ENV_PREFIX = "MYAPP_";',
+                "const MAX_CACHE_SIZE = 500;",
+                'const DEFAULT_LOG_LEVEL = "debug";',
             ],
             theirsLines: [
-                "reload(): AppConfig {",
-                "  this.config = this.loadDefaults();",
-                "  return this.loadFromFile();",
-                "}",
-                "",
-                "validate(): string[] {",
-                "  const errors: string[] = [];",
-                '  if (this.config.port < 1) errors.push("Port must be between 1 and 65535");',
-                "  return errors;",
-                "}",
+                'const CONFIG_FILE_NAME = "app.config.toml";',
+                'const ENV_PREFIX = "SVC_";',
+                "const MAX_CACHE_SIZE = 250;",
+                'const DEFAULT_LOG_LEVEL = "warn";',
             ],
         },
         {
             type: "common",
-            lines: ["}", "loadFromEnv(): void {"],
+            lines: ["", "// SECTION 2: Types", "interface AppConfig {", "  port: number;", "}"],
         },
         {
+            // Tall one-sided green insertion: only ours added mergeConfig.
             type: "conflict",
-            id: 9,
-            changeKind: "conflict",
-            baseLines: ['  const raw = process.env["APP_PORT"];'],
-            oursLines: [
-                '  const envPort = process.env["MYAPP_PORT"];',
-                "  if (envPort) {",
-                "    this.config.port = parseInt(envPort, 10);",
-                "  }",
-            ],
-            theirsLines: ['  const envPort = process.env["SVC_PORT"];'],
-        },
-        {
-            type: "common",
-            lines: ["}", "", "warmCache(): void {"],
-        },
-        {
-            // One-sided green insertion: only ours added lines.
-            type: "conflict",
-            id: 10,
+            id: 3,
             changeKind: "ours-only",
             baseLines: [],
-            oursLines: ['  logger.debug("cache warm start");', '  logger.debug("cache ready");'],
+            oursLines: [
+                "private mergeConfig(base: AppConfig, override: Partial<AppConfig>): AppConfig {",
+                "  return {",
+                "    ...base,",
+                "    ...override,",
+                "    database: {",
+                "      ...base.database,",
+                "      ...(override.database ?? {}),",
+                "    },",
+                "    features: {",
+                "      ...base.features,",
+                "      ...(override.features ?? {}),",
+                "    },",
+                "  };",
+                "}",
+            ],
             theirsLines: [],
         },
         {
             type: "common",
-            lines: ["  cache.prime();", "}"],
+            lines: ["", "loadFromEnv(): void {", '  const envPort = process.env["PORT"];', "}"],
         },
         {
-            // One-sided blue modification: only theirs rewrote the line.
+            // Theirs-only insertion: envHost handling added on the right.
             type: "conflict",
-            id: 11,
+            id: 4,
             changeKind: "theirs-only",
-            baseLines: ["  return cache.get(key);"],
-            oursLines: ["  return cache.get(key);"],
-            theirsLines: ["  return cache.fetch(key, { ttl: 60 });"],
+            baseLines: [],
+            oursLines: [],
+            theirsLines: [
+                '  const envHost = process.env["HOST"];',
+                "  if (envHost) {",
+                "    this.config.host = envHost;",
+                "  }",
+            ],
         },
         {
             type: "common",

--- a/scripts/preview-merge-editor.js
+++ b/scripts/preview-merge-editor.js
@@ -76,6 +76,32 @@ const sampleConflictData = {
         },
         {
             type: "common",
+            lines: ["}", "", "warmCache(): void {"],
+        },
+        {
+            // One-sided green insertion: only ours added lines.
+            type: "conflict",
+            id: 10,
+            changeKind: "ours-only",
+            baseLines: [],
+            oursLines: ['  logger.debug("cache warm start");', '  logger.debug("cache ready");'],
+            theirsLines: [],
+        },
+        {
+            type: "common",
+            lines: ["  cache.prime();", "}"],
+        },
+        {
+            // One-sided blue modification: only theirs rewrote the line.
+            type: "conflict",
+            id: 11,
+            changeKind: "theirs-only",
+            baseLines: ["  return cache.get(key);"],
+            oursLines: ["  return cache.get(key);"],
+            theirsLines: ["  return cache.fetch(key, { ttl: 60 });"],
+        },
+        {
+            type: "common",
             // Filler so the document exceeds the viewport and the preview can
             // exercise scroll-driven ribbon redraws, not just the first frame.
             lines: Array.from({ length: 40 }, (unused, i) => `  trace("scroll filler ${i}");`),

--- a/scripts/preview-merge-editor.js
+++ b/scripts/preview-merge-editor.js
@@ -42,11 +42,14 @@ const sampleConflictData = {
             ],
         },
         {
-            // Ours kept base's yaml import; theirs swapped it for toml.
+            // Ours and theirs each added a different import where base had
+            // nothing: zero-height middle, so FIX 2's cross-middle thin line
+            // is exercised here instead of the (no longer representative)
+            // unchanged-on-one-side case.
             type: "conflict",
             id: 1,
             changeKind: "conflict",
-            baseLines: ['import * as yaml from "yaml";'],
+            baseLines: [],
             oursLines: ['import * as yaml from "yaml";'],
             theirsLines: ['import * as toml from "toml";'],
         },

--- a/scripts/preview-merge-editor.js
+++ b/scripts/preview-merge-editor.js
@@ -61,6 +61,25 @@ const sampleConflictData = {
             type: "common",
             lines: ["}", "loadFromEnv(): void {"],
         },
+        {
+            type: "conflict",
+            id: 9,
+            changeKind: "conflict",
+            baseLines: ['  const raw = process.env["APP_PORT"];'],
+            oursLines: [
+                '  const envPort = process.env["MYAPP_PORT"];',
+                "  if (envPort) {",
+                "    this.config.port = parseInt(envPort, 10);",
+                "  }",
+            ],
+            theirsLines: ['  const envPort = process.env["SVC_PORT"];'],
+        },
+        {
+            type: "common",
+            // Filler so the document exceeds the viewport and the preview can
+            // exercise scroll-driven ribbon redraws, not just the first frame.
+            lines: Array.from({ length: 40 }, (unused, i) => `  trace("scroll filler ${i}");`),
+        },
     ],
 };
 

--- a/scripts/preview-merge-editor.js
+++ b/scripts/preview-merge-editor.js
@@ -91,6 +91,11 @@ body {
 }
 </style>
 <script>
+// The merge scroll driver draws in requestAnimationFrame, which Chrome suspends
+// for hidden tabs — headless/screenshot tooling would never get a frame. The
+// preview swaps in a timeout-based shim so frames always run.
+window.requestAnimationFrame = (cb) => window.setTimeout(() => cb(performance.now()), 16);
+window.cancelAnimationFrame = (id) => window.clearTimeout(id);
 const sampleConflictData = ${JSON.stringify(sampleConflictData)};
 function postSampleConflictData() {
   window.dispatchEvent(new MessageEvent("message", {

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -56,10 +56,13 @@ import {
 } from "./segments";
 import {
     buildVerticalLayout,
+    LINE_HEIGHT_PX,
     paneOffsetForCanonical,
+    ribbonOutlineD,
     ribbonPathD,
     type MergeVerticalLayout,
     type MergePane,
+    type RibbonSide,
     type RibbonSpan,
     type SegmentPaneLines,
 } from "./mergeScrollLayout";
@@ -74,51 +77,87 @@ const EMPTY_SEGMENTS: MergeSegment[] = [];
 const LINE_PADDING_PX = 18;
 
 const MERGE_PANES: readonly MergePane[] = ["left", "middle", "right"];
-/* connector-resolved dims the accepted side's ribbon to a quiet "done" marker
-   so it does not read as a still-pending insertion next to the neutral result. */
-const ACCEPTED_CONNECTOR_CLASS = "variant-insertion connector-resolved";
-
-interface ConnectorClassPair {
-    leftColorClass?: string;
-    rightColorClass?: string;
-}
-
-type RibbonLineSide = "a" | "b";
 
 const RIBBON_LINE_TARGET_HEIGHT_PX = 3;
 
-interface ConnectorRenderSpec extends ConnectorClassPair {
+/** Row extent of one side's target inside the stacked result block (in lines). */
+interface ResultSlice {
+    top: number;
+    count: number;
+}
+
+/** One divider side of a hunk's connector: color, settled state, and target. */
+interface ConnectorSideSpec {
+    colorClass: string;
+    /** Settled (accepted/discarded): drawn as PyCharm's dotted contour, not a band. */
+    resolved: boolean;
+    /** Sub-extent of the result the side maps to; whole block when absent. */
+    midSlice?: ResultSlice;
+}
+
+interface ConnectorRenderSpec {
     id: number;
     index: number;
     middleLineTarget: boolean;
+    left: ConnectorSideSpec;
+    right: ConnectorSideSpec;
 }
 
-function connectorClassPair(
+/**
+ * Derives both connector sides for a hunk, PyCharm-style: a pending side keeps
+ * its filled suggestion band; a settled side (accepted into the result,
+ * discarded via X, or dropped with "none") turns into a dotted contour so the
+ * hunk stays traceable across panes after the decision. Stacking both sides
+ * settles both ribbons and points each at its own slice of the result.
+ */
+function connectorSideSpecs(
     segment: ConflictSegment,
     resolution: HunkResolution | undefined,
-    editedLines: string[] | undefined,
     dismissed: HunkSideDismissal | undefined,
-): ConnectorClassPair {
-    if (editedLines !== undefined || resolution === "none") return {};
-    if (resolution === "both" || resolution === "both-reversed") return {};
-
+): { left: ConnectorSideSpec; right: ConnectorSideSpec } {
     const pendingClass = connectorClass(segment);
-    if (resolution === "ours") {
+    const resolvedClass = `${pendingClass} connector-resolved`;
+    if (resolution === "both" || resolution === "both-reversed") {
+        const oursLen = segment.oursLines.length;
+        const theirsLen = segment.theirsLines.length;
+        const oursFirst = resolution === "both";
         return {
-            leftColorClass: ACCEPTED_CONNECTOR_CLASS,
-            rightColorClass: dismissed?.theirs ? undefined : pendingClass,
+            left: {
+                colorClass: resolvedClass,
+                resolved: true,
+                midSlice: { top: oursFirst ? 0 : theirsLen, count: oursLen },
+            },
+            right: {
+                colorClass: resolvedClass,
+                resolved: true,
+                midSlice: { top: oursFirst ? oursLen : 0, count: theirsLen },
+            },
         };
     }
-    if (resolution === "theirs") {
-        return {
-            leftColorClass: dismissed?.ours ? undefined : pendingClass,
-            rightColorClass: ACCEPTED_CONNECTOR_CLASS,
-        };
-    }
+    const leftResolved = resolution === "ours" || resolution === "none" || dismissed?.ours === true;
+    const rightResolved =
+        resolution === "theirs" || resolution === "none" || dismissed?.theirs === true;
     return {
-        leftColorClass: dismissed?.ours ? undefined : pendingClass,
-        rightColorClass: dismissed?.theirs ? undefined : pendingClass,
+        left: {
+            colorClass: leftResolved ? resolvedClass : pendingClass,
+            resolved: leftResolved,
+        },
+        right: {
+            colorClass: rightResolved ? resolvedClass : pendingClass,
+            resolved: rightResolved,
+        },
     };
+}
+
+/** Maps a side's result slice to pixel extents inside the middle block. */
+function sliceExtent(
+    midTop: number,
+    midBot: number,
+    slice: ResultSlice | undefined,
+): { top: number; bot: number } {
+    if (!slice) return { top: midTop, bot: midBot };
+    const top = midTop + slice.top * LINE_HEIGHT_PX;
+    return { top, bot: top + slice.count * LINE_HEIGHT_PX };
 }
 
 function resultIsLineTarget(
@@ -136,26 +175,44 @@ function readPxVar(element: Element, name: string): number {
     return Number.isFinite(value) ? value : 0;
 }
 
+/** Horizontal spans for one divider: filled band vs resolved contour x-zones. */
+interface DividerSpans {
+    /** Gutter-to-gutter span the filled suggestion band covers. */
+    band: RibbonSpan;
+    /** Pane-outer-edge span the resolved dotted contour traces. */
+    contour: RibbonSpan;
+}
+
+/** Per-ribbon draw options: thin insertion target and/or settled contour mode. */
+interface RibbonDrawOptions {
+    /** Collapse this side to a thin insertion-target wedge (empty result). */
+    lineSide?: RibbonSide;
+    /** Draw the dotted resolved contour, closed on this side's pane edge. */
+    outlineEdge?: RibbonSide;
+}
+
 /**
- * Sets one connector ribbon's path across a gutter: flat under the pane
- * gutters, curved only in the divider strip. Empty result targets render as a
- * thin filled wedge so insertion hunks stay visible without a full row.
+ * Sets one connector ribbon's path across a gutter. Pending sides draw the
+ * filled band (flat under the pane gutters, curved only in the divider strip);
+ * resolved sides draw the dotted contour across the pane outer edges instead.
+ * Empty result targets render as a thin wedge so insertion hunks stay visible
+ * without a full row.
  */
 function setRibbonPath(
     path: SVGPathElement | undefined,
-    span: RibbonSpan,
+    spans: DividerSpans,
     aTop: number,
     aBot: number,
     bTop: number,
     bBot: number,
     viewportH: number,
-    lineSide?: RibbonLineSide,
+    options: RibbonDrawOptions = {},
 ): void {
     if (!path) return;
-    if (lineSide === "a") {
+    if (options.lineSide === "a") {
         aBot = aTop + RIBBON_LINE_TARGET_HEIGHT_PX;
     }
-    if (lineSide === "b") {
+    if (options.lineSide === "b") {
         bBot = bTop + RIBBON_LINE_TARGET_HEIGHT_PX;
     }
 
@@ -167,7 +224,12 @@ function setRibbonPath(
     }
 
     path.style.display = "";
-    path.setAttribute("d", ribbonPathD(span, aTop, aBot, bTop, bBot));
+    path.setAttribute(
+        "d",
+        options.outlineEdge
+            ? ribbonOutlineD(spans.contour, aTop, aBot, bTop, bBot, options.outlineEdge)
+            : ribbonPathD(spans.band, aTop, aBot, bTop, bBot),
+    );
 }
 
 // --- VS Code API ---
@@ -223,9 +285,10 @@ function App() {
     const connectorPaths = useMemo(() => new Map<string, SVGPathElement>(), []);
     // Ribbon spans (viewport-relative) across each divider; measured on
     // layout/resize so the per-frame draw only recomputes y.
-    const gutterXRef = useRef<{ left: RibbonSpan; right: RibbonSpan }>({
-        left: { x0: 0, curveX0: 0, curveX1: 0, x1: 0 },
-        right: { x0: 0, curveX0: 0, curveX1: 0, x1: 0 },
+    const emptySpan = (): RibbonSpan => ({ x0: 0, curveX0: 0, curveX1: 0, x1: 0 });
+    const gutterXRef = useRef<{ left: DividerSpans; right: DividerSpans }>({
+        left: { band: emptySpan(), contour: emptySpan() },
+        right: { band: emptySpan(), contour: emptySpan() },
     });
     const viewportHRef = useRef(0);
     const layoutRef = useRef<MergeVerticalLayout | null>(null);
@@ -297,18 +360,37 @@ function App() {
         };
         const leftEdge = left.offsetLeft + left.offsetWidth;
         const middleEdge = middle.offsetLeft + middle.offsetWidth;
+        const rightEdge = right.offsetLeft + right.offsetWidth;
+        // Band spans stop at the gutters; contour spans (resolved hunks) run
+        // pane-edge to pane-edge so the dotted trace crosses the whole block.
         gutterXRef.current = {
             left: {
-                x0: leftEdge - gutterWidth(left, true),
-                curveX0: leftEdge,
-                curveX1: middle.offsetLeft,
-                x1: middle.offsetLeft + gutterWidth(middle, false),
+                band: {
+                    x0: leftEdge - gutterWidth(left, true),
+                    curveX0: leftEdge,
+                    curveX1: middle.offsetLeft,
+                    x1: middle.offsetLeft + gutterWidth(middle, false),
+                },
+                contour: {
+                    x0: left.offsetLeft,
+                    curveX0: leftEdge,
+                    curveX1: middle.offsetLeft,
+                    x1: middleEdge,
+                },
             },
             right: {
-                x0: middleEdge,
-                curveX0: middleEdge,
-                curveX1: right.offsetLeft,
-                x1: right.offsetLeft + gutterWidth(right, true),
+                band: {
+                    x0: middleEdge,
+                    curveX0: middleEdge,
+                    curveX1: right.offsetLeft,
+                    x1: right.offsetLeft + gutterWidth(right, true),
+                },
+                contour: {
+                    x0: middle.offsetLeft,
+                    curveX0: middleEdge,
+                    curveX1: right.offsetLeft,
+                    x1: rightEdge,
+                },
             },
         };
     }, []);
@@ -317,33 +399,42 @@ function App() {
         (offsets: Record<MergePane, number>, viewportH: number) => {
             const layout = layoutRef.current;
             if (!layout) return;
-            const { left: leftSpan, right: rightSpan } = gutterXRef.current;
-            for (const { id, index, middleLineTarget } of connectorsRef.current) {
+            const { left: leftSpans, right: rightSpans } = gutterXRef.current;
+            for (const { id, index, middleLineTarget, left, right } of connectorsRef.current) {
                 const oursTop = layout.paneTopPx.left[index] - offsets.left;
                 const oursBot = oursTop + layout.paneHPx.left[index];
                 const midTop = layout.paneTopPx.middle[index] - offsets.middle;
                 const midBot = midTop + layout.paneHPx.middle[index];
                 const theirsTop = layout.paneTopPx.right[index] - offsets.right;
                 const theirsBot = theirsTop + layout.paneHPx.right[index];
+                // Stacked resolutions point each side at its own result slice.
+                const leftTarget = sliceExtent(midTop, midBot, left.midSlice);
+                const rightSource = sliceExtent(midTop, midBot, right.midSlice);
                 setRibbonPath(
                     connectorPaths.get(`${id}-left`),
-                    leftSpan,
+                    leftSpans,
                     oursTop,
                     oursBot,
-                    midTop,
-                    midBot,
+                    leftTarget.top,
+                    leftTarget.bot,
                     viewportH,
-                    middleLineTarget ? "b" : undefined,
+                    {
+                        lineSide: middleLineTarget ? "b" : undefined,
+                        outlineEdge: left.resolved ? "a" : undefined,
+                    },
                 );
                 setRibbonPath(
                     connectorPaths.get(`${id}-right`),
-                    rightSpan,
-                    midTop,
-                    midBot,
+                    rightSpans,
+                    rightSource.top,
+                    rightSource.bot,
                     theirsTop,
                     theirsBot,
                     viewportH,
-                    middleLineTarget ? "a" : undefined,
+                    {
+                        lineSide: middleLineTarget ? "a" : undefined,
+                        outlineEdge: right.resolved ? "b" : undefined,
+                    },
                 );
             }
         },
@@ -582,9 +673,11 @@ function App() {
         return buildVerticalLayout(paneLines);
     }, [renderedSegments]);
 
-    // Conflict hunks the connector ribbons link across panes. `index` is the
-    // segment index into the layout tables; `colorClass` matches the block band.
-    const connectors = useMemo(
+    // Hunks the connector ribbons link across panes — every conflict segment,
+    // including one-sided green/blue/gray changes (PyCharm connects those too).
+    // Manually edited hunks and untouched auto-merges carry no ribbons; `index`
+    // is the segment index into the layout tables.
+    const connectors = useMemo<ConnectorRenderSpec[]>(
         () =>
             renderedSegments
                 .filter(
@@ -592,8 +685,11 @@ function App() {
                         item,
                     ): item is (typeof renderedSegments)[number] & { segment: ConflictSegment } =>
                         item.segment.type === "conflict" &&
-                        isTrueConflict(item.segment) &&
-                        state.edits[item.segment.id] === undefined,
+                        state.edits[item.segment.id] === undefined &&
+                        !(
+                            item.segment.autoResolvedLines !== undefined &&
+                            state.resolutions[item.segment.id] === undefined
+                        ),
                 )
                 .map((item) => ({
                     id: item.segment.id,
@@ -603,25 +699,20 @@ function App() {
                         state.resolutions[item.segment.id],
                         state.edits[item.segment.id],
                     ),
-                    ...connectorClassPair(
+                    ...connectorSideSpecs(
                         item.segment,
                         state.resolutions[item.segment.id],
-                        state.edits[item.segment.id],
                         state.dismissals[item.segment.id],
                     ),
-                }))
-                .filter(
-                    (item) =>
-                        item.leftColorClass !== undefined || item.rightColorClass !== undefined,
-                ),
+                })),
         [renderedSegments, state.resolutions, state.edits, state.dismissals],
     );
     const connectorSpecs: ConnectorSpec[] = useMemo(
         () =>
-            connectors.map(({ id, leftColorClass, rightColorClass, middleLineTarget }) => ({
+            connectors.map(({ id, left, right, middleLineTarget }) => ({
                 id,
-                leftColorClass,
-                rightColorClass,
+                leftColorClass: left.colorClass,
+                rightColorClass: right.colorClass,
                 middleLineTarget,
             })),
         [connectors],

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -60,6 +60,7 @@ import {
     ribbonPathD,
     type MergeVerticalLayout,
     type MergePane,
+    type RibbonSpan,
     type SegmentPaneLines,
 } from "./mergeScrollLayout";
 import { buildLineNumberValues } from "./lineNumbers";
@@ -136,14 +137,13 @@ function readPxVar(element: Element, name: string): number {
 }
 
 /**
- * Sets one connector ribbon's curved path across a gutter. Empty result targets
- * render as a thin filled wedge so insertion hunks stay visible without a full
- * row.
+ * Sets one connector ribbon's path across a gutter: flat under the pane
+ * gutters, curved only in the divider strip. Empty result targets render as a
+ * thin filled wedge so insertion hunks stay visible without a full row.
  */
 function setRibbonPath(
     path: SVGPathElement | undefined,
-    x0: number,
-    x1: number,
+    span: RibbonSpan,
     aTop: number,
     aBot: number,
     bTop: number,
@@ -167,7 +167,7 @@ function setRibbonPath(
     }
 
     path.style.display = "";
-    path.setAttribute("d", ribbonPathD(x0, x1, aTop, aBot, bTop, bBot));
+    path.setAttribute("d", ribbonPathD(span, aTop, aBot, bTop, bBot));
 }
 
 // --- VS Code API ---
@@ -221,11 +221,12 @@ function App() {
         right: null,
     });
     const connectorPaths = useMemo(() => new Map<string, SVGPathElement>(), []);
-    // Gutter x-ranges (viewport-relative) the connector ribbons span; measured
-    // on layout/resize so the per-frame draw only recomputes y.
-    const gutterXRef = useRef<{ leftX0: number; leftX1: number; rightX0: number; rightX1: number }>(
-        { leftX0: 0, leftX1: 0, rightX0: 0, rightX1: 0 },
-    );
+    // Ribbon spans (viewport-relative) across each divider; measured on
+    // layout/resize so the per-frame draw only recomputes y.
+    const gutterXRef = useRef<{ left: RibbonSpan; right: RibbonSpan }>({
+        left: { x0: 0, curveX0: 0, curveX1: 0, x1: 0 },
+        right: { x0: 0, curveX0: 0, curveX1: 0, x1: 0 },
+    });
     const viewportHRef = useRef(0);
     const layoutRef = useRef<MergeVerticalLayout | null>(null);
     // Conflict hunks the ribbons link, kept in a ref so the rAF draw reads the
@@ -271,18 +272,44 @@ function App() {
         content.style.setProperty("--merge-viewport-h", `${h}px`);
     }, []);
 
-    // Gutter x-ranges are viewport-relative and change only on layout/resize, so
-    // measure them once here and let the per-frame draw recompute only y.
+    // Ribbon spans are viewport-relative and change only on layout/resize, so
+    // measure them once here and let the per-frame draw recompute only y. The
+    // flat zones run under the source panes' trailing/leading gutters and the
+    // result pane's line numbers; the curve zones are exactly the divider
+    // strips between columns, PyCharm-style.
     const measureGutters = useCallback(() => {
         const { left, middle, right } = columnRefs.current;
         if (!left || !middle || !right) return;
-        const lineGutter = readPxVar(left, "--merge-line-number-gutter");
-        const sourceGutter = lineGutter + readPxVar(left, "--merge-action-gutter");
+        // Each pane's rendered .line-numbers element is its full divider-facing
+        // gutter: the side panes' grid track already includes the action strip,
+        // the result pane's is numbers only. Measure it directly — the runtime
+        // line-number width is a max()/calc() expression parseFloat cannot
+        // resolve — and fall back to the static CSS vars when a pane happens to
+        // render no numbered block.
+        const gutterWidth = (col: HTMLElement, withActions: boolean): number => {
+            const numbers = col.querySelector<HTMLElement>(".line-numbers");
+            // offsetWidth can read 0 while content-visibility keeps the block's
+            // layout skipped (deep scroll + resize) — fall back rather than
+            // collapse the ribbon's flat zones to nothing.
+            if (numbers && numbers.offsetWidth > 0) return numbers.offsetWidth;
+            const fallback = readPxVar(col, "--merge-line-number-gutter");
+            return withActions ? fallback + readPxVar(col, "--merge-action-gutter") : fallback;
+        };
+        const leftEdge = left.offsetLeft + left.offsetWidth;
+        const middleEdge = middle.offsetLeft + middle.offsetWidth;
         gutterXRef.current = {
-            leftX0: left.offsetLeft + left.offsetWidth - sourceGutter,
-            leftX1: middle.offsetLeft + lineGutter,
-            rightX0: middle.offsetLeft + middle.offsetWidth,
-            rightX1: right.offsetLeft + sourceGutter,
+            left: {
+                x0: leftEdge - gutterWidth(left, true),
+                curveX0: leftEdge,
+                curveX1: middle.offsetLeft,
+                x1: middle.offsetLeft + gutterWidth(middle, false),
+            },
+            right: {
+                x0: middleEdge,
+                curveX0: middleEdge,
+                curveX1: right.offsetLeft,
+                x1: right.offsetLeft + gutterWidth(right, true),
+            },
         };
     }, []);
 
@@ -290,7 +317,7 @@ function App() {
         (offsets: Record<MergePane, number>, viewportH: number) => {
             const layout = layoutRef.current;
             if (!layout) return;
-            const { leftX0, leftX1, rightX0, rightX1 } = gutterXRef.current;
+            const { left: leftSpan, right: rightSpan } = gutterXRef.current;
             for (const { id, index, middleLineTarget } of connectorsRef.current) {
                 const oursTop = layout.paneTopPx.left[index] - offsets.left;
                 const oursBot = oursTop + layout.paneHPx.left[index];
@@ -300,8 +327,7 @@ function App() {
                 const theirsBot = theirsTop + layout.paneHPx.right[index];
                 setRibbonPath(
                     connectorPaths.get(`${id}-left`),
-                    leftX0,
-                    leftX1,
+                    leftSpan,
                     oursTop,
                     oursBot,
                     midTop,
@@ -311,8 +337,7 @@ function App() {
                 );
                 setRibbonPath(
                     connectorPaths.get(`${id}-right`),
-                    rightX0,
-                    rightX1,
+                    rightSpan,
                     midTop,
                     midBot,
                     theirsTop,

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -1134,7 +1134,7 @@ function App() {
     // unreliable --vscode-editor-font-size webview variable.
     const gutterDigits = Math.max(String(totalVisualLines).length, 2);
     const rootStyle = {
-        "--merge-line-number-gutter": `max(37px, calc(${gutterDigits}ch + 14px))`,
+        "--merge-line-number-gutter": `max(33px, calc(${gutterDigits}ch + 12px))`,
         // Shared minimum content width for every pane so all code-lines panes
         // scroll in lockstep (see .code-lines in merge-editor.css). Monospace
         // editor font makes 1ch == one glyph, matching the synthetic scrollbar.

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -55,6 +55,7 @@ import {
     type OverviewMarker,
 } from "./segments";
 import {
+    bandSpansForMiddleGap,
     buildVerticalLayout,
     LINE_HEIGHT_PX,
     paneOffsetForCanonical,
@@ -97,8 +98,8 @@ interface ConnectorSideSpec {
 interface ConnectorRenderSpec {
     id: number;
     index: number;
-    left: ConnectorSideSpec;
-    right: ConnectorSideSpec;
+    left?: ConnectorSideSpec;
+    right?: ConnectorSideSpec;
 }
 
 /**
@@ -109,20 +110,24 @@ interface ConnectorRenderSpec {
  * settles both ribbons and points each at its own slice of the result. While
  * exactly one side is accepted, the other side — pending append or discarded —
  * points at the zero-height append edge below the accepted lines instead of
- * re-wrapping the whole result block.
+ * re-wrapping the whole result block. A one-sided hunk (`ours-only` /
+ * `theirs-only`) has no suggestion on its non-contributing divider — PyCharm
+ * links only the side that actually changed — so that side is omitted from
+ * the returned spec entirely rather than drawn as a stray empty connector.
  */
 function connectorSideSpecs(
     segment: ConflictSegment,
     resolution: HunkResolution | undefined,
     dismissed: HunkSideDismissal | undefined,
-): { left: ConnectorSideSpec; right: ConnectorSideSpec } {
+): { left?: ConnectorSideSpec; right?: ConnectorSideSpec } {
     const pendingClass = connectorClass(segment);
     const resolvedClass = `${pendingClass} connector-resolved`;
+    let sides: { left: ConnectorSideSpec; right: ConnectorSideSpec };
     if (resolution === "both" || resolution === "both-reversed") {
         const oursLen = segment.oursLines.length;
         const theirsLen = segment.theirsLines.length;
         const oursFirst = resolution === "both";
-        return {
+        sides = {
             left: {
                 colorClass: resolvedClass,
                 resolved: true,
@@ -134,24 +139,31 @@ function connectorSideSpecs(
                 midSlice: { top: oursFirst ? oursLen : 0, count: theirsLen },
             },
         };
+    } else {
+        const leftResolved =
+            resolution === "ours" || resolution === "none" || dismissed?.ours === true;
+        const rightResolved =
+            resolution === "theirs" || resolution === "none" || dismissed?.theirs === true;
+        sides = {
+            left: {
+                colorClass: leftResolved ? resolvedClass : pendingClass,
+                resolved: leftResolved,
+                midSlice:
+                    resolution === "theirs"
+                        ? { top: segment.theirsLines.length, count: 0 }
+                        : undefined,
+            },
+            right: {
+                colorClass: rightResolved ? resolvedClass : pendingClass,
+                resolved: rightResolved,
+                midSlice:
+                    resolution === "ours" ? { top: segment.oursLines.length, count: 0 } : undefined,
+            },
+        };
     }
-    const leftResolved = resolution === "ours" || resolution === "none" || dismissed?.ours === true;
-    const rightResolved =
-        resolution === "theirs" || resolution === "none" || dismissed?.theirs === true;
-    return {
-        left: {
-            colorClass: leftResolved ? resolvedClass : pendingClass,
-            resolved: leftResolved,
-            midSlice:
-                resolution === "theirs" ? { top: segment.theirsLines.length, count: 0 } : undefined,
-        },
-        right: {
-            colorClass: rightResolved ? resolvedClass : pendingClass,
-            resolved: rightResolved,
-            midSlice:
-                resolution === "ours" ? { top: segment.oursLines.length, count: 0 } : undefined,
-        },
-    };
+    if (segment.changeKind === "ours-only") return { left: sides.left };
+    if (segment.changeKind === "theirs-only") return { right: sides.right };
+    return sides;
 }
 
 /** Maps a side's result slice to pixel extents inside the middle block. */
@@ -401,31 +413,52 @@ function App() {
                 const midBot = midTop + layout.paneHPx.middle[index];
                 const theirsTop = layout.paneTopPx.right[index] - offsets.right;
                 const theirsBot = theirsTop + layout.paneHPx.right[index];
-                // Stacked resolutions point each side at its own result slice;
-                // a lone accepted side leaves the other side a zero-height
-                // append-edge slice.
-                const leftTarget = sliceExtent(midTop, midBot, left.midSlice);
-                const rightSource = sliceExtent(midTop, midBot, right.midSlice);
-                setRibbonPath(
-                    connectorPaths.get(`${id}-left`),
-                    leftSpans,
-                    oursTop,
-                    oursBot,
-                    leftTarget.top,
-                    leftTarget.bot,
-                    viewportH,
-                    left.resolved,
+                // A hunk whose result has no rows (both sides changed a spot
+                // the base left empty) draws no in-pane band in the middle
+                // column; extend the pending side's divider band across the
+                // gap so the thin insertion line reads as one continuous
+                // PyCharm line instead of stopping at the middle pane's
+                // content edges.
+                const middleEmpty = midBot - midTop <= 0;
+                const gapBands = bandSpansForMiddleGap(
+                    leftSpans.band,
+                    rightSpans.band,
+                    middleEmpty,
+                    left !== undefined && !left.resolved,
+                    right !== undefined && !right.resolved,
                 );
-                setRibbonPath(
-                    connectorPaths.get(`${id}-right`),
-                    rightSpans,
-                    rightSource.top,
-                    rightSource.bot,
-                    theirsTop,
-                    theirsBot,
-                    viewportH,
-                    right.resolved,
-                );
+                // One-sided hunks (ours-only / theirs-only) carry a
+                // suggestion on only one divider — connectorSideSpecs already
+                // omitted the other side, so only draw the side present.
+                if (left) {
+                    // Stacked resolutions point each side at its own result
+                    // slice; a lone accepted side leaves the other side a
+                    // zero-height append-edge slice.
+                    const leftTarget = sliceExtent(midTop, midBot, left.midSlice);
+                    setRibbonPath(
+                        connectorPaths.get(`${id}-left`),
+                        { band: gapBands.left, contour: leftSpans.contour },
+                        oursTop,
+                        oursBot,
+                        leftTarget.top,
+                        leftTarget.bot,
+                        viewportH,
+                        left.resolved,
+                    );
+                }
+                if (right) {
+                    const rightSource = sliceExtent(midTop, midBot, right.midSlice);
+                    setRibbonPath(
+                        connectorPaths.get(`${id}-right`),
+                        { band: gapBands.right, contour: rightSpans.contour },
+                        rightSource.top,
+                        rightSource.bot,
+                        theirsTop,
+                        theirsBot,
+                        viewportH,
+                        right.resolved,
+                    );
+                }
             }
         },
         [connectorPaths],
@@ -696,8 +729,8 @@ function App() {
         () =>
             connectors.map(({ id, left, right }) => ({
                 id,
-                leftColorClass: left.colorClass,
-                rightColorClass: right.colorClass,
+                leftColorClass: left?.colorClass,
+                rightColorClass: right?.colorClass,
             })),
         [connectors],
     );

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -62,7 +62,6 @@ import {
     ribbonPathD,
     type MergeVerticalLayout,
     type MergePane,
-    type RibbonSide,
     type RibbonSpan,
     type SegmentPaneLines,
 } from "./mergeScrollLayout";
@@ -98,7 +97,6 @@ interface ConnectorSideSpec {
 interface ConnectorRenderSpec {
     id: number;
     index: number;
-    middleLineTarget: boolean;
     left: ConnectorSideSpec;
     right: ConnectorSideSpec;
 }
@@ -108,7 +106,10 @@ interface ConnectorRenderSpec {
  * its filled suggestion band; a settled side (accepted into the result,
  * discarded via X, or dropped with "none") turns into a dotted contour so the
  * hunk stays traceable across panes after the decision. Stacking both sides
- * settles both ribbons and points each at its own slice of the result.
+ * settles both ribbons and points each at its own slice of the result. While
+ * exactly one side is accepted, the other side — pending append or discarded —
+ * points at the zero-height append edge below the accepted lines instead of
+ * re-wrapping the whole result block.
  */
 function connectorSideSpecs(
     segment: ConflictSegment,
@@ -141,10 +142,14 @@ function connectorSideSpecs(
         left: {
             colorClass: leftResolved ? resolvedClass : pendingClass,
             resolved: leftResolved,
+            midSlice:
+                resolution === "theirs" ? { top: segment.theirsLines.length, count: 0 } : undefined,
         },
         right: {
             colorClass: rightResolved ? resolvedClass : pendingClass,
             resolved: rightResolved,
+            midSlice:
+                resolution === "ours" ? { top: segment.oursLines.length, count: 0 } : undefined,
         },
     };
 }
@@ -158,15 +163,6 @@ function sliceExtent(
     if (!slice) return { top: midTop, bot: midBot };
     const top = midTop + slice.top * LINE_HEIGHT_PX;
     return { top, bot: top + slice.count * LINE_HEIGHT_PX };
-}
-
-function resultIsLineTarget(
-    segment: ConflictSegment,
-    resolution: HunkResolution | undefined,
-    editedLines: string[] | undefined,
-): boolean {
-    if (editedLines !== undefined) return false;
-    return getEffectiveResultLines(segment, resolution, editedLines).length === 0;
 }
 
 /** Reads a numeric px-valued CSS variable used by merge-editor geometry. */
@@ -183,20 +179,13 @@ interface DividerSpans {
     contour: RibbonSpan;
 }
 
-/** Per-ribbon draw options: thin insertion target and/or settled contour mode. */
-interface RibbonDrawOptions {
-    /** Collapse this side to a thin insertion-target wedge (empty result). */
-    lineSide?: RibbonSide;
-    /** Draw the dotted resolved contour, closed on this side's pane edge. */
-    outlineEdge?: RibbonSide;
-}
-
 /**
  * Sets one connector ribbon's path across a gutter. Pending sides draw the
  * filled band (flat under the pane gutters, curved only in the divider strip);
- * resolved sides draw the dotted contour across the pane outer edges instead.
- * Empty result targets render as a thin wedge so insertion hunks stay visible
- * without a full row.
+ * resolved sides draw the dotted linked-block contour instead. Any zero-height
+ * side — an empty result, an untouched pane of a one-sided hunk, or an append
+ * edge — is clamped to a thin line so insertion targets stay visible without a
+ * full row, PyCharm-style.
  */
 function setRibbonPath(
     path: SVGPathElement | undefined,
@@ -206,13 +195,13 @@ function setRibbonPath(
     bTop: number,
     bBot: number,
     viewportH: number,
-    options: RibbonDrawOptions = {},
+    outline: boolean,
 ): void {
     if (!path) return;
-    if (options.lineSide === "a") {
+    if (aBot - aTop < RIBBON_LINE_TARGET_HEIGHT_PX) {
         aBot = aTop + RIBBON_LINE_TARGET_HEIGHT_PX;
     }
-    if (options.lineSide === "b") {
+    if (bBot - bTop < RIBBON_LINE_TARGET_HEIGHT_PX) {
         bBot = bTop + RIBBON_LINE_TARGET_HEIGHT_PX;
     }
 
@@ -226,8 +215,8 @@ function setRibbonPath(
     path.style.display = "";
     path.setAttribute(
         "d",
-        options.outlineEdge
-            ? ribbonOutlineD(spans.contour, aTop, aBot, bTop, bBot, options.outlineEdge)
+        outline
+            ? ribbonOutlineD(spans.contour, aTop, aBot, bTop, bBot)
             : ribbonPathD(spans.band, aTop, aBot, bTop, bBot),
     );
 }
@@ -361,20 +350,25 @@ function App() {
         const leftEdge = left.offsetLeft + left.offsetWidth;
         const middleEdge = middle.offsetLeft + middle.offsetWidth;
         const rightEdge = right.offsetLeft + right.offsetWidth;
-        // Band spans stop at the gutters; contour spans (resolved hunks) run
-        // pane-edge to pane-edge so the dotted trace crosses the whole block.
+        const leftContentEnd = leftEdge - gutterWidth(left, true);
+        const middleContentStart = middle.offsetLeft + gutterWidth(middle, false);
+        const rightContentStart = right.offsetLeft + gutterWidth(right, true);
+        // Band spans stop at the gutters. Contour spans (resolved hunks) wrap
+        // each block's pane CONTENT in a closed dotted rectangle and let the
+        // linking curves sweep the whole gutter+divider zone between them, so
+        // no dotted edge crosses a pane it does not belong to.
         gutterXRef.current = {
             left: {
                 band: {
-                    x0: leftEdge - gutterWidth(left, true),
+                    x0: leftContentEnd,
                     curveX0: leftEdge,
                     curveX1: middle.offsetLeft,
-                    x1: middle.offsetLeft + gutterWidth(middle, false),
+                    x1: middleContentStart,
                 },
                 contour: {
                     x0: left.offsetLeft,
-                    curveX0: leftEdge,
-                    curveX1: middle.offsetLeft,
+                    curveX0: leftContentEnd,
+                    curveX1: middleContentStart,
                     x1: middleEdge,
                 },
             },
@@ -383,12 +377,12 @@ function App() {
                     x0: middleEdge,
                     curveX0: middleEdge,
                     curveX1: right.offsetLeft,
-                    x1: right.offsetLeft + gutterWidth(right, true),
+                    x1: rightContentStart,
                 },
                 contour: {
-                    x0: middle.offsetLeft,
+                    x0: middleContentStart,
                     curveX0: middleEdge,
-                    curveX1: right.offsetLeft,
+                    curveX1: rightContentStart,
                     x1: rightEdge,
                 },
             },
@@ -400,14 +394,16 @@ function App() {
             const layout = layoutRef.current;
             if (!layout) return;
             const { left: leftSpans, right: rightSpans } = gutterXRef.current;
-            for (const { id, index, middleLineTarget, left, right } of connectorsRef.current) {
+            for (const { id, index, left, right } of connectorsRef.current) {
                 const oursTop = layout.paneTopPx.left[index] - offsets.left;
                 const oursBot = oursTop + layout.paneHPx.left[index];
                 const midTop = layout.paneTopPx.middle[index] - offsets.middle;
                 const midBot = midTop + layout.paneHPx.middle[index];
                 const theirsTop = layout.paneTopPx.right[index] - offsets.right;
                 const theirsBot = theirsTop + layout.paneHPx.right[index];
-                // Stacked resolutions point each side at its own result slice.
+                // Stacked resolutions point each side at its own result slice;
+                // a lone accepted side leaves the other side a zero-height
+                // append-edge slice.
                 const leftTarget = sliceExtent(midTop, midBot, left.midSlice);
                 const rightSource = sliceExtent(midTop, midBot, right.midSlice);
                 setRibbonPath(
@@ -418,10 +414,7 @@ function App() {
                     leftTarget.top,
                     leftTarget.bot,
                     viewportH,
-                    {
-                        lineSide: middleLineTarget ? "b" : undefined,
-                        outlineEdge: left.resolved ? "a" : undefined,
-                    },
+                    left.resolved,
                 );
                 setRibbonPath(
                     connectorPaths.get(`${id}-right`),
@@ -431,10 +424,7 @@ function App() {
                     theirsTop,
                     theirsBot,
                     viewportH,
-                    {
-                        lineSide: middleLineTarget ? "a" : undefined,
-                        outlineEdge: right.resolved ? "b" : undefined,
-                    },
+                    right.resolved,
                 );
             }
         },
@@ -694,11 +684,6 @@ function App() {
                 .map((item) => ({
                     id: item.segment.id,
                     index: item.index,
-                    middleLineTarget: resultIsLineTarget(
-                        item.segment,
-                        state.resolutions[item.segment.id],
-                        state.edits[item.segment.id],
-                    ),
                     ...connectorSideSpecs(
                         item.segment,
                         state.resolutions[item.segment.id],
@@ -709,11 +694,10 @@ function App() {
     );
     const connectorSpecs: ConnectorSpec[] = useMemo(
         () =>
-            connectors.map(({ id, left, right, middleLineTarget }) => ({
+            connectors.map(({ id, left, right }) => ({
                 id,
                 leftColorClass: left.colorClass,
                 rightColorClass: right.colorClass,
-                middleLineTarget,
             })),
         [connectors],
     );

--- a/src/webviews/react/merge-editor/MergeEditorApp.tsx
+++ b/src/webviews/react/merge-editor/MergeEditorApp.tsx
@@ -57,6 +57,7 @@ import {
 import {
     buildVerticalLayout,
     paneOffsetForCanonical,
+    ribbonPathD,
     type MergeVerticalLayout,
     type MergePane,
     type SegmentPaneLines,
@@ -135,8 +136,9 @@ function readPxVar(element: Element, name: string): number {
 }
 
 /**
- * Sets one connector ribbon's path across a gutter. Empty result targets render
- * as a thin filled trapezoid so insertion hunks stay visible without a full row.
+ * Sets one connector ribbon's curved path across a gutter. Empty result targets
+ * render as a thin filled wedge so insertion hunks stay visible without a full
+ * row.
  */
 function setRibbonPath(
     path: SVGPathElement | undefined,
@@ -165,8 +167,7 @@ function setRibbonPath(
     }
 
     path.style.display = "";
-    path.classList.remove("merge-connector-line");
-    path.setAttribute("d", `M ${x0},${aTop} L ${x1},${bTop} L ${x1},${bBot} L ${x0},${aBot} Z`);
+    path.setAttribute("d", ribbonPathD(x0, x1, aTop, aBot, bTop, bBot));
 }
 
 // --- VS Code API ---
@@ -616,7 +617,11 @@ function App() {
     }, [layout, connectors, measureViewport, measureGutters, scheduleMergeFrame]);
 
     // Track viewport height (pane-offset clamp + ribbon culling) and gutter
-    // x-ranges across resizes. jsdom lacks ResizeObserver, so guard it.
+    // x-ranges across resizes. jsdom lacks ResizeObserver, so guard it. Keyed on
+    // hasConflictData because the scroller only mounts with data: the mount-time
+    // run finds no element, so it must re-attach once the loading branch is
+    // replaced or resizes would leave the viewport geometry stale.
+    const hasConflictData = state.data !== null;
     useEffect(() => {
         measureViewport();
         if (typeof ResizeObserver === "undefined") return;
@@ -629,7 +634,7 @@ function App() {
         });
         observer.observe(content);
         return () => observer.disconnect();
-    }, [measureViewport, measureGutters, scheduleMergeFrame]);
+    }, [hasConflictData, measureViewport, measureGutters, scheduleMergeFrame]);
 
     // `vFrameRef` is a stable ref; this cleanup is unmount-only.
     // react-doctor-disable-next-line react-doctor/exhaustive-deps

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -413,24 +413,7 @@
 .merge-connector.variant-deletion {
     fill: var(--merge-deleted-block-bg);
 }
-/* Hairline connectors keep the brighter word palette: band colors are too dim
-   for a 1px stroke. */
-.merge-connector.merge-connector-line {
-    fill: none;
-    stroke: var(--pycharm-conflict);
-    stroke-width: 1px;
-}
-.merge-connector.merge-connector-line.variant-insertion {
-    stroke: var(--pycharm-inserted);
-}
-.merge-connector.merge-connector-line.variant-modification {
-    stroke: var(--pycharm-modified);
-}
-.merge-connector.merge-connector-line.variant-deletion {
-    stroke: var(--pycharm-deleted);
-}
-/* Accepted-side ribbons dim to a quiet "done" marker; opacity (not
-   fill-opacity) so paired hairline strokes dim too. */
+/* Accepted-side ribbons dim to a quiet "done" marker. */
 .merge-connector.connector-resolved {
     opacity: 0.45;
 }

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -400,27 +400,27 @@
     overflow: visible;
     z-index: 1;
 }
-/* Ribbon fills reuse the block-band palette so a hunk's band and its connector
-   read as one continuous region across the gutters — but translucent with a
-   1px solid edge stroke, PyCharm-style: steep or overlapping ribbons (blocks
-   pushed apart by proportional scrolling) then read as distinct layered
-   ribbons instead of fusing into an opaque wall in the divider strip. The
-   in-pane row bands stay opaque; only the SVG connector is see-through. */
+/* Ribbon fills use the block-band color at full strength — no translucency —
+   so a hunk's band, its gutter strips, and its divider curve read as one
+   continuous region across all three panes, PyCharm-style. The muted block
+   palette keeps overlapping ribbons legible at full opacity, and the 1px
+   brightened edge stroke keeps individual ribbons traceable where they
+   cross. */
 .merge-connector {
-    fill: color-mix(in srgb, var(--merge-conflict-ribbon-bg) 55%, transparent);
+    fill: var(--merge-conflict-ribbon-bg);
     stroke: color-mix(in srgb, var(--merge-conflict-ribbon-bg) 45%, #d86c6c 55%);
     stroke-width: 1;
 }
 .merge-connector.variant-insertion {
-    fill: color-mix(in srgb, var(--merge-inserted-block-bg) 55%, transparent);
+    fill: var(--merge-inserted-block-bg);
     stroke: color-mix(in srgb, var(--merge-inserted-block-bg) 45%, #79c18d 55%);
 }
 .merge-connector.variant-modification {
-    fill: color-mix(in srgb, var(--merge-modified-block-bg) 55%, transparent);
+    fill: var(--merge-modified-block-bg);
     stroke: color-mix(in srgb, var(--merge-modified-block-bg) 45%, #58b5c9 55%);
 }
 .merge-connector.variant-deletion {
-    fill: color-mix(in srgb, var(--merge-deleted-block-bg) 55%, transparent);
+    fill: var(--merge-deleted-block-bg);
     stroke: color-mix(in srgb, var(--merge-deleted-block-bg) 45%, #9aa3ad 55%);
 }
 /* Settled sides (accepted / discarded) trade the filled band for PyCharm's
@@ -631,9 +631,6 @@
 }
 .segment-common .code-line {
     color: var(--vscode-editor-foreground);
-}
-.segment-common .code-line-content {
-    opacity: 0.62;
 }
 
 .segment-conflict {

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -29,7 +29,7 @@
     --merge-pane-boundary: color-mix(in srgb, var(--merge-editor-fg) 24%, #0d1522 76%);
     --merge-hunk-boundary: color-mix(in srgb, var(--merge-border) 72%, transparent);
     --merge-hunk-boundary-width: 1px;
-    --merge-line-number-gutter: 37px;
+    --merge-line-number-gutter: 33px;
     --merge-action-gutter: 44px;
 
     display: flex;
@@ -688,16 +688,16 @@
 }
 .hunk-action-glyph {
     font-family: var(--vscode-editor-font-family, monospace);
-    font-size: 15px;
+    font-size: 22.5px;
     font-weight: 700;
     line-height: 1;
 }
 .accept-btn {
     color: var(--merge-ok);
 }
-/* Gray at rest like PyCharm's ×; the hover rule escalates to red. */
+/* Dark red at rest like PyCharm's ×; the hover rule escalates to bright red. */
 .discard-btn {
-    color: var(--merge-muted);
+    color: #c02b42;
 }
 .conflict-column {
     position: relative;
@@ -783,7 +783,7 @@
     color: var(--merge-ok);
 }
 .action-btn.discard-btn {
-    color: var(--merge-muted);
+    color: #c02b42;
 }
 /* Block backgrounds are row-scoped like IntelliJ/PyCharm line fragments:
    filler rows align panes but stay neutral. Code rows use a sticky background

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -27,7 +27,6 @@
     --merge-pane-boundary: color-mix(in srgb, var(--merge-editor-fg) 24%, #0d1522 76%);
     --merge-hunk-boundary: color-mix(in srgb, var(--merge-border) 72%, transparent);
     --merge-hunk-boundary-width: 1px;
-    --merge-insertion-marker-height: 3px;
     --merge-line-number-gutter: 37px;
     --merge-action-gutter: 44px;
 
@@ -400,19 +399,27 @@
     z-index: 1;
 }
 /* Ribbon fills reuse the block-band palette so a hunk's band and its connector
-   read as one continuous region across the gutters. */
+   read as one continuous region across the gutters — but translucent with a
+   1px solid edge stroke, PyCharm-style: steep or overlapping ribbons (blocks
+   pushed apart by proportional scrolling) then read as distinct layered
+   ribbons instead of fusing into an opaque wall in the divider strip. The
+   in-pane row bands stay opaque; only the SVG connector is see-through. */
 .merge-connector {
-    fill: var(--merge-conflict-ribbon-bg);
-    stroke: none;
+    fill: color-mix(in srgb, var(--merge-conflict-ribbon-bg) 55%, transparent);
+    stroke: color-mix(in srgb, var(--merge-conflict-ribbon-bg) 45%, #d86c6c 55%);
+    stroke-width: 1;
 }
 .merge-connector.variant-insertion {
-    fill: var(--merge-inserted-block-bg);
+    fill: color-mix(in srgb, var(--merge-inserted-block-bg) 55%, transparent);
+    stroke: color-mix(in srgb, var(--merge-inserted-block-bg) 45%, #79c18d 55%);
 }
 .merge-connector.variant-modification {
-    fill: var(--merge-modified-block-bg);
+    fill: color-mix(in srgb, var(--merge-modified-block-bg) 55%, transparent);
+    stroke: color-mix(in srgb, var(--merge-modified-block-bg) 45%, #58b5c9 55%);
 }
 .merge-connector.variant-deletion {
-    fill: var(--merge-deleted-block-bg);
+    fill: color-mix(in srgb, var(--merge-deleted-block-bg) 55%, transparent);
+    stroke: color-mix(in srgb, var(--merge-deleted-block-bg) 45%, #9aa3ad 55%);
 }
 /* Settled sides (accepted / discarded) trade the filled band for PyCharm's
    dotted contour: an unfilled outline tracing the source block, the divider
@@ -696,46 +703,6 @@
 .conflict-column {
     position: relative;
     overflow: visible;
-}
-.result-insertion-marker {
-    position: absolute;
-    left: 0;
-    width: var(--merge-line-number-gutter);
-    height: var(--merge-insertion-marker-height);
-    background: var(--pycharm-conflict);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--pycharm-conflict) 40%, transparent);
-    pointer-events: none;
-    z-index: 6;
-}
-.result-insertion-marker.marker-top {
-    top: 0;
-}
-.result-insertion-marker.marker-bottom {
-    bottom: 0;
-}
-.result-insertion-marker.variant-insertion {
-    background: var(--pycharm-conflict);
-}
-.source-insertion-marker {
-    position: absolute;
-    width: calc(var(--merge-line-number-gutter) + var(--merge-action-gutter));
-    height: var(--merge-insertion-marker-height);
-    background: var(--pycharm-conflict);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--pycharm-conflict) 40%, transparent);
-    pointer-events: none;
-    z-index: 6;
-}
-.source-insertion-marker.marker-left {
-    right: 0;
-}
-.source-insertion-marker.marker-right {
-    left: 0;
-}
-.source-insertion-marker.marker-top {
-    top: 0;
-}
-.source-insertion-marker.marker-bottom {
-    bottom: 0;
 }
 .merge-horizontal-scroll {
     position: absolute;

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -414,9 +414,26 @@
 .merge-connector.variant-deletion {
     fill: var(--merge-deleted-block-bg);
 }
-/* Accepted-side ribbons dim to a quiet "done" marker. */
+/* Settled sides (accepted / discarded) trade the filled band for PyCharm's
+   dotted contour: an unfilled outline tracing the source block, the divider
+   curve, and the result extent, so a decided hunk stays traceable without
+   competing with pending suggestions. Strokes brighten the band color so 1px
+   dots stay legible on the editor background. Ordered after the variant fill
+   rules so fill:none wins the specificity tie. */
 .merge-connector.connector-resolved {
-    opacity: 0.45;
+    fill: none;
+    stroke: color-mix(in srgb, var(--merge-conflict-ribbon-bg) 45%, #d86c6c 55%);
+    stroke-width: 1;
+    stroke-dasharray: 2 2;
+}
+.merge-connector.variant-insertion.connector-resolved {
+    stroke: color-mix(in srgb, var(--merge-inserted-block-bg) 45%, #79c18d 55%);
+}
+.merge-connector.variant-modification.connector-resolved {
+    stroke: color-mix(in srgb, var(--merge-modified-block-bg) 45%, #58b5c9 55%);
+}
+.merge-connector.variant-deletion.connector-resolved {
+    stroke: color-mix(in srgb, var(--merge-deleted-block-bg) 45%, #9aa3ad 55%);
 }
 .merge-content::-webkit-scrollbar {
     width: 9px;
@@ -838,8 +855,13 @@
     background: transparent;
 }
 /* One-sided hunks are auto-resolved, so their result pane can be "resolved"
-   without meaning "green accepted"; keep non-green variant colors where useful.
-   User edits win via the .edited tint below. */
+   without meaning "green accepted"; keep the variant colors so the result band
+   matches its source band and connector ribbon. User edits win via the .edited
+   tint below. */
+.variant-insertion .conflict-result.resolved:not(.edited) .real-code-line::before,
+.variant-insertion .conflict-result.resolved:not(.edited) .real-line-row {
+    background: var(--merge-inserted-block-bg);
+}
 .variant-modification .conflict-result.resolved:not(.edited) .real-code-line::before,
 .variant-modification .conflict-result.resolved:not(.edited) .real-line-row {
     background: var(--merge-modified-block-bg);
@@ -869,6 +891,28 @@
 }
 .conflict-column.dismissed {
     opacity: 0.5;
+}
+/* Settled blocks are framed by the dotted SVG contour instead of the solid
+   hunk boundary: doubled chrome reads as a still-pending suggestion. Applies
+   to accepted/dismissed source panes and to the result once nothing is
+   pending against it; an active hunk keeps only its focus ring. */
+.segment-conflict.change-conflict:has(> .conflict-column.accepted),
+.segment-conflict.change-conflict:has(> .conflict-column.dismissed),
+.segment-conflict.change-conflict.resolved:has(.conflict-result.resolved) {
+    box-shadow: none;
+}
+.segment-conflict.change-conflict.active:has(> .conflict-column.accepted),
+.segment-conflict.change-conflict.active:has(> .conflict-column.dismissed),
+.segment-conflict.change-conflict.resolved.active:has(.conflict-result.resolved) {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--vscode-focusBorder, #4ea1ff) 16%, transparent);
+}
+/* A dismissed-only side has no resolution yet, so its wrapper is still
+   .unresolved — strip the red number/gutter bands the unresolved rules paint
+   so the discarded block shows only its dotted contour. */
+.segment-conflict.change-conflict.unresolved:has(> .conflict-column.dismissed) .line-numbers,
+.segment-conflict.change-conflict.unresolved:has(> .conflict-column.dismissed) .line-number-row,
+.segment-conflict.change-conflict.unresolved:has(> .conflict-column.dismissed) .code-block::before {
+    background: transparent;
 }
 
 .result-editable {
@@ -1063,7 +1107,8 @@
     background: var(--pycharm-conflict);
 }
 .variant-insertion .conflict-ours .word-diff-change,
-.variant-insertion .conflict-theirs .word-diff-change {
+.variant-insertion .conflict-theirs .word-diff-change,
+.variant-insertion .conflict-result .word-diff-change {
     background: var(--pycharm-inserted);
 }
 .variant-modification .word-diff-change {

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -373,9 +373,10 @@
        line numbers and action glyphs (z-index applies to flex items). */
     z-index: 2;
 }
-/* Separator rail; hunk ribbons supply red only where conflict rows exist. */
+/* Divider strip between panes; hunk ribbons curve across exactly this zone
+   (PyCharm's divider width), so it stays wide enough for the S-bend to read. */
 .merge-gutter {
-    flex: 0 0 16px;
+    flex: 0 0 28px;
     align-self: stretch;
     background: transparent;
     z-index: 3;

--- a/src/webviews/react/merge-editor/merge-editor.css
+++ b/src/webviews/react/merge-editor/merge-editor.css
@@ -13,14 +13,16 @@
     --merge-warning: #f2c572;
     --merge-danger: #d86c6c;
     --merge-ok: #79c18d;
-    /* PyCharm Darcula merge palette: strong changed-region bands, with word
-       fragments using the same family at full intensity. */
+    /* PyCharm Darcula merge palette: the block/ribbon wash is a muted maroon
+       so it reads as a background tint, while changed-word fragments (see
+       .word-diff-change below) carry the same family at full intensity on
+       top of it. */
     --pycharm-conflict: #4b1515;
     --pycharm-inserted: #3d6f4e;
     --pycharm-modified: #1c6978;
     --pycharm-deleted: #565b62;
-    --merge-conflict-ribbon-bg: var(--pycharm-conflict);
-    --merge-conflict-block-bg: var(--merge-conflict-ribbon-bg);
+    --merge-conflict-block-bg: #3a2a32;
+    --merge-conflict-ribbon-bg: var(--merge-conflict-block-bg);
     --merge-inserted-block-bg: #264b33;
     --merge-modified-block-bg: #13404b;
     --merge-deleted-block-bg: #3f444b;
@@ -824,17 +826,20 @@
 /* One-sided hunks are auto-resolved, so their result pane can be "resolved"
    without meaning "green accepted"; keep the variant colors so the result band
    matches its source band and connector ribbon. User edits win via the .edited
-   tint below. */
-.variant-insertion .conflict-result.resolved:not(.edited) .real-code-line::before,
-.variant-insertion .conflict-result.resolved:not(.edited) .real-line-row {
+   tint below. Once the user explicitly settles the hunk (.settled, set when a
+   resolution is actually chosen rather than just auto-included) the decision
+   is made: the result drops the variant wash and reads as plain merged text
+   under its dotted contour, PyCharm-style. */
+.variant-insertion .conflict-result.resolved:not(.edited):not(.settled) .real-code-line::before,
+.variant-insertion .conflict-result.resolved:not(.edited):not(.settled) .real-line-row {
     background: var(--merge-inserted-block-bg);
 }
-.variant-modification .conflict-result.resolved:not(.edited) .real-code-line::before,
-.variant-modification .conflict-result.resolved:not(.edited) .real-line-row {
+.variant-modification .conflict-result.resolved:not(.edited):not(.settled) .real-code-line::before,
+.variant-modification .conflict-result.resolved:not(.edited):not(.settled) .real-line-row {
     background: var(--merge-modified-block-bg);
 }
-.variant-deletion .conflict-result.resolved:not(.edited) .real-code-line::before,
-.variant-deletion .conflict-result.resolved:not(.edited) .real-line-row {
+.variant-deletion .conflict-result.resolved:not(.edited):not(.settled) .real-code-line::before,
+.variant-deletion .conflict-result.resolved:not(.edited):not(.settled) .real-line-row {
     background: var(--merge-deleted-block-bg);
 }
 /* An accepted source pane drops its conflict band (the choice now lives in the

--- a/src/webviews/react/merge-editor/mergeScrollLayout.ts
+++ b/src/webviews/react/merge-editor/mergeScrollLayout.ts
@@ -156,3 +156,31 @@ export function paneOffsetForCanonical(
     const maxOffset = Math.max(0, paneTotalPx[pane] - viewportH);
     return clamp(raw, 0, maxOffset);
 }
+
+/** Horizontal control-point proximity (fraction of the span) for ribbon curves. */
+const RIBBON_CTRL_PROXIMITY_X = 0.3;
+
+/**
+ * Builds the SVG path for one connector ribbon spanning `x0..x1`, joining the
+ * hunk edge `aTop..aBot` (near pane) to `bTop..bBot` (far pane). Both long
+ * edges are cubic Béziers with horizontal end tangents — control points at
+ * 30% / 70% of the span, IntelliJ's curve-trapezium geometry — so the ribbon
+ * meets each pane's rectangular band without a kink and flexes smoothly while
+ * proportional scrolling slides the panes apart. Aligned sides degenerate to
+ * straight edges; a zero-height side collapses the ribbon into a wedge.
+ */
+export function ribbonPathD(
+    x0: number,
+    x1: number,
+    aTop: number,
+    aBot: number,
+    bTop: number,
+    bBot: number,
+): string {
+    const cA = x0 + (x1 - x0) * RIBBON_CTRL_PROXIMITY_X;
+    const cB = x0 + (x1 - x0) * (1 - RIBBON_CTRL_PROXIMITY_X);
+    return (
+        `M ${x0},${aTop} C ${cA},${aTop} ${cB},${bTop} ${x1},${bTop}` +
+        ` L ${x1},${bBot} C ${cB},${bBot} ${cA},${aBot} ${x0},${aBot} Z`
+    );
+}

--- a/src/webviews/react/merge-editor/mergeScrollLayout.ts
+++ b/src/webviews/react/merge-editor/mergeScrollLayout.ts
@@ -205,20 +205,16 @@ export function ribbonPathD(
     );
 }
 
-/** The two vertical edges a connector joins: "a" is the near pane, "b" the far. */
-export type RibbonSide = "a" | "b";
-
 /**
  * Builds the SVG path for a RESOLVED hunk's connector, PyCharm-style: instead
- * of a filled band, an unfilled contour meant to be stroked dotted. Three
- * subpaths: the top edge (`aTop` → `bTop`), the bottom edge (`aBot` → `bBot`)
- * — both flat outside the divider strip and curved across it with the same
- * 30% / 70% Bézier controls as {@link ribbonPathD} — plus one vertical closure
- * on `edgeSide`'s outer pane edge. For this contour the span's `x0`/`x1` are
- * pane OUTER edges (the trace runs across the whole source block and result
- * extent), not gutter starts. No subpath closes with `Z`, so stroking never
- * draws seams at the divider joints; the closure is inset 0.5px so a 1px
- * stroke is not clipped at the pane boundary.
+ * of a filled band, an unfilled contour meant to be stroked dotted. Two closed
+ * rectangles — the a-block over `x0..curveX0` at `aTop..aBot` and the b-block
+ * over `curveX1..x1` at `bTop..bBot` — linked by an open pair of divider
+ * curves with the same 30% / 70% Bézier controls as {@link ribbonPathD}. The
+ * rectangles wrap each block inside its own pane only, so no dotted edge ever
+ * crosses a pane it does not belong to; the outer verticals are inset 0.5px so
+ * a 1px stroke is not clipped at the pane boundaries. A zero-height block
+ * degenerates to a dotted line at the insertion point.
  */
 export function ribbonOutlineD(
     span: RibbonSpan,
@@ -226,21 +222,15 @@ export function ribbonOutlineD(
     aBot: number,
     bTop: number,
     bBot: number,
-    edgeSide: RibbonSide,
 ): string {
     const { x0, curveX0, curveX1, x1 } = span;
     const width = curveX1 - curveX0;
     const cA = curveX0 + width * RIBBON_CTRL_PROXIMITY_X;
     const cB = curveX0 + width * (1 - RIBBON_CTRL_PROXIMITY_X);
-    const edge =
-        edgeSide === "a"
-            ? `M ${x0 + 0.5},${aTop} L ${x0 + 0.5},${aBot}`
-            : `M ${x1 - 0.5},${bTop} L ${x1 - 0.5},${bBot}`;
     return (
-        `M ${x0},${aTop} L ${curveX0},${aTop}` +
-        ` C ${cA},${aTop} ${cB},${bTop} ${curveX1},${bTop} L ${x1},${bTop}` +
-        ` M ${x0},${aBot} L ${curveX0},${aBot}` +
-        ` C ${cA},${aBot} ${cB},${bBot} ${curveX1},${bBot} L ${x1},${bBot}` +
-        ` ${edge}`
+        `M ${x0 + 0.5},${aTop} L ${curveX0},${aTop} L ${curveX0},${aBot} L ${x0 + 0.5},${aBot} Z` +
+        ` M ${curveX0},${aTop} C ${cA},${aTop} ${cB},${bTop} ${curveX1},${bTop}` +
+        ` M ${curveX0},${aBot} C ${cA},${aBot} ${cB},${bBot} ${curveX1},${bBot}` +
+        ` M ${curveX1},${bTop} L ${x1 - 0.5},${bTop} L ${x1 - 0.5},${bBot} L ${curveX1},${bBot} Z`
     );
 }

--- a/src/webviews/react/merge-editor/mergeScrollLayout.ts
+++ b/src/webviews/react/merge-editor/mergeScrollLayout.ts
@@ -157,30 +157,50 @@ export function paneOffsetForCanonical(
     return clamp(raw, 0, maxOffset);
 }
 
-/** Horizontal control-point proximity (fraction of the span) for ribbon curves. */
+/** Horizontal control-point proximity (fraction of the strip) for ribbon curves. */
 const RIBBON_CTRL_PROXIMITY_X = 0.3;
 
 /**
- * Builds the SVG path for one connector ribbon spanning `x0..x1`, joining the
- * hunk edge `aTop..aBot` (near pane) to `bTop..bBot` (far pane). Both long
- * edges are cubic Béziers with horizontal end tangents — control points at
- * 30% / 70% of the span, IntelliJ's curve-trapezium geometry — so the ribbon
- * meets each pane's rectangular band without a kink and flexes smoothly while
- * proportional scrolling slides the panes apart. Aligned sides degenerate to
- * straight edges; a zero-height side collapses the ribbon into a wedge.
+ * Horizontal anatomy of one connector ribbon, PyCharm-style: the band stays a
+ * flat rectangle while it runs under the near pane's gutter (`x0..curveX0`)
+ * and the far pane's gutter (`curveX1..x1`); only the divider strip between
+ * the panes (`curveX0..curveX1`) bends. Producers must keep
+ * `x0 <= curveX0 <= curveX1 <= x1` — the merge layout guarantees it because
+ * the zones come from left-to-right column offsets with a fixed-width divider.
+ */
+export interface RibbonSpan {
+    x0: number;
+    curveX0: number;
+    curveX1: number;
+    x1: number;
+}
+
+/**
+ * Builds the SVG path for one connector ribbon, joining the hunk edge
+ * `aTop..aBot` (near pane) to `bTop..bBot` (far pane) across `span`. Gutter
+ * zones are horizontal rectangles at each side's own extent; the divider strip
+ * curves with cubic Béziers whose control points sit at 30% / 70% of the strip
+ * with horizontal end tangents — IntelliJ's curve-trapezium geometry — so the
+ * band reads as a straight highlight under line numbers and buttons and the
+ * whole height change happens in the divider, without a kink at either joint.
+ * Aligned sides degenerate to straight edges; a zero-height side collapses the
+ * divider curve into a wedge.
  */
 export function ribbonPathD(
-    x0: number,
-    x1: number,
+    span: RibbonSpan,
     aTop: number,
     aBot: number,
     bTop: number,
     bBot: number,
 ): string {
-    const cA = x0 + (x1 - x0) * RIBBON_CTRL_PROXIMITY_X;
-    const cB = x0 + (x1 - x0) * (1 - RIBBON_CTRL_PROXIMITY_X);
+    const { x0, curveX0, curveX1, x1 } = span;
+    const width = curveX1 - curveX0;
+    const cA = curveX0 + width * RIBBON_CTRL_PROXIMITY_X;
+    const cB = curveX0 + width * (1 - RIBBON_CTRL_PROXIMITY_X);
     return (
-        `M ${x0},${aTop} C ${cA},${aTop} ${cB},${bTop} ${x1},${bTop}` +
-        ` L ${x1},${bBot} C ${cB},${bBot} ${cA},${aBot} ${x0},${aBot} Z`
+        `M ${x0},${aTop} L ${curveX0},${aTop}` +
+        ` C ${cA},${aTop} ${cB},${bTop} ${curveX1},${bTop} L ${x1},${bTop}` +
+        ` L ${x1},${bBot} L ${curveX1},${bBot}` +
+        ` C ${cB},${bBot} ${cA},${aBot} ${curveX0},${aBot} L ${x0},${aBot} Z`
     );
 }

--- a/src/webviews/react/merge-editor/mergeScrollLayout.ts
+++ b/src/webviews/react/merge-editor/mergeScrollLayout.ts
@@ -234,3 +234,25 @@ export function ribbonOutlineD(
         ` M ${curveX1},${bTop} L ${x1 - 0.5},${bTop} L ${x1 - 0.5},${bBot} L ${curveX1},${bBot} Z`
     );
 }
+
+/**
+ * Extends pending band spans across the middle pane when a hunk has no
+ * result rows, so the clamped thin line reads as one continuous PyCharm
+ * line through all three panels instead of stopping at the middle pane's
+ * content edges. Only pending (filled-band) sides extend — a settled
+ * side's dotted contour already spans the middle via its result
+ * rectangle. When both sides are pending only the left band extends, so
+ * translucent fills do not double-paint the shared middle run.
+ */
+export function bandSpansForMiddleGap(
+    leftBand: RibbonSpan,
+    rightBand: RibbonSpan,
+    middleEmpty: boolean,
+    leftPending: boolean,
+    rightPending: boolean,
+): { left: RibbonSpan; right: RibbonSpan } {
+    if (!middleEmpty) return { left: leftBand, right: rightBand };
+    const left = leftPending ? { ...leftBand, x1: rightBand.x0 } : leftBand;
+    const right = rightPending && !leftPending ? { ...rightBand, x0: leftBand.x1 } : rightBand;
+    return { left, right };
+}

--- a/src/webviews/react/merge-editor/mergeScrollLayout.ts
+++ b/src/webviews/react/merge-editor/mergeScrollLayout.ts
@@ -204,3 +204,43 @@ export function ribbonPathD(
         ` C ${cB},${bBot} ${cA},${aBot} ${curveX0},${aBot} L ${x0},${aBot} Z`
     );
 }
+
+/** The two vertical edges a connector joins: "a" is the near pane, "b" the far. */
+export type RibbonSide = "a" | "b";
+
+/**
+ * Builds the SVG path for a RESOLVED hunk's connector, PyCharm-style: instead
+ * of a filled band, an unfilled contour meant to be stroked dotted. Three
+ * subpaths: the top edge (`aTop` → `bTop`), the bottom edge (`aBot` → `bBot`)
+ * — both flat outside the divider strip and curved across it with the same
+ * 30% / 70% Bézier controls as {@link ribbonPathD} — plus one vertical closure
+ * on `edgeSide`'s outer pane edge. For this contour the span's `x0`/`x1` are
+ * pane OUTER edges (the trace runs across the whole source block and result
+ * extent), not gutter starts. No subpath closes with `Z`, so stroking never
+ * draws seams at the divider joints; the closure is inset 0.5px so a 1px
+ * stroke is not clipped at the pane boundary.
+ */
+export function ribbonOutlineD(
+    span: RibbonSpan,
+    aTop: number,
+    aBot: number,
+    bTop: number,
+    bBot: number,
+    edgeSide: RibbonSide,
+): string {
+    const { x0, curveX0, curveX1, x1 } = span;
+    const width = curveX1 - curveX0;
+    const cA = curveX0 + width * RIBBON_CTRL_PROXIMITY_X;
+    const cB = curveX0 + width * (1 - RIBBON_CTRL_PROXIMITY_X);
+    const edge =
+        edgeSide === "a"
+            ? `M ${x0 + 0.5},${aTop} L ${x0 + 0.5},${aBot}`
+            : `M ${x1 - 0.5},${bTop} L ${x1 - 0.5},${bBot}`;
+    return (
+        `M ${x0},${aTop} L ${curveX0},${aTop}` +
+        ` C ${cA},${aTop} ${cB},${bTop} ${curveX1},${bTop} L ${x1},${bTop}` +
+        ` M ${x0},${aBot} L ${curveX0},${aBot}` +
+        ` C ${cA},${aBot} ${cB},${bBot} ${curveX1},${bBot} L ${x1},${bBot}` +
+        ` ${edge}`
+    );
+}

--- a/src/webviews/react/merge-editor/segments.tsx
+++ b/src/webviews/react/merge-editor/segments.tsx
@@ -618,10 +618,15 @@ function deriveConflictView(
     const oursInResult = isOurs || isBoth;
     const theirsInResult = isTheirs || isBoth;
     // A side is "dismissed" when the user discarded it (X) without accepting the
-    // opposite side. Acceptance overrides dismissal, so a side in the result is
-    // never treated as dismissed. A manual edit supersedes both.
-    const oursDismissed = !isEdited && !oursInResult && dismissed?.ours === true;
-    const theirsDismissed = !isEdited && !theirsInResult && dismissed?.theirs === true;
+    // opposite side. Resolving to "none" discards BOTH sides (the reducer clears
+    // per-side dismissals then), so it must read as dismissed too — otherwise the
+    // settled blocks would keep their suggestion bands and controls. Acceptance
+    // overrides dismissal, so a side in the result is never treated as
+    // dismissed. A manual edit supersedes both.
+    const bothDiscarded = !isEdited && resolution === "none";
+    const oursDismissed = !isEdited && !oursInResult && (dismissed?.ours === true || bothDiscarded);
+    const theirsDismissed =
+        !isEdited && !theirsInResult && (dismissed?.theirs === true || bothDiscarded);
     const isAutoMerged =
         segment.autoResolvedLines !== undefined && resolution === undefined && !isEdited;
     const isResolved =

--- a/src/webviews/react/merge-editor/segments.tsx
+++ b/src/webviews/react/merge-editor/segments.tsx
@@ -561,6 +561,8 @@ interface ConflictView {
     isAutoMerged: boolean;
     isResolved: boolean;
     resultIsUnresolved: boolean;
+    /** One-sided hunk explicitly settled by the user: its result rows drop the variant fill. */
+    resultSettled: boolean;
     showLeftActions: boolean;
     showRightActions: boolean;
     leftAppend: boolean;
@@ -637,6 +639,14 @@ function deriveConflictView(
         segment.changeKind === "conflict" &&
         !isEdited &&
         ((isOurs && !theirsDismissed) || (isTheirs && !oursDismissed));
+    // A one-sided hunk is auto-included in the result the moment it loads
+    // (isResolved is unconditionally true for changeKind !== "conflict"), but
+    // it only counts as the user's DECISION once a resolution is actually set
+    // — an explicit accept/discard, not the initial auto-include. Only then
+    // does PyCharm drop the variant wash and show the result as plain merged
+    // text under its dotted contour.
+    const resultSettled =
+        segment.changeKind !== "conflict" && resolution !== undefined && !isEdited;
     return {
         isEdited,
         isOurs,
@@ -648,6 +658,7 @@ function deriveConflictView(
         isAutoMerged,
         isResolved,
         resultIsUnresolved,
+        resultSettled,
         // A side's controls show only while that side is still pending: not yet
         // in the result and not discarded. Accepting one side leaves the other
         // side's accept button available to append (stack) below it; discarding
@@ -954,7 +965,7 @@ export const ResultConflictBlock = React.memo(function ResultConflictBlock({
                     lineNumbers={lineNumbers}
                     className={`conflict-result ${
                         view.resultIsUnresolved || !view.isResolved ? "unresolved" : "resolved"
-                    } ${view.isEdited ? "edited" : ""}`}
+                    } ${view.isEdited ? "edited" : ""} ${view.resultSettled ? "settled" : ""}`}
                     wordHighlight={highlightWords}
                     compareLines={view.resultCompareLines}
                     onCommit={(lines) => onEditResult(segment.id, lines)}

--- a/src/webviews/react/merge-editor/segments.tsx
+++ b/src/webviews/react/merge-editor/segments.tsx
@@ -561,7 +561,6 @@ interface ConflictView {
     isAutoMerged: boolean;
     isResolved: boolean;
     resultIsUnresolved: boolean;
-    resultInsertionMarker: "top" | "bottom" | undefined;
     showLeftActions: boolean;
     showRightActions: boolean;
     leftAppend: boolean;
@@ -638,23 +637,6 @@ function deriveConflictView(
         segment.changeKind === "conflict" &&
         !isEdited &&
         ((isOurs && !theirsDismissed) || (isTheirs && !oursDismissed));
-    const hasPendingInsertionTarget =
-        segment.changeKind === "conflict" &&
-        !isEdited &&
-        segment.autoResolvedLines === undefined &&
-        ((!oursInResult && !theirsInResult && segment.baseLines.length === 0) ||
-            (isOurs && !theirsDismissed) ||
-            (isTheirs && !oursDismissed));
-    const acceptedResultLineCount = isOurs
-        ? segment.oursLines.length
-        : isTheirs
-          ? segment.theirsLines.length
-          : 0;
-    const resultInsertionMarker = hasPendingInsertionTarget
-        ? (!oursInResult && !theirsInResult) || acceptedResultLineCount === 0
-            ? "top"
-            : "bottom"
-        : undefined;
     return {
         isEdited,
         isOurs,
@@ -666,7 +648,6 @@ function deriveConflictView(
         isAutoMerged,
         isResolved,
         resultIsUnresolved,
-        resultInsertionMarker,
         // A side's controls show only while that side is still pending: not yet
         // in the result and not discarded. Accepting one side leaves the other
         // side's accept button available to append (stack) below it; discarding
@@ -906,12 +887,6 @@ export const OursConflictBlock = React.memo(function OursConflictBlock({
                     wordHighlight={highlightWords}
                     compareLines={view.oursInResult ? undefined : segment.baseLines}
                 />
-                {view.oursInResult && view.resultInsertionMarker ? (
-                    <div
-                        className={`source-insertion-marker marker-left marker-${view.resultInsertionMarker} variant-insertion`}
-                        aria-hidden="true"
-                    />
-                ) : null}
                 {view.showLeftActions ? (
                     <LeftHunkActions
                         segmentId={segment.id}
@@ -984,12 +959,6 @@ export const ResultConflictBlock = React.memo(function ResultConflictBlock({
                     compareLines={view.resultCompareLines}
                     onCommit={(lines) => onEditResult(segment.id, lines)}
                 />
-                {view.resultInsertionMarker ? (
-                    <div
-                        className={`result-insertion-marker marker-${view.resultInsertionMarker} variant-insertion`}
-                        aria-hidden="true"
-                    />
-                ) : null}
             </div>
         </div>
     );
@@ -1056,12 +1025,6 @@ export const TheirsConflictBlock = React.memo(function TheirsConflictBlock({
                     wordHighlight={highlightWords}
                     compareLines={view.theirsInResult ? undefined : segment.baseLines}
                 />
-                {view.theirsInResult && view.resultInsertionMarker ? (
-                    <div
-                        className={`source-insertion-marker marker-right marker-${view.resultInsertionMarker} variant-insertion`}
-                        aria-hidden="true"
-                    />
-                ) : null}
             </div>
         </div>
     );
@@ -1074,7 +1037,6 @@ export interface ConnectorSpec {
     id: number;
     leftColorClass?: string;
     rightColorClass?: string;
-    middleLineTarget: boolean;
 }
 
 /** Color class for a hunk's connector ribbon, matching its block band. */

--- a/tests/integration/webviews/merge-webviews.integration.test.tsx
+++ b/tests/integration/webviews/merge-webviews.integration.test.tsx
@@ -955,6 +955,107 @@ describe("MergeEditorApp", () => {
         });
     });
 
+    it("draws exactly one connector per one-sided hunk, on its contributing divider only", async () => {
+        installVsCodeMock();
+        createRootHost();
+
+        await act(async () => {
+            await import("../../../src/webviews/react/merge-editor/MergeEditorApp");
+        });
+        await flush();
+
+        dispatchHostMessage({
+            type: "setConflictData",
+            data: {
+                filePath: "src/conflict.ts",
+                oursLabel: "main",
+                theirsLabel: "feature/incoming",
+                eol: "\n",
+                hasTrailingNewline: true,
+                segments: [
+                    {
+                        type: "conflict",
+                        id: 0,
+                        changeKind: "ours-only",
+                        oursLines: ["added();"],
+                        theirsLines: [],
+                        baseLines: [],
+                    },
+                    {
+                        type: "conflict",
+                        id: 1,
+                        changeKind: "theirs-only",
+                        oursLines: [],
+                        theirsLines: ["incoming();"],
+                        baseLines: [],
+                    },
+                ],
+            },
+        });
+        await flush();
+
+        // PyCharm links a one-sided hunk only across the divider its change
+        // came from: an ours-only hunk has no suggestion on the right, a
+        // theirs-only hunk none on the left. Drawing both (the old bug) left a
+        // stray wedge/stub converging on the pane with nothing to suggest —
+        // two hunks would render four paths instead of two.
+        const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
+        expect(connectors).toHaveLength(2);
+        for (const connector of Array.from(connectors)) {
+            expect(connector.getAttribute("class")).toContain("variant-insertion");
+            expect(connector.getAttribute("class")).not.toContain("connector-resolved");
+        }
+    });
+
+    it("drops the variant fill from a one-sided result once the user explicitly settles it", async () => {
+        installVsCodeMock();
+        createRootHost();
+
+        await act(async () => {
+            await import("../../../src/webviews/react/merge-editor/MergeEditorApp");
+        });
+        await flush();
+
+        dispatchHostMessage({
+            type: "setConflictData",
+            data: {
+                filePath: "src/conflict.ts",
+                oursLabel: "main",
+                theirsLabel: "feature/incoming",
+                eol: "\n",
+                hasTrailingNewline: true,
+                segments: [
+                    {
+                        type: "conflict",
+                        id: 0,
+                        changeKind: "ours-only",
+                        oursLines: ["added();"],
+                        theirsLines: [],
+                        baseLines: [],
+                    },
+                ],
+            },
+        });
+        await flush();
+
+        // Auto-included but not yet explicitly decided: the result still
+        // reads as the pending variant fill, not a settled plain merge.
+        const resultBlockBefore = document.querySelector('[data-conflict-id="0"] .conflict-result');
+        expect(resultBlockBefore?.className).toContain("resolved");
+        expect(resultBlockBefore?.className).not.toContain("settled");
+
+        clickButton("Accept left block");
+        await flush();
+
+        // The user made an explicit decision: the result drops the green wash
+        // and reads as plain merged text under its dotted contour.
+        const resultBlockAfter = document.querySelector('[data-conflict-id="0"] .conflict-result');
+        expect(resultBlockAfter?.className).toContain("settled");
+        const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
+        expect(connectors).toHaveLength(1);
+        expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
+    });
+
     it("resolves conflicts with Ctrl+Arrow side shortcuts, auto-advances, and applies with Ctrl+Enter", async () => {
         const vscode = installVsCodeMock();
         createRootHost();

--- a/tests/integration/webviews/merge-webviews.integration.test.tsx
+++ b/tests/integration/webviews/merge-webviews.integration.test.tsx
@@ -81,6 +81,17 @@ async function flushShikiInit(): Promise<void> {
     });
 }
 
+/**
+ * Waits out jsdom's ~16ms requestAnimationFrame timer so the merge scroll
+ * driver's scheduled frame runs and connector path `d` attributes are set.
+ * The microtask-only `flush()` never reaches macrotask-backed rAF callbacks.
+ */
+async function flushAnimationFrame(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 40));
+    });
+}
+
 /** Conflict payload with two true conflicts separated by common code. */
 function twoConflictData(): unknown {
     return {
@@ -275,10 +286,16 @@ describe("MergeEditorApp", () => {
         expect(
             document.querySelector('[data-conflict-id="0"] .source-insertion-marker.marker-right'),
         ).toBeNull();
+        // The accepted left side keeps its conflict color but flips to the
+        // dotted resolved contour; the right suggestion stays a filled band.
+        // (Path `d` shapes are asserted in the insert-conflict test whose hunk
+        // sits at y=0 — this hunk is culled under jsdom's zero-height viewport.)
         const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
         expect(connectors).toHaveLength(2);
-        expect(connectors[0].getAttribute("class")).toContain("variant-insertion");
+        expect(connectors[0].getAttribute("class")).toContain("change-conflict");
+        expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
         expect(connectors[1].getAttribute("class")).toContain("change-conflict");
+        expect(connectors[1].getAttribute("class")).not.toContain("connector-resolved");
         expect(
             document.querySelector('[data-conflict-id="0"] .conflict-theirs')?.className,
         ).not.toContain("accepted-pane");
@@ -324,6 +341,7 @@ describe("MergeEditorApp", () => {
         await flush();
 
         expect(document.querySelector(".result-insertion-marker.marker-top")).not.toBeNull();
+        await flushAnimationFrame();
         const pendingConnectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
         expect(pendingConnectors).toHaveLength(2);
         expect(
@@ -346,10 +364,18 @@ describe("MergeEditorApp", () => {
             document.querySelector(".source-insertion-marker.marker-left.marker-bottom"),
         ).not.toBeNull();
         expect(document.querySelector(".source-insertion-marker.marker-right")).toBeNull();
+        // This hunk sits at y=0, so the frame actually draws it: the accepted
+        // left side must switch to the open dotted contour (subpaths, no Z)
+        // while the pending right side keeps the closed filled band.
+        await flushAnimationFrame();
         const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
         expect(connectors).toHaveLength(2);
-        expect(connectors[0].getAttribute("class")).toContain("variant-insertion");
+        expect(connectors[0].getAttribute("class")).toContain("change-conflict");
+        expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
+        expect(connectors[0].getAttribute("d")?.trim().endsWith("Z")).toBe(false);
         expect(connectors[1].getAttribute("class")).toContain("change-conflict");
+        expect(connectors[1].getAttribute("class")).not.toContain("connector-resolved");
+        expect(connectors[1].getAttribute("d")?.trim().endsWith("Z")).toBe(true);
     });
 
     it("attaches the viewport ResizeObserver to the scroller once conflict data mounts it", async () => {
@@ -792,11 +818,14 @@ describe("MergeEditorApp", () => {
         expect(document.querySelector(".conflict-theirs")?.className).not.toContain(
             "accepted-pane",
         );
-        // The dismissed left side loses its ribbon; only the still-offered
-        // right suggestion keeps its pending conflict connector.
+        // The dismissed left side keeps a dotted resolved trace (PyCharm's
+        // ignored style); the still-offered right suggestion stays a pending
+        // filled connector.
         const pendingConnectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
-        expect(pendingConnectors).toHaveLength(1);
-        expect(pendingConnectors[0].getAttribute("class")).toContain("change-conflict");
+        expect(pendingConnectors).toHaveLength(2);
+        expect(pendingConnectors[0].getAttribute("class")).toContain("connector-resolved");
+        expect(pendingConnectors[1].getAttribute("class")).toContain("change-conflict");
+        expect(pendingConnectors[1].getAttribute("class")).not.toContain("connector-resolved");
 
         // The right side only enters the result when the user explicitly accepts it.
         clickButton("Accept right block");
@@ -859,12 +888,14 @@ describe("MergeEditorApp", () => {
         expect(document.querySelector(".conflict-theirs")?.className).not.toContain(
             "accepted-pane",
         );
-        // The dismissed right side loses its ribbon; the accepted left keeps a
-        // dimmed "done" connector instead of a pending suggestion ribbon.
+        // Both sides are settled (left accepted, right dismissed): each keeps a
+        // dotted resolved contour in the conflict color, no pending bands left.
         const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
-        expect(connectors).toHaveLength(1);
-        expect(connectors[0].getAttribute("class")).toContain("variant-insertion");
-        expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
+        expect(connectors).toHaveLength(2);
+        for (const connector of Array.from(connectors)) {
+            expect(connector.getAttribute("class")).toContain("change-conflict");
+            expect(connector.getAttribute("class")).toContain("connector-resolved");
+        }
 
         clickButton("Apply (1/1)");
         expect(vscode.postMessage).toHaveBeenCalledWith({
@@ -912,8 +943,14 @@ describe("MergeEditorApp", () => {
         clickButton("Ignore right block");
         await flush();
         expect(document.body.textContent).toContain("0 unresolved");
-        // A fully discarded hunk points at nothing: no ribbons remain.
-        expect(document.querySelectorAll(".merge-connector")).toHaveLength(0);
+        // A fully discarded hunk keeps two dotted traces pointing at the thin
+        // insertion line where the block used to be — PyCharm's ignored style —
+        // instead of vanishing entirely.
+        const discardedConnectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
+        expect(discardedConnectors).toHaveLength(2);
+        for (const connector of Array.from(discardedConnectors)) {
+            expect(connector.getAttribute("class")).toContain("connector-resolved");
+        }
 
         clickButton("Apply (1/1)");
         expect(vscode.postMessage).toHaveBeenCalledWith({

--- a/tests/integration/webviews/merge-webviews.integration.test.tsx
+++ b/tests/integration/webviews/merge-webviews.integration.test.tsx
@@ -275,17 +275,10 @@ describe("MergeEditorApp", () => {
         expect(
             document.querySelector('[data-conflict-id="0"] .conflict-result')?.className,
         ).toContain("unresolved");
-        expect(
-            document.querySelector('[data-conflict-id="0"] .result-insertion-marker.marker-bottom'),
-        ).not.toBeNull();
-        expect(
-            document.querySelector(
-                '[data-conflict-id="0"] .source-insertion-marker.marker-left.marker-bottom',
-            ),
-        ).not.toBeNull();
-        expect(
-            document.querySelector('[data-conflict-id="0"] .source-insertion-marker.marker-right'),
-        ).toBeNull();
+        // The old standalone insertion-marker bars are gone: the pending
+        // side's ribbon itself tapers to the append edge instead.
+        expect(document.querySelector(".result-insertion-marker")).toBeNull();
+        expect(document.querySelector(".source-insertion-marker")).toBeNull();
         // The accepted left side keeps its conflict color but flips to the
         // dotted resolved contour; the right suggestion stays a filled band.
         // (Path `d` shapes are asserted in the insert-conflict test whose hunk
@@ -309,7 +302,7 @@ describe("MergeEditorApp", () => {
         });
     });
 
-    it("shows a thin result insertion marker for pending insert conflicts", async () => {
+    it("draws pending insert conflicts as thin-line bands and accepted sides as contours", async () => {
         installVsCodeMock();
         createRootHost();
 
@@ -340,41 +333,39 @@ describe("MergeEditorApp", () => {
         });
         await flush();
 
-        expect(document.querySelector(".result-insertion-marker.marker-top")).not.toBeNull();
+        // No standalone insertion-marker bars anymore: the empty result target
+        // itself draws as a 3px-line band (this hunk sits at y=0, so the frame
+        // actually draws under jsdom's zero-height viewport).
+        expect(document.querySelector(".result-insertion-marker")).toBeNull();
         await flushAnimationFrame();
         const pendingConnectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
         expect(pendingConnectors).toHaveLength(2);
-        expect(
-            Array.from(pendingConnectors).every((connector) =>
-                connector.getAttribute("d")?.trim().endsWith("Z"),
-            ),
-        ).toBe(true);
-        expect(
-            Array.from(pendingConnectors).some((connector) =>
-                connector.classList.contains("merge-connector-line"),
-            ),
-        ).toBe(false);
+        for (const connector of pendingConnectors) {
+            const d = connector.getAttribute("d")?.trim() ?? "";
+            // A pending band is one closed subpath, its empty result side
+            // clamped to the 3px insertion line.
+            expect(d.endsWith("Z")).toBe(true);
+            expect(d.match(/M /g)).toHaveLength(1);
+            expect(d).toContain(",3 ");
+        }
 
         clickButton("Accept left block");
         await flush();
 
-        expect(document.querySelector(".result-insertion-marker.marker-top")).toBeNull();
-        expect(document.querySelector(".result-insertion-marker.marker-bottom")).not.toBeNull();
-        expect(
-            document.querySelector(".source-insertion-marker.marker-left.marker-bottom"),
-        ).not.toBeNull();
-        expect(document.querySelector(".source-insertion-marker.marker-right")).toBeNull();
-        // This hunk sits at y=0, so the frame actually draws it: the accepted
-        // left side must switch to the open dotted contour (subpaths, no Z)
-        // while the pending right side keeps the closed filled band.
+        expect(document.querySelector(".result-insertion-marker")).toBeNull();
+        expect(document.querySelector(".source-insertion-marker")).toBeNull();
+        // The accepted left side switches to the dotted linked-block contour
+        // (two closed rectangles + two open divider curves = 4 subpaths) while
+        // the pending right side keeps the single closed filled band.
         await flushAnimationFrame();
         const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
         expect(connectors).toHaveLength(2);
         expect(connectors[0].getAttribute("class")).toContain("change-conflict");
         expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
-        expect(connectors[0].getAttribute("d")?.trim().endsWith("Z")).toBe(false);
+        expect(connectors[0].getAttribute("d")?.match(/M /g)).toHaveLength(4);
         expect(connectors[1].getAttribute("class")).toContain("change-conflict");
         expect(connectors[1].getAttribute("class")).not.toContain("connector-resolved");
+        expect(connectors[1].getAttribute("d")?.match(/M /g)).toHaveLength(1);
         expect(connectors[1].getAttribute("d")?.trim().endsWith("Z")).toBe(true);
     });
 
@@ -714,14 +705,12 @@ describe("MergeEditorApp", () => {
         // Accept right first, then append left below it: theirs comes before ours.
         clickButton("Accept right block");
         await flush();
-        expect(document.querySelector(".result-insertion-marker.variant-insertion")).not.toBeNull();
         clickButton("Append left block below the result");
         await flush();
 
         expect(document.body.textContent).toContain("0 unresolved");
         expect(document.querySelector(".conflict-actions-left")).toBeNull();
         expect(document.querySelector(".conflict-actions-right")).toBeNull();
-        expect(document.querySelector(".result-insertion-marker")).toBeNull();
         expect(document.querySelector(".conflict-ours")?.className).toContain("accepted-pane");
         expect(document.querySelector(".conflict-theirs")?.className).toContain("accepted-pane");
 
@@ -732,7 +721,7 @@ describe("MergeEditorApp", () => {
         });
     });
 
-    it("shows the append marker at the top after accepting an empty side", async () => {
+    it("clamps the ribbons to thin lines after accepting an empty side", async () => {
         installVsCodeMock();
         createRootHost();
 
@@ -765,12 +754,19 @@ describe("MergeEditorApp", () => {
 
         clickButton("Accept left block");
         await flush();
+        await flushAnimationFrame();
 
-        const marker = document.querySelector<HTMLElement>(
-            ".result-insertion-marker.variant-insertion",
-        );
-        expect(marker).not.toBeNull();
-        expect(marker?.className).toContain("marker-top");
+        // Accepting the empty left side empties the result: the settled left
+        // contour and the pending right band both collapse their zero-height
+        // sides to the 3px insertion line instead of vanishing (the hunk sits
+        // at y=0, so jsdom's zero-height viewport still draws it).
+        const connectors = document.querySelectorAll<SVGPathElement>(".merge-connector");
+        expect(connectors).toHaveLength(2);
+        expect(connectors[0].getAttribute("class")).toContain("connector-resolved");
+        expect(connectors[0].getAttribute("d")).toContain(",3 ");
+        expect(connectors[1].getAttribute("class")).not.toContain("connector-resolved");
+        expect(connectors[1].getAttribute("d")).toContain(",3 ");
+        expect(document.querySelector(".result-insertion-marker")).toBeNull();
     });
 
     it("discards only the left side on left X and leaves the right suggestion offered", async () => {

--- a/tests/integration/webviews/merge-webviews.integration.test.tsx
+++ b/tests/integration/webviews/merge-webviews.integration.test.tsx
@@ -255,15 +255,15 @@ describe("MergeEditorApp", () => {
         expect(
             document.querySelectorAll('[data-conflict-id="0"] .conflict-actions-right .action-btn'),
         ).toHaveLength(2);
-        expect(document.querySelector('[data-conflict-id="0"] .conflict-ours')?.className).toContain(
-            "accepted-pane",
-        );
-        expect(document.querySelector('[data-conflict-id="0"] .conflict-result')?.className).not.toContain(
-            "accepted-pane",
-        );
-        expect(document.querySelector('[data-conflict-id="0"] .conflict-result')?.className).toContain(
-            "unresolved",
-        );
+        expect(
+            document.querySelector('[data-conflict-id="0"] .conflict-ours')?.className,
+        ).toContain("accepted-pane");
+        expect(
+            document.querySelector('[data-conflict-id="0"] .conflict-result')?.className,
+        ).not.toContain("accepted-pane");
+        expect(
+            document.querySelector('[data-conflict-id="0"] .conflict-result')?.className,
+        ).toContain("unresolved");
         expect(
             document.querySelector('[data-conflict-id="0"] .result-insertion-marker.marker-bottom'),
         ).not.toBeNull();
@@ -350,6 +350,44 @@ describe("MergeEditorApp", () => {
         expect(connectors).toHaveLength(2);
         expect(connectors[0].getAttribute("class")).toContain("variant-insertion");
         expect(connectors[1].getAttribute("class")).toContain("change-conflict");
+    });
+
+    it("attaches the viewport ResizeObserver to the scroller once conflict data mounts it", async () => {
+        // The scroller only exists after data arrives (the loading branch renders
+        // no .merge-content), so viewport tracking must attach at that point —
+        // otherwise panel resizes leave viewport height and gutter x-ranges stale
+        // and ribbons get culled against a dead viewport.
+        const observed: Element[] = [];
+        class RecordingResizeObserver {
+            observe(target: Element): void {
+                observed.push(target);
+            }
+            unobserve(): void {}
+            disconnect(): void {}
+        }
+        Object.defineProperty(globalThis, "ResizeObserver", {
+            configurable: true,
+            value: RecordingResizeObserver,
+        });
+        try {
+            installVsCodeMock();
+            createRootHost();
+
+            await act(async () => {
+                await import("../../../src/webviews/react/merge-editor/MergeEditorApp");
+            });
+            await flush();
+            expect(observed).toHaveLength(0);
+
+            dispatchHostMessage({ type: "setConflictData", data: twoConflictData() });
+            await flush();
+
+            const content = document.querySelector(".merge-content");
+            expect(content).not.toBeNull();
+            expect(observed).toContain(content);
+        } finally {
+            delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+        }
     });
 
     it("edits the result pane manually and applies the edited content", async () => {

--- a/tests/unit/merge/mergeScrollLayout.test.ts
+++ b/tests/unit/merge/mergeScrollLayout.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
     buildVerticalLayout,
     paneOffsetForCanonical,
+    ribbonOutlineD,
     ribbonPathD,
     type MergePane,
     type SegmentPaneLines,
@@ -189,6 +190,61 @@ describe("ribbonPathD", () => {
         expect(ribbonPathD({ x0: 100, curveX0: 100, curveX1: 200, x1: 200 }, 10, 50, 30, 90)).toBe(
             "M 100,10 L 100,10 C 130,10 170,30 200,30 L 200,30" +
                 " L 200,90 L 200,90 C 170,90 130,50 100,50 L 100,50 Z",
+        );
+    });
+});
+
+// Resolved-hunk contour, PyCharm's "settled" rendering: an unfilled dotted
+// outline tracing the source block, the divider curve, and the result extent.
+// The path is three subpaths — top edge, bottom edge, and one vertical closure
+// on the resolved side's outer pane edge (inset 0.5px so a 1px stroke is not
+// clipped at the pane boundary) — with NO closing Z, so stroking it never
+// draws vertical seams at the divider joints. Here the span's x0/x1 are pane
+// OUTER edges (not gutter starts); the curve zone stays the divider strip and
+// uses the same 30% / 70% control-point contract as the filled ribbon.
+describe("ribbonOutlineD", () => {
+    // Strip 140..170 (width 30) → controls at x=149 and x=161.
+    const SPAN = { x0: 0, curveX0: 140, curveX1: 170, x1: 300 };
+
+    it("traces open top/bottom edges and closes on the a-side pane edge", () => {
+        expect(ribbonOutlineD(SPAN, 10, 50, 30, 90, "a")).toBe(
+            "M 0,10 L 140,10 C 149,10 161,30 170,30 L 300,30" +
+                " M 0,50 L 140,50 C 149,50 161,90 170,90 L 300,90" +
+                " M 0.5,10 L 0.5,50",
+        );
+    });
+
+    it("closes on the b-side pane edge for right-pane resolutions", () => {
+        expect(ribbonOutlineD(SPAN, 10, 50, 30, 90, "b")).toBe(
+            "M 0,10 L 140,10 C 149,10 161,30 170,30 L 300,30" +
+                " M 0,50 L 140,50 C 149,50 161,90 170,90 L 300,90" +
+                " M 299.5,30 L 299.5,90",
+        );
+    });
+
+    it("degenerates to straight dotted rails when both sides align", () => {
+        expect(ribbonOutlineD(SPAN, 10, 50, 10, 50, "a")).toBe(
+            "M 0,10 L 140,10 C 149,10 161,10 170,10 L 300,10" +
+                " M 0,50 L 140,50 C 149,50 161,50 170,50 L 300,50" +
+                " M 0.5,10 L 0.5,50",
+        );
+    });
+
+    it("collapses both edges onto one curve when the target has zero height", () => {
+        // bTop == bBot (a wedge to an insertion point): the closure on side b
+        // is a zero-length vertical at the shared y.
+        expect(ribbonOutlineD(SPAN, 20, 60, 40, 40, "b")).toBe(
+            "M 0,20 L 140,20 C 149,20 161,40 170,40 L 300,40" +
+                " M 0,60 L 140,60 C 149,60 161,40 170,40 L 300,40" +
+                " M 299.5,40 L 299.5,40",
+        );
+    });
+
+    it("handles negative coordinates for hunks scrolled above the viewport", () => {
+        expect(ribbonOutlineD(SPAN, -30, -10, -20, 0, "a")).toBe(
+            "M 0,-30 L 140,-30 C 149,-30 161,-20 170,-20 L 300,-20" +
+                " M 0,-10 L 140,-10 C 149,-10 161,0 170,0 L 300,0" +
+                " M 0.5,-30 L 0.5,-10",
         );
     });
 });

--- a/tests/unit/merge/mergeScrollLayout.test.ts
+++ b/tests/unit/merge/mergeScrollLayout.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+    bandSpansForMiddleGap,
     buildVerticalLayout,
     paneOffsetForCanonical,
     ribbonOutlineD,
@@ -254,5 +255,54 @@ describe("ribbonOutlineD", () => {
                 " M 150,50 C 150,50 150,90 150,90" +
                 " M 150,30 L 199.5,30 L 199.5,90 L 150,90 Z",
         );
+    });
+});
+
+// A hunk whose result has no rows (both sides changed a spot the base left
+// empty) draws no in-pane band in the middle column, so the pending sides'
+// divider bands must extend across the gap themselves or the 3px thin line
+// stops dead at the middle pane's content edges instead of reading as one
+// continuous PyCharm line through all three panels. Settled sides are left
+// alone — their dotted contour already spans the middle via the result
+// rectangle in ribbonOutlineD.
+describe("bandSpansForMiddleGap", () => {
+    const leftBand = { x0: 426, curveX0: 508, curveX1: 536, x1: 572 };
+    const rightBand = { x0: 1042, curveX0: 1042, curveX1: 1070, x1: 1151 };
+
+    it("returns the input spans unchanged (same reference) when the middle pane has rows, regardless of pending flags", () => {
+        const bothPending = bandSpansForMiddleGap(leftBand, rightBand, false, true, true);
+        expect(bothPending.left).toBe(leftBand);
+        expect(bothPending.right).toBe(rightBand);
+
+        const neitherPending = bandSpansForMiddleGap(leftBand, rightBand, false, false, false);
+        expect(neitherPending.left).toBe(leftBand);
+        expect(neitherPending.right).toBe(rightBand);
+    });
+
+    it("extends the left band across the gap to the right band's start when only the left side is pending", () => {
+        const result = bandSpansForMiddleGap(leftBand, rightBand, true, true, false);
+        expect(result.left).toEqual({ x0: 426, curveX0: 508, curveX1: 536, x1: 1042 });
+        expect(result.right).toBe(rightBand);
+        // The function must not mutate its inputs.
+        expect(leftBand).toEqual({ x0: 426, curveX0: 508, curveX1: 536, x1: 572 });
+    });
+
+    it("extends the right band across the gap to the left band's end when only the right side is pending", () => {
+        const result = bandSpansForMiddleGap(leftBand, rightBand, true, false, true);
+        expect(result.right).toEqual({ x0: 572, curveX0: 1042, curveX1: 1070, x1: 1151 });
+        expect(result.left).toBe(leftBand);
+        expect(rightBand).toEqual({ x0: 1042, curveX0: 1042, curveX1: 1070, x1: 1151 });
+    });
+
+    it("extends only the left band when both sides are pending, so translucent fills do not double-paint the gap", () => {
+        const result = bandSpansForMiddleGap(leftBand, rightBand, true, true, true);
+        expect(result.left).toEqual({ x0: 426, curveX0: 508, curveX1: 536, x1: 1042 });
+        expect(result.right).toBe(rightBand);
+    });
+
+    it("leaves both bands unchanged when neither side is pending, even with an empty middle", () => {
+        const result = bandSpansForMiddleGap(leftBand, rightBand, true, false, false);
+        expect(result.left).toBe(leftBand);
+        expect(result.right).toBe(rightBand);
     });
 });

--- a/tests/unit/merge/mergeScrollLayout.test.ts
+++ b/tests/unit/merge/mergeScrollLayout.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
     buildVerticalLayout,
     paneOffsetForCanonical,
+    ribbonPathD,
     type MergePane,
     type SegmentPaneLines,
 } from "../../../src/webviews/react/merge-editor/mergeScrollLayout";
@@ -101,15 +102,9 @@ describe("paneOffsetForCanonical", () => {
         const viewport = 200;
         const conflictIndex = 1;
         const conflictTop = largeLayout.canonicalTopPx[conflictIndex];
-        const conflictBottom =
-            conflictTop + largeLayout.canonicalHPx[conflictIndex];
+        const conflictBottom = conflictTop + largeLayout.canonicalHPx[conflictIndex];
         const visibleExtent = (pane: MergePane, canonicalScroll: number) => {
-            const offset = paneOffsetForCanonical(
-                largeLayout,
-                pane,
-                canonicalScroll,
-                viewport,
-            );
+            const offset = paneOffsetForCanonical(largeLayout, pane, canonicalScroll, viewport);
             const top = largeLayout.paneTopPx[pane][conflictIndex] - offset;
             return { top, bottom: top + largeLayout.paneHPx[pane][conflictIndex] };
         };
@@ -126,5 +121,47 @@ describe("paneOffsetForCanonical", () => {
         expect(visibleExtent("left", conflictBottom).bottom).toBe(0);
         expect(visibleExtent("middle", conflictBottom).bottom).toBe(0);
         expect(visibleExtent("right", conflictBottom).bottom).toBe(0);
+    });
+});
+
+// Connector ribbon geometry: both long edges are cubic Béziers with horizontal
+// end tangents and control points at 30% / 70% of the horizontal span
+// (IntelliJ's curve-trapezium contract), so a ribbon leaves and meets the
+// rectangular pane bands without a kink. Expected strings are hand-computed
+// from that contract, not read back from the implementation.
+// Not exercised: x1 < x0 and non-finite inputs — gutter measurement always
+// yields a finite left-to-right span, and offscreen culling happens upstream.
+describe("ribbonPathD", () => {
+    it("emits flat-tangent cubic edges with control points at 30% and 70% of the span", () => {
+        // span 100..200 → controls at x=130 and x=170; each control keeps its
+        // endpoint's y (flat tangents), bottom edge runs right-to-left.
+        expect(ribbonPathD(100, 200, 10, 50, 30, 90)).toBe(
+            "M 100,10 C 130,10 170,30 200,30 L 200,90 C 170,90 130,50 100,50 Z",
+        );
+    });
+
+    it("degenerates to straight horizontal edges when both sides align", () => {
+        expect(ribbonPathD(100, 200, 10, 50, 10, 50)).toBe(
+            "M 100,10 C 130,10 170,10 200,10 L 200,50 C 170,50 130,50 100,50 Z",
+        );
+    });
+
+    it("preserves fractional offsets so ribbons track sub-pixel pane positions", () => {
+        expect(ribbonPathD(100, 200, 10.5, 50.25, 30.75, 90.5)).toBe(
+            "M 100,10.5 C 130,10.5 170,30.75 200,30.75 L 200,90.5 C 170,90.5 130,50.25 100,50.25 Z",
+        );
+    });
+
+    it("collapses to a curved wedge when the far side has zero height", () => {
+        // bTop == bBot: an insertion pointing at a line between rows.
+        expect(ribbonPathD(0, 10, 20, 60, 40, 40)).toBe(
+            "M 0,20 C 3,20 7,40 10,40 L 10,40 C 7,40 3,60 0,60 Z",
+        );
+    });
+
+    it("handles negative coordinates for hunks scrolled above the viewport", () => {
+        expect(ribbonPathD(0, 10, -30, -10, -20, 0)).toBe(
+            "M 0,-30 C 3,-30 7,-20 10,-20 L 10,0 C 7,0 3,-10 0,-10 Z",
+        );
     });
 });

--- a/tests/unit/merge/mergeScrollLayout.test.ts
+++ b/tests/unit/merge/mergeScrollLayout.test.ts
@@ -124,44 +124,71 @@ describe("paneOffsetForCanonical", () => {
     });
 });
 
-// Connector ribbon geometry: both long edges are cubic Béziers with horizontal
-// end tangents and control points at 30% / 70% of the horizontal span
-// (IntelliJ's curve-trapezium contract), so a ribbon leaves and meets the
-// rectangular pane bands without a kink. Expected strings are hand-computed
-// from that contract, not read back from the implementation.
-// Not exercised: x1 < x0 and non-finite inputs — gutter measurement always
-// yields a finite left-to-right span, and offscreen culling happens upstream.
+// Connector ribbon geometry, PyCharm's divider anatomy: the band stays a flat
+// rectangle under the near gutter (x0..curveX0) and the far gutter
+// (curveX1..x1); ONLY the divider strip (curveX0..curveX1) curves, using cubic
+// Béziers with horizontal end tangents and control points at 30% / 70% of the
+// strip (IntelliJ's curve-trapezium contract). Expected strings are
+// hand-computed from that contract, not read back from the implementation.
+// Not exercised: reversed spans and non-finite inputs — gutter measurement
+// always yields finite left-to-right x's, and offscreen culling happens
+// upstream.
 describe("ribbonPathD", () => {
-    it("emits flat-tangent cubic edges with control points at 30% and 70% of the span", () => {
-        // span 100..200 → controls at x=130 and x=170; each control keeps its
-        // endpoint's y (flat tangents), bottom edge runs right-to-left.
-        expect(ribbonPathD(100, 200, 10, 50, 30, 90)).toBe(
-            "M 100,10 C 130,10 170,30 200,30 L 200,90 C 170,90 130,50 100,50 Z",
+    // Strip 140..170 (width 30) → controls at x=149 and x=161.
+    const SPAN = { x0: 100, curveX0: 140, curveX1: 170, x1: 200 };
+
+    it("keeps gutter bands rectangular and curves only across the divider strip", () => {
+        expect(ribbonPathD(SPAN, 10, 50, 30, 90)).toBe(
+            "M 100,10 L 140,10 C 149,10 161,30 170,30 L 200,30" +
+                " L 200,90 L 170,90 C 161,90 149,50 140,50 L 100,50 Z",
         );
     });
 
     it("degenerates to straight horizontal edges when both sides align", () => {
-        expect(ribbonPathD(100, 200, 10, 50, 10, 50)).toBe(
-            "M 100,10 C 130,10 170,10 200,10 L 200,50 C 170,50 130,50 100,50 Z",
+        expect(ribbonPathD(SPAN, 10, 50, 10, 50)).toBe(
+            "M 100,10 L 140,10 C 149,10 161,10 170,10 L 200,10" +
+                " L 200,50 L 170,50 C 161,50 149,50 140,50 L 100,50 Z",
         );
     });
 
     it("preserves fractional offsets so ribbons track sub-pixel pane positions", () => {
-        expect(ribbonPathD(100, 200, 10.5, 50.25, 30.75, 90.5)).toBe(
-            "M 100,10.5 C 130,10.5 170,30.75 200,30.75 L 200,90.5 C 170,90.5 130,50.25 100,50.25 Z",
+        expect(ribbonPathD(SPAN, 10.5, 50.25, 30.75, 90.5)).toBe(
+            "M 100,10.5 L 140,10.5 C 149,10.5 161,30.75 170,30.75 L 200,30.75" +
+                " L 200,90.5 L 170,90.5 C 161,90.5 149,50.25 140,50.25 L 100,50.25 Z",
         );
     });
 
     it("collapses to a curved wedge when the far side has zero height", () => {
-        // bTop == bBot: an insertion pointing at a line between rows.
-        expect(ribbonPathD(0, 10, 20, 60, 40, 40)).toBe(
-            "M 0,20 C 3,20 7,40 10,40 L 10,40 C 7,40 3,60 0,60 Z",
+        // bTop == bBot: an insertion pointing at a line between rows. Strip
+        // 10..20 (width 10) → controls at x=13 and x=17.
+        expect(ribbonPathD({ x0: 0, curveX0: 10, curveX1: 20, x1: 30 }, 20, 60, 40, 40)).toBe(
+            "M 0,20 L 10,20 C 13,20 17,40 20,40 L 30,40" +
+                " L 30,40 L 20,40 C 17,40 13,60 10,60 L 0,60 Z",
         );
     });
 
     it("handles negative coordinates for hunks scrolled above the viewport", () => {
-        expect(ribbonPathD(0, 10, -30, -10, -20, 0)).toBe(
-            "M 0,-30 C 3,-30 7,-20 10,-20 L 10,0 C 7,0 3,-10 0,-10 Z",
+        expect(ribbonPathD({ x0: 0, curveX0: 10, curveX1: 20, x1: 30 }, -30, -10, -20, 0)).toBe(
+            "M 0,-30 L 10,-30 C 13,-30 17,-20 20,-20 L 30,-20" +
+                " L 30,0 L 20,0 C 17,0 13,-10 10,-10 L 0,-10 Z",
+        );
+    });
+
+    it("degenerates to a vertical seam when the divider strip has zero width", () => {
+        // curveX0 == curveX1: all curve x's collapse onto the shared edge, so
+        // the "curve" is a vertical joint between the two flat bands.
+        expect(ribbonPathD({ x0: 100, curveX0: 150, curveX1: 150, x1: 200 }, 10, 50, 30, 90)).toBe(
+            "M 100,10 L 150,10 C 150,10 150,30 150,30 L 200,30" +
+                " L 200,90 L 150,90 C 150,90 150,50 150,50 L 100,50 Z",
+        );
+    });
+
+    it("supports zero-width gutter bands, reducing to a pure divider curve", () => {
+        // A side with no gutter (e.g. the result pane's trailing edge) sets
+        // x0 == curveX0; the flat segment degenerates to a zero-length line.
+        expect(ribbonPathD({ x0: 100, curveX0: 100, curveX1: 200, x1: 200 }, 10, 50, 30, 90)).toBe(
+            "M 100,10 L 100,10 C 130,10 170,30 200,30 L 200,30" +
+                " L 200,90 L 200,90 C 170,90 130,50 100,50 L 100,50 Z",
         );
     });
 });

--- a/tests/unit/merge/mergeScrollLayout.test.ts
+++ b/tests/unit/merge/mergeScrollLayout.test.ts
@@ -194,57 +194,65 @@ describe("ribbonPathD", () => {
     });
 });
 
-// Resolved-hunk contour, PyCharm's "settled" rendering: an unfilled dotted
-// outline tracing the source block, the divider curve, and the result extent.
-// The path is three subpaths — top edge, bottom edge, and one vertical closure
-// on the resolved side's outer pane edge (inset 0.5px so a 1px stroke is not
-// clipped at the pane boundary) — with NO closing Z, so stroking it never
-// draws vertical seams at the divider joints. Here the span's x0/x1 are pane
-// OUTER edges (not gutter starts); the curve zone stays the divider strip and
-// uses the same 30% / 70% control-point contract as the filled ribbon.
+// Resolved-hunk contour, PyCharm's "settled" rendering: two closed dotted
+// rectangles — one around the source block in its own pane, one around the
+// result slice — linked by an open curve pair across the divider zone. The
+// span's x0..curveX0 is the a-block's pane content, curveX1..x1 the b-block's;
+// outer verticals are inset 0.5px so a 1px stroke is not clipped at pane
+// boundaries. The curves reuse the 30% / 70% control-point contract of the
+// filled ribbon. No edge crosses a pane it does not belong to.
 describe("ribbonOutlineD", () => {
     // Strip 140..170 (width 30) → controls at x=149 and x=161.
     const SPAN = { x0: 0, curveX0: 140, curveX1: 170, x1: 300 };
 
-    it("traces open top/bottom edges and closes on the a-side pane edge", () => {
-        expect(ribbonOutlineD(SPAN, 10, 50, 30, 90, "a")).toBe(
-            "M 0,10 L 140,10 C 149,10 161,30 170,30 L 300,30" +
-                " M 0,50 L 140,50 C 149,50 161,90 170,90 L 300,90" +
-                " M 0.5,10 L 0.5,50",
+    it("draws two closed block rectangles linked by open divider curves", () => {
+        expect(ribbonOutlineD(SPAN, 10, 50, 30, 90)).toBe(
+            "M 0.5,10 L 140,10 L 140,50 L 0.5,50 Z" +
+                " M 140,10 C 149,10 161,30 170,30" +
+                " M 140,50 C 149,50 161,90 170,90" +
+                " M 170,30 L 299.5,30 L 299.5,90 L 170,90 Z",
         );
     });
 
-    it("closes on the b-side pane edge for right-pane resolutions", () => {
-        expect(ribbonOutlineD(SPAN, 10, 50, 30, 90, "b")).toBe(
-            "M 0,10 L 140,10 C 149,10 161,30 170,30 L 300,30" +
-                " M 0,50 L 140,50 C 149,50 161,90 170,90 L 300,90" +
-                " M 299.5,30 L 299.5,90",
+    it("links the rectangles with straight rails when both blocks align", () => {
+        expect(ribbonOutlineD(SPAN, 10, 50, 10, 50)).toBe(
+            "M 0.5,10 L 140,10 L 140,50 L 0.5,50 Z" +
+                " M 140,10 C 149,10 161,10 170,10" +
+                " M 140,50 C 149,50 161,50 170,50" +
+                " M 170,10 L 299.5,10 L 299.5,50 L 170,50 Z",
         );
     });
 
-    it("degenerates to straight dotted rails when both sides align", () => {
-        expect(ribbonOutlineD(SPAN, 10, 50, 10, 50, "a")).toBe(
-            "M 0,10 L 140,10 C 149,10 161,10 170,10 L 300,10" +
-                " M 0,50 L 140,50 C 149,50 161,50 170,50 L 300,50" +
-                " M 0.5,10 L 0.5,50",
-        );
-    });
-
-    it("collapses both edges onto one curve when the target has zero height", () => {
-        // bTop == bBot (a wedge to an insertion point): the closure on side b
-        // is a zero-length vertical at the shared y.
-        expect(ribbonOutlineD(SPAN, 20, 60, 40, 40, "b")).toBe(
-            "M 0,20 L 140,20 C 149,20 161,40 170,40 L 300,40" +
-                " M 0,60 L 140,60 C 149,60 161,40 170,40 L 300,40" +
-                " M 299.5,40 L 299.5,40",
+    it("collapses a zero-height target to a flat line rectangle", () => {
+        // bTop == bBot (a wedge to an insertion point): both curves converge
+        // on the shared y and the b-rectangle degenerates to a dotted line.
+        expect(ribbonOutlineD(SPAN, 20, 60, 40, 40)).toBe(
+            "M 0.5,20 L 140,20 L 140,60 L 0.5,60 Z" +
+                " M 140,20 C 149,20 161,40 170,40" +
+                " M 140,60 C 149,60 161,40 170,40" +
+                " M 170,40 L 299.5,40 L 299.5,40 L 170,40 Z",
         );
     });
 
     it("handles negative coordinates for hunks scrolled above the viewport", () => {
-        expect(ribbonOutlineD(SPAN, -30, -10, -20, 0, "a")).toBe(
-            "M 0,-30 L 140,-30 C 149,-30 161,-20 170,-20 L 300,-20" +
-                " M 0,-10 L 140,-10 C 149,-10 161,0 170,0 L 300,0" +
-                " M 0.5,-30 L 0.5,-10",
+        expect(ribbonOutlineD(SPAN, -30, -10, -20, 0)).toBe(
+            "M 0.5,-30 L 140,-30 L 140,-10 L 0.5,-10 Z" +
+                " M 140,-30 C 149,-30 161,-20 170,-20" +
+                " M 140,-10 C 149,-10 161,0 170,0" +
+                " M 170,-20 L 299.5,-20 L 299.5,0 L 170,0 Z",
+        );
+    });
+
+    it("degenerates to a vertical joint when the curve zone has zero width", () => {
+        // curveX0 == curveX1: the connector collapses onto the shared edge and
+        // the two rectangles simply touch it.
+        expect(
+            ribbonOutlineD({ x0: 100, curveX0: 150, curveX1: 150, x1: 200 }, 10, 50, 30, 90),
+        ).toBe(
+            "M 100.5,10 L 150,10 L 150,50 L 100.5,50 Z" +
+                " M 150,10 C 150,10 150,30 150,30" +
+                " M 150,50 C 150,50 150,90 150,90" +
+                " M 150,30 L 199.5,30 L 199.5,90 L 150,90 Z",
         );
     });
 });


### PR DESCRIPTION
## Summary

- Aligns merge-editor conflict colors, empty-middle-line handling, and one-sided hunk connectors with PyCharm.
- Refines ribbon geometry and gutter measurement for smooth connector rendering during scrolling.
- Adds preview coverage for one-sided merge hunks.

## Why

The merge editor now presents conflicts, resolved hunks, and connector ribbons with closer PyCharm visual parity.

## Validation

- Preview fixture updates are included with the visual rendering changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated merge-editor connectors and conflict ribbons with clearer PyCharm-style visuals.
  - Improved handling of one-sided changes, empty result sections, and settled or dismissed conflicts.
  - Added smoother ribbon continuity across the editor and improved scrolling behavior.

- **Bug Fixes**
  - Corrected connector alignment, gutter spacing, conflict colors, and resolved-state rendering.

- **Documentation**
  - Released version 0.18.0 with updated changelog details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->