### PR TITLE
chore(coderabbit): exclude the README gallery screenshots from review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,6 +42,12 @@ reviews:
         # gate into a no-op that certifies whatever the first run rendered.
         # They still cannot be reviewed: 32 binary PNGs carrying no text.
         - "!tests/visual/__screenshots__/**"
+        # The README gallery, for the same reason: 9 binary PNGs plus the
+        # marketplace icon. Nothing under `media/screenshots` is text, so the
+        # slots they occupy were being spent on a reviewer that cannot open
+        # them. Kept separate from the baselines above because these change for
+        # documentation reasons rather than as visual-suite output.
+        - "!media/screenshots/**"
         # DOM and host-wiring tests: breakage shows up as a red suite, not as a
         # silently-passing test, so an extra reviewer buys the least here.
         - "!tests/webview/**"


### PR DESCRIPTION
## What

Adds `media/screenshots/**` to the `path_filters` exclusion list in `.coderabbit.yaml`.

## Why

CodeRabbit reviews at most 100 changed files per PR — past that it reviews **nothing at all**. There is no setting for the cap; `path_filters` is the only lever, and CodeRabbit applies it as a sparse-checkout so excluded files are never fetched.

`tests/visual/__screenshots__/**` was already excluded when the visual-testing branch crossed the cap. `media/screenshots/**` is the same kind of content for the same reason: nine binary PNGs with no text for a reviewer to have an opinion about, occupying nine of the hundred slots.

Kept as its own pattern rather than folded into the baselines line above, because the two change for different reasons — the baselines move as visual-suite output, these move when the README gallery is updated — and a future reader deciding what to cut next needs to be able to tell them apart.

## Verification

Verified by matching the glob patterns against the tracked file list (`git ls-files`) on both `main` and the visual-testing branch, rather than by reading the globs:

- 9/9 files under `media/screenshots` excluded
- 32/32 files under `tests/visual/__screenshots__` excluded
- `media/intelligit-icon.png` is the one binary asset still reviewed — a single file outside either screenshots directory, deliberately left alone

Side effect worth recording: PR #161 changes 130 files, of which **91** now survive the filters. That is under the cap, so the cap is no longer what stops CodeRabbit reviewing it.

## Test plan

- [x] Patterns matched against `git ls-files` on two branches (see above)
- [ ] Confirm on the next large PR that CodeRabbit posts a review rather than skipping

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the README gallery screenshot directory to CodeRabbit’s review exclusions so binary images do not consume its changed-file limit.
- Excludes `media/screenshots/**` from automated review.
- Preserves review coverage for assets outside that directory, including `media/intelligit-icon.png`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new filter is narrowly scoped to the intended screenshot directory.

The added pattern follows the existing exclusion syntax and matches only the binary PNG gallery assets described by the PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .coderabbit.yaml | Adds a narrowly scoped exclusion matching the nine binary gallery screenshots without excluding other media assets. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(coderabbit): exclude the README ga..."](https://github.com/maheshkok/intelligit/commit/9b84aca4801f992d7fcd99165c5e0c531c6c53ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53598525)</sub>

<!-- /greptile_comment -->