### PR TITLE
fix: stop re-posting an unchanged commit detail to the webview (v0.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-08-15
+
+### Fixed
+
+- Selecting a commit posted its detail to the webview twice: once raw, then again unconditionally once asynchronous icon-theme decoration settled. With no icon resolver attached, or whenever decoration changed nothing, that second message was byte-identical to the first and the pane re-rendered for nothing. The follow-up post is now sent only when the fully-built outgoing payload actually differs. The comparison is deliberately made on the payload rather than on the decoration result, because awaiting the icon theme can populate folder-icon and icon-font data for the first time between the two posts, and a guard keyed on "did decoration change the commit detail" would have silently dropped that legitimately new data. The first post to a given webview is always sent, so a restored view can never render empty.
+
 ## [0.25.0] - 2026-08-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/reviewPromptHost";
 import { getErrorMessage } from "../utils/errors";
 import { IconThemeService } from "./shared/IconThemeService";
+import { isRedundantPost, serializeWebviewPayload } from "./shared/postedPayload";
 import { registerThemeChangeListeners, disposeAll } from "./shared/themeListeners";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { assertRepoRelativePath } from "../utils/fileOps";
@@ -87,6 +88,11 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
     private folderIconsByName: ThemeFolderIconMap = {};
     private branchFolderIconsByName: ThemeFolderIconMap = {};
     private commitDetailSeq = 0;
+    /** Serialized form of the last `setCommitDetail` payload actually posted to the CURRENT
+     * webview -- see `shared/postedPayload.ts`. Reset to `undefined` whenever a fresh webview is
+     * resolved or the commit-detail cache is cleared, so a redundant-looking repost after either
+     * is never wrongly suppressed. */
+    private lastPostedPayload: string | undefined;
     private reviewPromptSeq = 0;
     /** The single outstanding review card, if one is on screen; answers from any other ID are stale. */
     private pendingReviewPrompt?: {
@@ -232,6 +238,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
         this.disposeThemeChangeDisposables();
         this.iconTheme.dispose();
         this.view = webviewView;
+        this.lastPostedPayload = undefined;
         this.applyRepositoryDescription();
 
         webviewView.webview.options = {
@@ -277,6 +284,12 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
                         await this.iconTheme.initIconThemeData();
                         await this.sendBranches();
                         await this.loadInitial();
+                        // A fresh webview context has received nothing, so the re-post below
+                        // must never be suppressed as a duplicate of what the PREVIOUS context
+                        // was sent. `ready` fires again whenever VS Code tears this view down
+                        // while it is hidden and reloads it on show -- `resolveWebviewView` does
+                        // NOT re-run then, so its reset alone would leave the pane empty.
+                        this.lastPostedPayload = undefined;
                         this.postCommitDetailState();
                         break;
                     case "selectCommit":
@@ -485,6 +498,7 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
         this.selectedCommitDetail = null;
         this.commitDetailLoading = options?.loading ?? false;
         this.folderIconsByName = {};
+        this.lastPostedPayload = undefined;
         this.postCommitDetailState();
     }
 
@@ -919,16 +933,23 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
     private postCommitDetailState(): void {
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         if (this.selectedCommitDetail) {
-            this.postToWebview({
+            const payload: CommitGraphInbound = {
                 type: "setCommitDetail",
                 detail: this.selectedCommitDetail,
                 folderIcon: folderIcons.folderIcon,
                 folderExpandedIcon: folderIcons.folderExpandedIcon,
                 folderIconsByName: this.folderIconsByName,
                 iconFonts,
-            });
+            };
+            const serialized = serializeWebviewPayload(payload);
+            if (isRedundantPost(serialized, this.lastPostedPayload)) return;
+            // Recorded only after the post is handed over, so a payload that was never sent
+            // cannot suppress the next identical one.
+            this.postToWebview(payload);
+            this.lastPostedPayload = serialized;
             return;
         }
+        this.lastPostedPayload = undefined;
         this.postToWebview(
             this.commitDetailLoading
                 ? { type: "clearCommitDetail", loading: true }

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -277,6 +277,20 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
             try {
                 switch (msg.type) {
                     case "ready":
+                        // A fresh webview context has received nothing, so any commit-detail
+                        // post made during this handler must never be suppressed as a duplicate
+                        // of what the PREVIOUS context was sent. `ready` fires again whenever VS
+                        // Code tears this view down while it is hidden and reloads it on show --
+                        // `resolveWebviewView` does NOT re-run then, so its reset alone would
+                        // leave the pane empty.
+                        //
+                        // The reset runs before the awaits below, not after them: those awaits
+                        // yield, and a commit selected or refreshed while they run posts against
+                        // this new context. Resetting afterwards would both suppress that post
+                        // (it is compared against the retired context's payload) and then make
+                        // the final `postCommitDetailState()` re-send what the webview already
+                        // has -- reintroducing the duplicate post this guard exists to remove.
+                        this.lastPostedPayload = undefined;
                         this.postToWebview({
                             type: "setViewVisibility",
                             visible: webviewView.visible,
@@ -284,12 +298,6 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
                         await this.iconTheme.initIconThemeData();
                         await this.sendBranches();
                         await this.loadInitial();
-                        // A fresh webview context has received nothing, so the re-post below
-                        // must never be suppressed as a duplicate of what the PREVIOUS context
-                        // was sent. `ready` fires again whenever VS Code tears this view down
-                        // while it is hidden and reloads it on show -- `resolveWebviewView` does
-                        // NOT re-run then, so its reset alone would leave the pane empty.
-                        this.lastPostedPayload = undefined;
                         this.postCommitDetailState();
                         break;
                     case "selectCommit":

--- a/src/views/CommitInfoViewProvider.ts
+++ b/src/views/CommitInfoViewProvider.ts
@@ -72,18 +72,26 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         webviewView.webview.onDidReceiveMessage(async (msg: CommitInfoOutbound) => {
             switch (msg.type) {
                 case "ready":
+                    // A fresh webview context has received nothing, so any commit-detail post
+                    // made during this handler must never be suppressed as a duplicate of what
+                    // the PREVIOUS context was sent. `ready` fires again whenever VS Code tears
+                    // this view down while it is hidden and reloads it on show --
+                    // `resolveWebviewView` does NOT re-run in that case, so its reset alone
+                    // would leave the restored pane empty.
+                    //
+                    // The reset runs before the await below, not after it: that await yields,
+                    // and a commit selected or refreshed while it runs posts against this new
+                    // context. Resetting afterwards would both suppress that post (it is
+                    // compared against the retired context's payload) and then make the
+                    // following `postCurrentState()` re-send what the webview already has --
+                    // reintroducing the duplicate post this guard exists to remove.
+                    this.lastPostedPayload = undefined;
                     try {
                         await this.iconTheme.initIconThemeData();
                     } catch (err) {
                         console.error("[IntelliGit] Failed to initialize icon theme data:", err);
                     }
                     this.ready = true;
-                    // A fresh webview context has received nothing, so the re-post below must
-                    // never be suppressed as a duplicate of what the PREVIOUS context was sent.
-                    // `ready` fires again whenever VS Code tears this view down while it is
-                    // hidden and reloads it on show -- `resolveWebviewView` does NOT re-run in
-                    // that case, so its reset alone would leave the restored pane empty.
-                    this.lastPostedPayload = undefined;
                     this.postCurrentState();
                     break;
                 case "openCommitFileDiff":

--- a/src/views/CommitInfoViewProvider.ts
+++ b/src/views/CommitInfoViewProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import type { CommitDetail, ThemeFolderIconMap } from "../types";
 import type { CommitInfoInbound, CommitInfoOutbound } from "../webviews/protocol/commitInfoTypes";
 import { IconThemeService } from "./shared/IconThemeService";
+import { isRedundantPost, serializeWebviewPayload } from "./shared/postedPayload";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
 import { assertRepoRelativePath } from "../utils/fileOps";
@@ -23,6 +24,11 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
     private ready = false;
     private folderIconsByName: ThemeFolderIconMap = {};
     private requestSeq = 0;
+    /** Serialized form of the last `setCommitDetail` payload actually posted to the CURRENT
+     * webview -- see `shared/postedPayload.ts`. Reset to `undefined` whenever a fresh webview is
+     * resolved or the cache is cleared, so a redundant-looking repost after either is never
+     * wrongly suppressed. */
+    private lastPostedPayload: string | undefined;
     private readonly iconTheme: IconThemeService;
     private readonly _onOpenCommitFileDiff = new vscode.EventEmitter<{
         commitHash: string;
@@ -55,6 +61,7 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         this.iconTheme.dispose();
         this.view = webviewView;
         this.ready = false;
+        this.lastPostedPayload = undefined;
 
         webviewView.webview.options = {
             enableScripts: true,
@@ -71,6 +78,12 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
                         console.error("[IntelliGit] Failed to initialize icon theme data:", err);
                     }
                     this.ready = true;
+                    // A fresh webview context has received nothing, so the re-post below must
+                    // never be suppressed as a duplicate of what the PREVIOUS context was sent.
+                    // `ready` fires again whenever VS Code tears this view down while it is
+                    // hidden and reloads it on show -- `resolveWebviewView` does NOT re-run in
+                    // that case, so its reset alone would leave the restored pane empty.
+                    this.lastPostedPayload = undefined;
                     this.postCurrentState();
                     break;
                 case "openCommitFileDiff":
@@ -135,6 +148,7 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         this.detail = undefined;
         this.loading = options?.loading ?? false;
         this.folderIconsByName = {};
+        this.lastPostedPayload = undefined;
         if (this.ready) {
             this.postToWebview(this.loading ? { type: "clear", loading: true } : { type: "clear" });
         }
@@ -150,17 +164,24 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         if (!this.ready) return;
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         if (!this.detail) {
+            this.lastPostedPayload = undefined;
             this.postToWebview(this.loading ? { type: "clear", loading: true } : { type: "clear" });
             return;
         }
-        this.postToWebview({
+        const payload: CommitInfoInbound = {
             type: "setCommitDetail",
             detail: this.detail,
             folderIcon: folderIcons.folderIcon,
             folderExpandedIcon: folderIcons.folderExpandedIcon,
             folderIconsByName: this.folderIconsByName,
             iconFonts,
-        });
+        };
+        const serialized = serializeWebviewPayload(payload);
+        if (isRedundantPost(serialized, this.lastPostedPayload)) return;
+        // Recorded only after the post is handed over, so a payload that was never sent
+        // cannot suppress the next identical one.
+        this.postToWebview(payload);
+        this.lastPostedPayload = serialized;
     }
 
     private postToWebview(msg: CommitInfoInbound): void {

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -36,6 +36,7 @@ import type {
 import type { RebaseSubmissionEntry } from "../git/interactiveRebase/types";
 import { isBranchAction, isCommitAction } from "../webviews/protocol/commitGraphTypes";
 import { IconThemeService } from "./shared/IconThemeService";
+import { isRedundantPost, serializeWebviewPayload } from "./shared/postedPayload";
 import { registerThemeChangeListeners, disposeAll } from "./shared/themeListeners";
 import {
     assertGitHash,
@@ -126,6 +127,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private commitDetailFolderIconsByName: ThemeFolderIconMap = {};
     private branchFolderIconsByName: ThemeFolderIconMap = {};
     private commitDetailSeq = 0;
+    /** Serialized form of the last `setCommitDetail` payload actually posted to the CURRENT
+     * webview -- see `shared/postedPayload.ts`. Reset to `undefined` whenever a fresh webview is
+     * resolved or the commit-detail cache is cleared, so a redundant-looking repost after either
+     * is never wrongly suppressed. */
+    private lastPostedPayload: string | undefined;
     private readonly _onDidChangeFileCount = new vscode.EventEmitter<number>();
     readonly onDidChangeFileCount = this._onDidChangeFileCount.event;
     private readonly _onDidChangeWorkingTree = new vscode.EventEmitter<void>();
@@ -1034,6 +1040,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.selectedCommitDetail = null;
         this.commitDetailLoading = options?.loading ?? false;
         this.commitDetailFolderIconsByName = {};
+        this.lastPostedPayload = undefined;
         this.postToWebview(
             this.commitDetailLoading
                 ? { type: "clearCommitDetail", loading: true }
@@ -1055,6 +1062,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.disposeThemeChangeDisposables();
         this.iconTheme.dispose();
         this.view = webviewView;
+        this.lastPostedPayload = undefined;
         webviewView.webview.options = {
             enableScripts: true,
             localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, "dist")],
@@ -1430,6 +1438,12 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     }
     /** Hydrates the active repository and restores its persisted commit draft after webview readiness. */
     private async handleReadyMessage(): Promise<void> {
+        // A fresh webview context has received nothing, so any commit-detail post made during
+        // this handler must never be suppressed as a duplicate of what the PREVIOUS context was
+        // sent. `ready` fires again whenever VS Code tears this view down while it is hidden and
+        // reloads it on show -- `resolveWebviewView` does NOT re-run then, so its reset alone
+        // would leave the restored changed-files pane empty.
+        this.lastPostedPayload = undefined;
         const runtime = this.getActiveRuntime();
         this.postRepositoryListHydration();
         if (runtime) {
@@ -1958,16 +1972,23 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private postGraphCommitDetailState(): void {
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         if (this.selectedCommitDetail) {
-            this.postToWebview({
+            const payload: CommitGraphInbound = {
                 type: "setCommitDetail",
                 detail: this.selectedCommitDetail,
                 folderIcon: folderIcons.folderIcon,
                 folderExpandedIcon: folderIcons.folderExpandedIcon,
                 folderIconsByName: this.commitDetailFolderIconsByName,
                 iconFonts,
-            });
+            };
+            const serialized = serializeWebviewPayload(payload);
+            if (isRedundantPost(serialized, this.lastPostedPayload)) return;
+            // Recorded only after the post is handed over, so a payload that was never sent
+            // cannot suppress the next identical one.
+            this.postToWebview(payload);
+            this.lastPostedPayload = serialized;
             return;
         }
+        this.lastPostedPayload = undefined;
         this.postToWebview(
             this.commitDetailLoading
                 ? { type: "clearCommitDetail", loading: true }

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -929,6 +929,19 @@ export class UndockedViewProvider {
                 break;
             // Graph-side
             case "ready":
+                // A fresh webview context has received nothing, so any commit-detail post made
+                // during this handler must never be suppressed as a duplicate of what the
+                // PREVIOUS context was sent. This panel sets retainContextWhenHidden, but
+                // `ready` still fires again on a window reload, when `open()`'s create-panel
+                // reset does NOT run.
+                //
+                // The reset runs before the awaits below, not after them: those awaits yield,
+                // and a commit selected or refreshed while they run posts against this new
+                // context. Resetting afterwards would both suppress that post (it is compared
+                // against the retired context's payload) and then make the following
+                // `postCommitDetailState()` re-send what the webview already has --
+                // reintroducing the duplicate post this guard exists to remove.
+                this.lastPostedPayload = undefined;
                 this.postToWebview({
                     type: "setViewVisibility",
                     visible: this.panel?.visible ?? false,
@@ -942,11 +955,6 @@ export class UndockedViewProvider {
                 await this.iconTheme.initIconThemeData();
                 await this.sendBranches();
                 await this.loadInitial();
-                // A fresh webview context has received nothing, so the re-post below must never
-                // be suppressed as a duplicate of what the PREVIOUS context was sent. This panel
-                // sets retainContextWhenHidden, but `ready` still fires again on a window reload,
-                // when `open()`'s create-panel reset does NOT run.
-                this.lastPostedPayload = undefined;
                 this.postCommitDetailState();
                 await this.refreshCommitPanelData();
                 this.postToWebview({

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -13,6 +13,7 @@ import { showCommitMessageGenerationNotification } from "../ai/commitMessageGene
 import type { ShelfService } from "../services/shelfService";
 import type { ShelfEntry, ShelfHealthWarning } from "../webviews/protocol/commitPanelMessages";
 import { IconThemeService } from "./shared/IconThemeService";
+import { isRedundantPost, serializeWebviewPayload } from "./shared/postedPayload";
 import { operationSnapshotForRepository } from "./commitPanelOperationSnapshot";
 import { registerThemeChangeListeners, disposeAll } from "./shared/themeListeners";
 import { buildWebviewShellHtml } from "./webviewHtml";
@@ -213,6 +214,12 @@ export class UndockedViewProvider {
     private folderIconsByName: ThemeFolderIconMap = {};
     private branchFolderIconsByName: ThemeFolderIconMap = {};
     private commitDetailSeq = 0;
+    /** Serialized form of the last `setCommitDetail` payload actually posted to the CURRENT
+     * panel webview -- see `shared/postedPayload.ts`. Reset to `undefined` whenever a fresh panel
+     * is created (`open()`'s create-panel branch, never its `reveal()` fast path) or the
+     * commit-detail cache is cleared, so a redundant-looking repost after either is never wrongly
+     * suppressed. */
+    private lastPostedPayload: string | undefined;
     private themeChangeDisposables: vscode.Disposable[] = [];
     // Commit-panel state
     private files: WorkingFile[] = [];
@@ -607,6 +614,7 @@ export class UndockedViewProvider {
         this.selectedCommitDetail = null;
         this.commitDetailLoading = options?.loading ?? false;
         this.folderIconsByName = {};
+        this.lastPostedPayload = undefined;
         this.postToWebview(
             this.commitDetailLoading
                 ? { type: "clearCommitDetail", loading: true }
@@ -677,6 +685,7 @@ export class UndockedViewProvider {
             },
         );
         this.panel = captureWebview(rawPanel, "undocked");
+        this.lastPostedPayload = undefined;
         this.iconTheme.attachWebview(this.panel.webview);
         this.registerThemeChangeListeners();
         this.panel.webview.html = this.getHtml(this.panel.webview);
@@ -933,6 +942,11 @@ export class UndockedViewProvider {
                 await this.iconTheme.initIconThemeData();
                 await this.sendBranches();
                 await this.loadInitial();
+                // A fresh webview context has received nothing, so the re-post below must never
+                // be suppressed as a duplicate of what the PREVIOUS context was sent. This panel
+                // sets retainContextWhenHidden, but `ready` still fires again on a window reload,
+                // when `open()`'s create-panel reset does NOT run.
+                this.lastPostedPayload = undefined;
                 this.postCommitDetailState();
                 await this.refreshCommitPanelData();
                 this.postToWebview({
@@ -1894,16 +1908,23 @@ export class UndockedViewProvider {
     private postCommitDetailState(): void {
         const { folderIcons, iconFonts } = this.iconTheme.getThemeData();
         if (this.selectedCommitDetail) {
-            this.postToWebview({
+            const payload: UnifiedInbound = {
                 type: "setCommitDetail",
                 detail: this.selectedCommitDetail,
                 folderIcon: folderIcons.folderIcon,
                 folderExpandedIcon: folderIcons.folderExpandedIcon,
                 folderIconsByName: this.folderIconsByName,
                 iconFonts,
-            });
+            };
+            const serialized = serializeWebviewPayload(payload);
+            if (isRedundantPost(serialized, this.lastPostedPayload)) return;
+            // Recorded only after the post is handed over, so a payload that was never sent
+            // cannot suppress the next identical one.
+            this.postToWebview(payload);
+            this.lastPostedPayload = serialized;
             return;
         }
+        this.lastPostedPayload = undefined;
         this.postToWebview(
             this.commitDetailLoading
                 ? { type: "clearCommitDetail", loading: true }

--- a/src/views/shared/postedPayload.ts
+++ b/src/views/shared/postedPayload.ts
@@ -1,0 +1,32 @@
+/**
+ * Duplicate-post detection for outgoing webview messages.
+ *
+ * `CommitInfoViewProvider.setCommitDetail` and its three siblings
+ * (`CommitGraphViewProvider.setCommitDetail`, `CommitPanelViewProvider.setCommitDetail`,
+ * `UndockedViewProvider.setCommitDetail`) post a raw commit detail immediately, then post again,
+ * unconditionally, once async icon-theme decoration settles. When no icon resolver is attached, or
+ * decoration otherwise changes nothing, that second post is byte-identical to the first.
+ *
+ * The comparison here is deliberately the fully-built OUTGOING payload, not the commit detail or
+ * the decoration result alone: `IconThemeService.decorateCommitDetailWithFolderIcons` awaits
+ * `initIconThemeData()` before decorating, which can populate `folderIcon` / `folderExpandedIcon` /
+ * `iconFonts` for the first time between the two posts -- those fields come from
+ * `IconThemeService.getThemeData()` at post time, not from the decoration result, so a guard keyed
+ * on "did decoration change the detail" would silently drop that legitimately new theme data.
+ */
+
+/** Serializes an outgoing webview payload for duplicate detection. */
+export function serializeWebviewPayload(payload: unknown): string {
+    return JSON.stringify(payload);
+}
+
+/**
+ * True when this payload is byte-identical to the last one actually posted.
+ * `lastPosted === undefined` means nothing has been posted to the CURRENT
+ * webview, so the payload must always be sent -- otherwise view restoration
+ * renders an empty pane.
+ */
+export function isRedundantPost(serialized: string, lastPosted: string | undefined): boolean {
+    if (lastPosted === undefined) return false;
+    return serialized === lastPosted;
+}

--- a/tests/unit/views/CommitGraphViewProvider.test.ts
+++ b/tests/unit/views/CommitGraphViewProvider.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Provider-level test for the redundant `setCommitDetail` post fix in
+ * `src/views/CommitGraphViewProvider.ts`, pinning the ONE invariant `postCommitDetailState`'s
+ * duplicate-post guard (`lastPostedPayload`, ~line 933) cannot see on its own: VS Code tears a
+ * hidden `WebviewView`'s context down and reloads it on show. The bundle re-runs and re-announces
+ * itself with a second `ready`, but `resolveWebviewView` -- and the `lastPostedPayload` reset it
+ * performs -- does NOT run again for that reload; only the `ready` handler's OWN reset (~line 292,
+ * immediately before `postCommitDetailState()`) stands between this and a suppressed repost.
+ * Without it, a guard keyed purely on payload equality would treat the restored (but blank)
+ * webview's first `setCommitDetail` as a no-op repeat of what the previous, now-dead context
+ * already received, and the reloaded pane would render with no commit detail at all.
+ *
+ * Modeled directly on `tests/unit/views/CommitInfoViewProvider.test.ts`'s own third `it` block,
+ * which pins the identical invariant for the sibling provider -- same shared duplicate-post guard
+ * (`src/views/shared/postedPayload.ts`), same reload scenario, same shape of proof.
+ *
+ * **Observation seam.** Option (a), not (b): a small LOCAL inspectable `vscode.WebviewView` double
+ * built in this file (`createInspectableFakeCommitGraphWebviewView`), mirroring
+ * `CommitInfoViewProvider.test.ts`'s own `createInspectableFakeWebviewView` rather than
+ * `commitInfoVscodeDouble.ts`'s `createFakeCommitGraphWebviewView` -- that function's `postMessage`
+ * is fixed at `() => Promise.resolve(true)` with no capture hook, so it cannot answer "what was
+ * posted, and how many times". The E2E capture seam (`captureWebviewViewProvider` /
+ * `setE2eControlChannelActive`) the visual recorder uses is a heavier alternative built for
+ * recording canonicalized fixtures across a process-wide sink; a provider-level unit test asserting
+ * directly on posted messages needs neither the sink's global state nor the E2E gate, so this file
+ * does not pull it in.
+ *
+ * **Construction.** Everything else is copied from the recorder that already builds a real
+ * `CommitGraphViewProvider` end to end, `tests/visual/recorder/recordCommitGraphWebviewFixture.ts`:
+ * a real `GitOps` over a real seeded git repository (`loadInitial()`'s `getLog` /
+ * `getUnpushedCommitHashes` calls are never mocked), an inert `CredentialStore` over a
+ * `throwingDouble`-backed `vscode.SecretStorage`, and `buildProviderOptions("card")` -- reused
+ * directly rather than re-typed by hand -- to keep `commitChecksProviders: []`, so the constructor
+ * never builds the four real HTTP-backed commit-check providers (see that function's own doc
+ * comment on the commit-checks trap).
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+// Hoisted above the imports below -- see `recordCommitInfoWebviewFixture.test.ts` (and
+// `CommitInfoViewProvider.test.ts`, which this file otherwise mirrors) for why this must be a
+// plain, non-mocked import ahead of the `vi.mock` call it feeds.
+vi.mock("vscode", () => createCommitInfoVscodeDouble());
+
+import type * as vscode from "vscode";
+import { createFakeExtensionUri } from "../../visual/recorder/commitInfoVscodeDouble";
+import { throwingDouble } from "../../visual/recorder/throwingDouble";
+import { toGitEnvironment } from "../../visual/recorder/recordingGitEnvironment";
+import { buildProviderOptions } from "../../visual/recorder/recordCommitGraphWebviewFixture";
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+import { CredentialStore } from "../../../src/services/commitChecks/credentialStore";
+import { CommitGraphViewProvider } from "../../../src/views/CommitGraphViewProvider";
+import type { CommitDetail } from "../../../src/types";
+import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
+import { createScratchWorkspaces } from "../fixtures/scratchWorkspaces";
+
+/** A resolve-context/token stand-in `resolveWebviewView` never reads -- same reasoning as
+ * `CommitInfoViewProvider.test.ts`'s own `INERT_CONTEXT`/`INERT_TOKEN`. */
+const INERT_CONTEXT = {} as vscode.WebviewViewResolveContext;
+const INERT_TOKEN = {} as vscode.CancellationToken;
+
+/** Resolves once every microtask queued synchronously up to this call has drained -- see
+ * `CommitInfoViewProvider.test.ts`'s own `flushMicrotasks` doc comment for why a single
+ * `setImmediate` tick is sufficient to observe `decorateAndStoreCommitDetail`'s settled effects:
+ * the shared `IconThemeService.decorateCommitDetailWithFolderIcons` call both providers' decoration
+ * paths await has no real timer or I/O wait anywhere in its chain. */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** A `vscode.SecretStorage` double for `CredentialStore` -- every member throws by name (see
+ * `throwingDouble.ts`). `buildProviderOptions("card")` always passes `commitChecksProviders: []`,
+ * so no commit-check provider that could read a stored secret is ever constructed; a throw here
+ * would mean a real secret read happened, which would be a finding, not an expected path. Mirrors
+ * `recordCommitGraphWebviewFixture.ts`'s own `createInertSecretStorage`. */
+function createInertSecretStorage(): vscode.SecretStorage {
+    return throwingDouble<vscode.SecretStorage>("secretStorage", {});
+}
+
+/** A minimal local `vscode.WebviewView` double with an inspectable `posted` array -- see this
+ * file's own doc comment for why this is the chosen observation seam. Same member set
+ * `CommitInfoViewProvider.test.ts`'s own `createInspectableFakeWebviewView` implements, PLUS the
+ * two members `CommitGraphViewProvider.resolveWebviewView` additionally reaches for: `visible`
+ * (read synchronously inside the `ready` handler to post the webview's own initial
+ * `setViewVisibility` message) and `onDidChangeVisibility` (registered unconditionally on every
+ * resolution, to forward real host visibility into the webview) -- see `commitInfoVscodeDouble.ts`'s
+ * own `createFakeCommitGraphWebviewView` doc comment for the same accounting against
+ * `CommitInfoViewProvider`'s smaller member set. */
+function createInspectableFakeCommitGraphWebviewView(): {
+    readonly webviewView: vscode.WebviewView;
+    readonly posted: unknown[];
+    receiveMessage(message: unknown): Promise<void>;
+} {
+    let messageHandler: ((message: unknown) => unknown) | undefined;
+    const posted: unknown[] = [];
+
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        html: "",
+        cspSource: "vscode-webview://fake-commit-graph-provider-test",
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: (listener: (message: unknown) => unknown) => {
+            messageHandler = listener;
+            return { dispose(): void {} };
+        },
+        postMessage: (message: unknown) => {
+            posted.push(message);
+            return Promise.resolve(true);
+        },
+    };
+
+    const webviewView = {
+        webview,
+        visible: true,
+        onDidDispose: () => ({ dispose(): void {} }),
+        onDidChangeVisibility: () => ({ dispose(): void {} }),
+    } as unknown as vscode.WebviewView;
+
+    return {
+        webviewView,
+        posted,
+        receiveMessage: async (message: unknown): Promise<void> => {
+            if (!messageHandler) {
+                throw new Error(
+                    "createInspectableFakeCommitGraphWebviewView.receiveMessage: no message " +
+                        "handler was registered yet -- resolveWebviewView() must run first.",
+                );
+            }
+            await messageHandler(message);
+        },
+    };
+}
+
+/** A well-formed `CommitDetail` -- verbatim from `CommitInfoViewProvider.test.ts`'s own
+ * `sampleDetail()`. Its exact field values are never asserted on here; what matters is that it has
+ * real, decoratable production shape, not a minimal stub. */
+function sampleDetail(): CommitDetail {
+    return {
+        hash: "b08ddf030532f359194329a212f0d9ba54bb6a02",
+        shortHash: "b08ddf03",
+        message: "Add conflict target",
+        body: "",
+        author: "IntelliGit Fixture Repo",
+        email: "intelligit-fixture@example.invalid",
+        date: "2000-01-01T01:00:00Z",
+        parentHashes: ["70fa528600605d9b3f1fce7aa04ec799ed494ffd"],
+        refs: [],
+        files: [{ path: "conflict.txt", status: "A", additions: 3, deletions: 0 }],
+    };
+}
+
+function setDetailMessages(posted: readonly unknown[]): Record<string, unknown>[] {
+    return posted.filter(
+        (message): message is Record<string, unknown> =>
+            isRecord(message) && message.type === "setCommitDetail",
+    );
+}
+
+describe("CommitGraphViewProvider redundant setCommitDetail post on webview reload", () => {
+    let parentDir: string;
+    let workspace: FixtureTemplate;
+    const scratch = createScratchWorkspaces();
+
+    beforeAll(async () => {
+        parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-commitgraph-provider-test-"));
+        scratch.register(parentDir);
+        // A single seeded root is enough: unlike the recorder's own byte-identical test, nothing
+        // here compares two independently seeded workspaces.
+        workspace = await seedFixtureTemplate(path.join(parentDir, "root"));
+        // `home` lives OUTSIDE `parentDir` (it is `mkdtemp`'d under the OS temp root by
+        // `createSanitizedGitEnv`) -- see `scratchWorkspaces.ts`'s own doc comment for why it must
+        // be registered explicitly rather than assumed to be removed along with `parentDir`.
+        scratch.register(workspace.home);
+    }, 60_000);
+
+    afterAll(async () => {
+        await scratch.removeAll();
+    });
+
+    it(
+        "re-posts the currently selected commit detail when a torn-down webview sends a second " +
+            "`ready` with no intervening resolveWebviewView, even though the payload is " +
+            "byte-identical to what the previous (now dead) webview context received",
+        async () => {
+            const gitOps = new GitOps(
+                new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
+            );
+            const credentialStore = new CredentialStore(createInertSecretStorage());
+            const provider = new CommitGraphViewProvider(
+                createFakeExtensionUri(),
+                gitOps,
+                credentialStore,
+                buildProviderOptions("card"),
+            );
+            const { webviewView, posted, receiveMessage } =
+                createInspectableFakeCommitGraphWebviewView();
+
+            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+            await receiveMessage({ type: "ready" });
+
+            provider.setCommitDetail(sampleDetail());
+            await flushMicrotasks();
+
+            const beforeReload = setDetailMessages(posted);
+            expect(
+                beforeReload.length,
+                "setCommitDetail() must post at least once before any reload is simulated",
+            ).toBeGreaterThanOrEqual(1);
+            const postedBeforeReload = beforeReload.length;
+
+            // VS Code tears a hidden WebviewView's context down and reloads it on show. The
+            // script re-runs and announces itself with a second `ready`, but the provider is
+            // already resolved, so `resolveWebviewView` -- and its `lastPostedPayload` reset --
+            // does NOT run again. The detail is byte-identical to the one posted before the
+            // reload, so a duplicate guard keyed only on the payload would suppress it and leave
+            // the restored pane empty. This is the regression the `ready` handler's OWN reset
+            // (`src/views/CommitGraphViewProvider.ts`, ~line 292) prevents.
+            await receiveMessage({ type: "ready" });
+            await flushMicrotasks();
+
+            const afterReload = setDetailMessages(posted);
+            expect(
+                afterReload.length,
+                "the reloaded webview must receive a NEW setCommitDetail post -- it must not be " +
+                    "suppressed as a duplicate of what the previous, now-dead webview context " +
+                    "already received",
+            ).toBeGreaterThan(postedBeforeReload);
+            expect(
+                afterReload[afterReload.length - 1],
+                "the re-sent payload must be byte-identical to the last one the dead context " +
+                    "received -- a guard keyed only on payload equality would have swallowed " +
+                    "exactly this repost, which is the whole point of this test",
+            ).toEqual(beforeReload[postedBeforeReload - 1]);
+        },
+    );
+});

--- a/tests/unit/views/CommitInfoViewProvider.test.ts
+++ b/tests/unit/views/CommitInfoViewProvider.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Provider-level tests for the redundant `setCommitDetail` post fix in
+ * `src/views/CommitInfoViewProvider.ts`.
+ *
+ * `CommitInfoViewProvider.setCommitDetail` posts the raw commit detail immediately, then starts
+ * `decorateAndStoreDetail`, which awaits `IconThemeService.decorateCommitDetailWithFolderIcons` and
+ * posts again unconditionally. When no icon resolver is attached (this test's `vscode` double never
+ * implements `vscode.extensions` -- see `commitInfoVscodeDouble.ts`'s own doc comment), decoration
+ * is a true no-op and the second post is byte-identical to the first: "suppresses the second post"
+ * below proves that redundant post is gone.
+ *
+ * THE TRAP: `IconThemeService.getThemeData()` reads live, mutable instance state
+ * (`folderIcons`/`iconFonts`) independently of whatever `decorateCommitDetailWithFolderIcons`
+ * returns, and that method awaits `initIconThemeData()` -- which can populate that state for the
+ * FIRST time -- before decorating. So the second post can legitimately differ from the first in
+ * exactly those fields, even though the commit detail itself never changed. "does NOT suppress"
+ * below proves the guard does not get this wrong: it stubs `getThemeData()` to return different
+ * values across the two `postCurrentState` calls this scenario drives (installed AFTER the
+ * `ready`-handler's own call, so it controls exactly the two calls under test) and asserts BOTH
+ * posts still go out.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+// Hoisted above the imports below -- see `recordCommitInfoWebviewFixture.test.ts` for why this must
+// be a plain, non-mocked import ahead of the `vi.mock` call it feeds.
+vi.mock("vscode", () => createCommitInfoVscodeDouble());
+
+import type * as vscode from "vscode";
+import { createFakeExtensionUri } from "../../visual/recorder/commitInfoVscodeDouble";
+import { CommitInfoViewProvider } from "../../../src/views/CommitInfoViewProvider";
+import type { IconThemeService } from "../../../src/views/shared/IconThemeService";
+import type { CommitDetail } from "../../../src/types";
+
+/** A resolve-context/token stand-in `resolveWebviewView` never reads -- same reasoning as
+ * `recordCommitInfoWebviewFixture.ts`'s own `INERT_RESOLVE_CONTEXT`/`INERT_CANCELLATION_TOKEN`. */
+const INERT_CONTEXT = {} as vscode.WebviewViewResolveContext;
+const INERT_TOKEN = {} as vscode.CancellationToken;
+
+/** Resolves once every microtask queued synchronously up to this call has drained -- see
+ * `recordCommitInfoWebviewFixture.ts`'s own `flushMicrotasks` doc comment for why a single
+ * `setImmediate` tick is sufficient to observe `decorateAndStoreDetail`'s settled effects in this
+ * double (no real timer or I/O wait anywhere in its chain). */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** A minimal local `vscode.WebviewView` double with an inspectable `posted` array -- deliberately
+ * NOT `commitInfoVscodeDouble.ts`'s own `createFakeCommitInfoWebviewView`, whose `postMessage` is
+ * fixed at `() => Promise.resolve(true)` with no capture hook. Same member set that function's own
+ * doc comment establishes as the exact minimum `CommitInfoViewProvider.resolveWebviewView` reaches
+ * for (`webview.{options,html,cspSource,asWebviewUri,onDidReceiveMessage,postMessage}`, the view's
+ * own `onDidDispose`). */
+function createInspectableFakeWebviewView(): {
+    readonly webviewView: vscode.WebviewView;
+    readonly posted: unknown[];
+    receiveMessage(message: unknown): Promise<void>;
+} {
+    let messageHandler: ((message: unknown) => unknown) | undefined;
+    const posted: unknown[] = [];
+
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        html: "",
+        cspSource: "vscode-webview://fake-commit-info-provider-test",
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: (listener: (message: unknown) => unknown) => {
+            messageHandler = listener;
+            return { dispose(): void {} };
+        },
+        postMessage: (message: unknown) => {
+            posted.push(message);
+            return Promise.resolve(true);
+        },
+    };
+
+    const webviewView = {
+        webview,
+        onDidDispose: () => ({ dispose(): void {} }),
+    } as unknown as vscode.WebviewView;
+
+    return {
+        webviewView,
+        posted,
+        receiveMessage: async (message: unknown): Promise<void> => {
+            if (!messageHandler) {
+                throw new Error(
+                    "createInspectableFakeWebviewView.receiveMessage: no message handler was " +
+                        "registered yet -- resolveWebviewView() must run first.",
+                );
+            }
+            await messageHandler(message);
+        },
+    };
+}
+
+function sampleDetail(): CommitDetail {
+    return {
+        hash: "b08ddf030532f359194329a212f0d9ba54bb6a02",
+        shortHash: "b08ddf03",
+        message: "Add conflict target",
+        body: "",
+        author: "IntelliGit Fixture Repo",
+        email: "intelligit-fixture@example.invalid",
+        date: "2000-01-01T01:00:00Z",
+        parentHashes: ["70fa528600605d9b3f1fce7aa04ec799ed494ffd"],
+        refs: [],
+        files: [{ path: "conflict.txt", status: "A", additions: 3, deletions: 0 }],
+    };
+}
+
+function setDetailMessages(posted: readonly unknown[]): Record<string, unknown>[] {
+    return posted.filter(
+        (message): message is Record<string, unknown> =>
+            isRecord(message) && message.type === "setCommitDetail",
+    );
+}
+
+describe("CommitInfoViewProvider redundant setCommitDetail post", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("suppresses the second post when decoration changes nothing", async () => {
+        const provider = new CommitInfoViewProvider(createFakeExtensionUri());
+        const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
+
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        await receiveMessage({ type: "ready" });
+
+        provider.setCommitDetail(sampleDetail());
+        await flushMicrotasks();
+
+        expect(setDetailMessages(posted)).toHaveLength(1);
+    });
+
+    it(
+        "does NOT suppress the second post when theme data legitimately arrives late " +
+            "(initIconThemeData populates state between the two posts)",
+        async () => {
+            const provider = new CommitInfoViewProvider(createFakeExtensionUri());
+            const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
+
+            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+            await receiveMessage({ type: "ready" });
+
+            // Installed AFTER the ready-handler's own `postCurrentState()` call already ran for
+            // real, so this controls exactly the two calls `setCommitDetail` below drives: the
+            // immediate raw post, and the post-decoration post.
+            const iconTheme = (provider as unknown as { iconTheme: IconThemeService }).iconTheme;
+            const themeDataSpy = vi.spyOn(iconTheme, "getThemeData");
+            themeDataSpy.mockReturnValueOnce({ folderIcons: {}, iconFonts: [] });
+            themeDataSpy.mockReturnValueOnce({
+                folderIcons: {
+                    folderIcon: { uri: "icon-a.svg" },
+                    folderExpandedIcon: { uri: "icon-a-expanded.svg" },
+                },
+                iconFonts: [{ fontFamily: "seti", src: "seti.woff" }],
+            });
+
+            provider.setCommitDetail(sampleDetail());
+            await flushMicrotasks();
+
+            const messages = setDetailMessages(posted);
+            expect(messages).toHaveLength(2);
+            expect(messages[0].iconFonts).toEqual([]);
+            expect(messages[0].folderIcon).toBeUndefined();
+            expect(messages[1].iconFonts).toEqual([{ fontFamily: "seti", src: "seti.woff" }]);
+            expect(messages[1].folderIcon).toEqual({ uri: "icon-a.svg" });
+        },
+    );
+
+    it(
+        "re-posts the unchanged detail to a webview that reloaded, because a second `ready` " +
+            "means a fresh context that received none of the earlier posts",
+        async () => {
+            const provider = new CommitInfoViewProvider(createFakeExtensionUri());
+            const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
+
+            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+            await receiveMessage({ type: "ready" });
+
+            provider.setCommitDetail(sampleDetail());
+            await flushMicrotasks();
+            expect(setDetailMessages(posted)).toHaveLength(1);
+
+            // VS Code tears a hidden WebviewView's context down and reloads it on show. The
+            // script re-runs and announces itself with a second `ready`, but the provider is
+            // already resolved, so `resolveWebviewView` -- and its `lastPostedPayload` reset --
+            // does NOT run again. The detail is byte-identical to the one posted before the
+            // reload, so a duplicate guard keyed only on the payload would suppress it and leave
+            // the restored pane empty. This is the regression the `ready`-handler reset prevents.
+            await receiveMessage({ type: "ready" });
+            await flushMicrotasks();
+
+            const messages = setDetailMessages(posted);
+            expect(
+                messages,
+                "the reloaded webview must receive the detail again, byte-identical or not",
+            ).toHaveLength(2);
+            expect(messages[1]).toEqual(messages[0]);
+        },
+    );
+});

--- a/tests/unit/views/CommitInfoViewProvider.test.ts
+++ b/tests/unit/views/CommitInfoViewProvider.test.ts
@@ -115,6 +115,23 @@ function sampleDetail(): CommitDetail {
     };
 }
 
+/** A second, distinguishable commit -- the mid-`ready` selection in the ordering test below. Its
+ * hash is `sampleDetail()`'s parent, so the pair reads as two commits from one real history. */
+function otherDetail(): CommitDetail {
+    return {
+        hash: "70fa528600605d9b3f1fce7aa04ec799ed494ffd",
+        shortHash: "70fa5286",
+        message: "Seed the fixture repository",
+        body: "",
+        author: "IntelliGit Fixture Repo",
+        email: "intelligit-fixture@example.invalid",
+        date: "2000-01-01T00:00:00Z",
+        parentHashes: [],
+        refs: [],
+        files: [{ path: "README.md", status: "A", additions: 1, deletions: 0 }],
+    };
+}
+
 function setDetailMessages(posted: readonly unknown[]): Record<string, unknown>[] {
     return posted.filter(
         (message): message is Record<string, unknown> =>
@@ -205,6 +222,62 @@ describe("CommitInfoViewProvider redundant setCommitDetail post", () => {
                 "the reloaded webview must receive the detail again, byte-identical or not",
             ).toHaveLength(2);
             expect(messages[1]).toEqual(messages[0]);
+        },
+    );
+
+    /**
+     * The `ready` handler's `lastPostedPayload` reset must run BEFORE its `await`, not after.
+     *
+     * That await yields, and on a reload `this.ready` is already true from the first `ready` --
+     * so a commit selected or refreshed during the window posts for real, against the context
+     * that is currently live. Resetting afterwards discards the record of that post, and the
+     * handler's closing `postCurrentState()` then re-sends what the webview already has.
+     *
+     * The two details must DIFFER for this to be detectable. With an identical one, the
+     * post-await reset merely relocates which of the two calls is suppressed and the webview
+     * ends up with the same message either way -- a test using one payload passes on the broken
+     * ordering. Selecting a different commit mid-window separates them: the correct ordering
+     * sends `X` then `Y`; the broken one sends `X`, `Y`, `Y`.
+     */
+    it(
+        "does not re-post a detail that arrived while the ready handler was still awaiting",
+        async () => {
+            const provider = new CommitInfoViewProvider(createFakeExtensionUri());
+            const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
+
+            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+            await receiveMessage({ type: "ready" });
+
+            provider.setCommitDetail(sampleDetail());
+            await flushMicrotasks();
+            expect(setDetailMessages(posted)).toHaveLength(1);
+
+            // The reload's `ready`. `initIconThemeData` is where that handler yields, so driving
+            // the selection from inside it puts the post exactly in the window under test.
+            //
+            // The guard is load-bearing, not defensive: `setCommitDetail` starts
+            // `decorateAndStoreDetail`, which awaits this very method again. Without it the
+            // stand-in re-enters itself and the test dies of heap exhaustion rather than
+            // reporting on the ordering.
+            const iconTheme = (provider as unknown as { iconTheme: IconThemeService }).iconTheme;
+            let selectedMidWindow = false;
+            vi.spyOn(iconTheme, "initIconThemeData").mockImplementation(async () => {
+                if (selectedMidWindow) return;
+                selectedMidWindow = true;
+                provider.setCommitDetail(otherDetail());
+                await flushMicrotasks();
+            });
+
+            await receiveMessage({ type: "ready" });
+            await flushMicrotasks();
+
+            const messages = setDetailMessages(posted);
+            expect(
+                messages.map((message) => (message.detail as CommitDetail).shortHash),
+                "the second commit must reach the webview exactly once: the reset belongs before " +
+                    "the await, so the mid-window post is the one recorded and the handler's " +
+                    "closing post is suppressed as the duplicate it is",
+            ).toEqual(["b08ddf03", "70fa5286"]);
         },
     );
 });

--- a/tests/unit/views/CommitPanelViewProvider.test.ts
+++ b/tests/unit/views/CommitPanelViewProvider.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Provider-level test for the `CommitPanelViewProvider` webview-reload re-post fix
+ * (`src/views/CommitPanelViewProvider.ts`).
+ *
+ * VS Code tears a hidden `WebviewView`'s context down and reloads it on show: the webview script
+ * re-runs and re-announces itself with a second `ready` message, but `resolveWebviewView` does NOT
+ * run again for that reload -- so its own `lastPostedPayload` reset (`:1065`) never fires.
+ * `handleReadyMessage` (`:1440`) resets `lastPostedPayload = undefined` as its own first statement
+ * (`:1446`) for exactly this reason: a fresh webview context has received nothing, so whatever
+ * `postGraphCommitDetailState` (`:1972`) posts during this handler must never be suppressed as a
+ * duplicate of what the PREVIOUS, now-dead context received -- even when the payload is
+ * byte-identical. Without that reset, `isRedundantPost` (`shared/postedPayload.ts`) would compare
+ * the unchanged commit-detail payload against the stale `lastPostedPayload` left over from the
+ * pre-reload context, silently suppress the post, and leave the restored pane empty.
+ *
+ * `handleReadyMessage` never calls `postGraphCommitDetailState` directly -- it only reaches it
+ * through `refreshGraphData(runtime)` (`:1463`), itself only invoked `if (runtime)`, i.e. only when
+ * an active repository runtime exists. This test constructs the provider against a REAL seeded git
+ * repository (mirroring `recordCommitPanelWebviewFixture.ts`'s construction recipe) so that path is
+ * real, not assumed: the "reaches refreshGraphData" claim is what the post-count assertion below
+ * actually exercises, not something asserted separately.
+ *
+ * Observation seam: `createFakeCommitPanelWebviewView()` (`commitInfoVscodeDouble.ts`) discards
+ * every posted message (`postMessage: () => Promise.resolve(true)`), so this file builds its own
+ * local inspectable double instead -- same choice, and the same reasoning, as
+ * `CommitInfoViewProvider.test.ts`'s own `createInspectableFakeWebviewView`, the closest existing
+ * model for this file's style. Its exact member set differs, though:
+ * `CommitPanelViewProvider.resolveWebviewView` (`:1095-1101`) reads `webviewView.visible` and
+ * calls `webviewView.onDidChangeVisibility(...)` unconditionally -- members
+ * `CommitInfoViewProvider.resolveWebviewView` never reaches for -- so the double below instead
+ * mirrors `createFakeCommitPanelWebviewView`'s own member set (`webview.*`, `onDidDispose`,
+ * `visible`, `onDidChangeVisibility`), with an inspectable `posted` array standing in for the
+ * discarding `postMessage`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+// Hoisted above the imports below -- see `recordCommitPanelWebviewFixture.test.ts` / `CommitInfoViewProvider.test.ts`
+// for this exact convention. Reused unchanged: `commit-panel` forces no new `vscode` member (see
+// `commitInfoVscodeDouble.ts`'s own doc comment).
+vi.mock("vscode", () => createCommitInfoVscodeDouble());
+
+import type * as vscode from "vscode";
+import {
+    createFakeExtensionUri,
+    createFakeUriFromPath,
+} from "../../visual/recorder/commitInfoVscodeDouble";
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+import { CommitPanelViewProvider } from "../../../src/views/CommitPanelViewProvider";
+import {
+    buildCommitPanelConstructorOptions,
+    createEmptyWorkspaceMemento,
+} from "../../visual/recorder/recordCommitPanelWebviewFixture";
+import { toGitEnvironment } from "../../visual/recorder/recordingGitEnvironment";
+import { assertDirtyPostcondition } from "../../fixtures/repo/scenarios";
+import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
+import { createScratchWorkspaces } from "../fixtures/scratchWorkspaces";
+import type { CommitDetail } from "../../../src/types";
+
+/** A resolve-context/token stand-in `resolveWebviewView` never reads -- same reasoning as
+ * `recordCommitPanelWebviewFixture.ts`'s own `INERT_RESOLVE_CONTEXT`/`INERT_CANCELLATION_TOKEN`. */
+const INERT_CONTEXT = {} as vscode.WebviewViewResolveContext;
+const INERT_TOKEN = {} as vscode.CancellationToken;
+
+function inertDisposable(): vscode.Disposable {
+    return { dispose(): void {} };
+}
+
+/** Resolves once every microtask / `setImmediate` callback queued synchronously up to this call
+ * has drained -- see `CommitInfoViewProvider.test.ts`'s own `flushMicrotasks` doc comment: a
+ * single `setImmediate` tick is sufficient to observe `decorateAndStoreCommitDetail`'s settled
+ * effects in this double (no real timer or I/O wait anywhere in its chain). */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/**
+ * Local inspectable `vscode.WebviewView` double. See this file's own doc comment for why its
+ * member set mirrors `createFakeCommitPanelWebviewView` (`commitInfoVscodeDouble.ts`) --
+ * `webview.*`, `onDidDispose`, `visible`, `onDidChangeVisibility` -- rather than the narrower set
+ * `CommitInfoViewProvider.test.ts`'s own inspectable double needs.
+ */
+function createInspectableCommitPanelWebviewView(): {
+    readonly webviewView: vscode.WebviewView;
+    readonly posted: unknown[];
+    receiveMessage(message: unknown): Promise<void>;
+} {
+    let messageHandler: ((message: unknown) => unknown) | undefined;
+    const posted: unknown[] = [];
+
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        html: "",
+        cspSource: "vscode-webview://fake-commit-panel-provider-test",
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: (listener: (message: unknown) => unknown) => {
+            messageHandler = listener;
+            return inertDisposable();
+        },
+        postMessage: (message: unknown) => {
+            posted.push(message);
+            return Promise.resolve(true);
+        },
+    };
+
+    const webviewView = {
+        webview,
+        visible: true,
+        onDidDispose: () => inertDisposable(),
+        onDidChangeVisibility: () => inertDisposable(),
+    } as unknown as vscode.WebviewView;
+
+    return {
+        webviewView,
+        posted,
+        receiveMessage: async (message: unknown): Promise<void> => {
+            if (!messageHandler) {
+                throw new Error(
+                    "createInspectableCommitPanelWebviewView.receiveMessage: no message handler " +
+                        "was registered yet -- resolveWebviewView() must run first.",
+                );
+            }
+            await messageHandler(message);
+        },
+    };
+}
+
+function setCommitDetailMessages(posted: readonly unknown[]): Record<string, unknown>[] {
+    return posted.filter(
+        (message): message is Record<string, unknown> =>
+            isRecord(message) && message.type === "setCommitDetail",
+    );
+}
+
+function sampleDetail(): CommitDetail {
+    return {
+        hash: "b08ddf030532f359194329a212f0d9ba54bb6a02",
+        shortHash: "b08ddf03",
+        message: "Add conflict target",
+        body: "",
+        author: "IntelliGit Fixture Repo",
+        email: "intelligit-fixture@example.invalid",
+        date: "2000-01-01T01:00:00Z",
+        parentHashes: ["70fa528600605d9b3f1fce7aa04ec799ed494ffd"],
+        refs: [],
+        files: [{ path: "conflict.txt", status: "A", additions: 3, deletions: 0 }],
+    };
+}
+
+const scratch = createScratchWorkspaces();
+
+/** Mirrors `recordCommitPanelWebviewFixture.test.ts`'s own (non-exported) `prepareDirtyWorkspace`:
+ * seeds one real git working tree and confirms it landed in the `dirty` postcondition
+ * `seedFixtureTemplate` always leaves it in. `dirty`, not `clean`, only because that is the
+ * scenario the sibling recorder test already established as safe for this provider -- this test's
+ * own assertions do not depend on working-tree dirtiness at all. */
+async function prepareDirtyWorkspace(destination: string): Promise<FixtureTemplate> {
+    const template = await seedFixtureTemplate(destination);
+    scratch.register(template.home);
+    await assertDirtyPostcondition(template.root, template.env);
+    return template;
+}
+
+describe("CommitPanelViewProvider reload re-post", () => {
+    afterEach(async () => {
+        await scratch.removeAll();
+    });
+
+    it(
+        "re-posts the unchanged commit detail after a webview reload's second `ready`, because " +
+            "resolveWebviewView does not re-run and a fresh context has received nothing",
+        async () => {
+            const parentDir = await mkdtemp(
+                path.join(tmpdir(), "intelligit-commit-panel-provider-test-"),
+            );
+            scratch.register(parentDir);
+            const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+            const constructorOptions = buildCommitPanelConstructorOptions();
+            const gitOps = new GitOps(
+                new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
+            );
+            const provider = new CommitPanelViewProvider(
+                createFakeExtensionUri(),
+                gitOps,
+                createFakeUriFromPath(workspace.root),
+                createEmptyWorkspaceMemento(),
+                undefined, // secrets -- nothing on this path reads a secret.
+                constructorOptions.shelfServiceForRepository,
+                constructorOptions.shelfRemoveOnUnshelve,
+                constructorOptions.commitMessageGenerationCoordinator,
+                constructorOptions.interactiveRebaseStorageRoot,
+            );
+
+            const { webviewView, posted, receiveMessage } =
+                createInspectableCommitPanelWebviewView();
+            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+            await receiveMessage({ type: "ready" });
+
+            provider.setCommitDetail(sampleDetail());
+            await flushMicrotasks();
+
+            const beforeReload = setCommitDetailMessages(posted);
+            expect(
+                beforeReload.length,
+                "setCommitDetail() must post at least once before the reload scenario begins",
+            ).toBeGreaterThanOrEqual(1);
+            const countBeforeReload = beforeReload.length;
+
+            // VS Code tears a hidden WebviewView's context down and reloads it on show. The
+            // script re-runs and re-announces itself with a second `ready`, but the provider is
+            // already resolved -- resolveWebviewView, and its own `lastPostedPayload` reset, does
+            // NOT run again. No intervening resolveWebviewView call here is the point.
+            await receiveMessage({ type: "ready" });
+            await flushMicrotasks();
+
+            const afterReload = setCommitDetailMessages(posted);
+            expect(
+                afterReload.length,
+                "the reloaded webview's second `ready` must reach postGraphCommitDetailState " +
+                    "(via refreshGraphData) and re-post the commit detail -- a guard keyed only " +
+                    "on payload equality would have wrongly swallowed exactly this repost",
+            ).toBeGreaterThan(countBeforeReload);
+            expect(
+                afterReload[afterReload.length - 1],
+                "the re-post to the reloaded webview must be byte-identical to what the dead " +
+                    "context received -- byte-identical is the whole point of this regression",
+            ).toEqual(beforeReload[beforeReload.length - 1]);
+        },
+        30_000,
+    );
+});

--- a/tests/unit/views/UndockedViewProvider.test.ts
+++ b/tests/unit/views/UndockedViewProvider.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression test for the `lastPostedPayload` reset inside `UndockedViewProvider`'s `ready` message
+ * handler (`src/views/UndockedViewProvider.ts:949`, immediately before the `postCommitDetailState()`
+ * call at `:950`).
+ *
+ * `postCommitDetailState()` (`:1908`) guards outgoing `setCommitDetail` posts against
+ * `lastPostedPayload`, an exact-byte duplicate check (`src/views/shared/postedPayload.ts`).
+ * `lastPostedPayload` is also reset when `open()` creates a brand new panel (`:688`) -- but that
+ * branch does NOT run again just because the webview reloads. This panel sets
+ * `retainContextWhenHidden: true` (`:683`), yet VS Code can still tear down and rebuild the
+ * webview's OWN script context on a window/webview reload, which re-announces itself with a second
+ * `ready` message while `this.panel` itself is untouched. Without the SECOND reset at `:949`, that
+ * second `ready` would call `postCommitDetailState()` against a `lastPostedPayload` still holding
+ * what the OLD, now-dead context received, so the identical-looking repost the reloaded context
+ * actually needs would be wrongly suppressed as a duplicate -- and the restored pane would render
+ * empty.
+ *
+ * Observation seam: option (a), a small local inspectable `postMessage`, in the style of
+ * `createInspectableFakeWebviewView()` in the sibling
+ * `tests/unit/views/CommitInfoViewProvider.test.ts` (which pins the identical invariant for the
+ * `WebviewView`-based `CommitInfoViewProvider`). Unlike that provider, `UndockedViewProvider` owns a
+ * `vscode.WebviewPanel` it creates ITSELF, internally, inside `open()` by calling
+ * `vscode.window.createWebviewPanel(...)` -- there is no view object this test can build and hand in
+ * directly. `webviewPanelDouble.ts`'s construction registry (`getCreatedWebviewPanels()`) is the only
+ * way to reach that internally-created panel, and this test replaces its `webview.postMessage` --
+ * which the shared double fixes at `() => Promise.resolve(true)` with no capture hook -- with a local
+ * recorder. That plain property write always falls through to the real underlying webview object
+ * (`throwingDouble.ts` has no `set` trap by design; see its own doc comment), so every later
+ * `panel.webview.postMessage(...)` call -- including every one `UndockedViewProvider.postToWebview`
+ * makes internally -- resolves to this recorder. The E2E control channel
+ * (`setE2eControlChannelActive`, `getE2eWebviewCaptureSink`) is never touched: it defaults to
+ * inactive, and `captureWebview` (`src/e2e/webviewCapture.ts`) returns the panel unwrapped and
+ * identity-equal while it is -- which is exactly what makes the patched `postMessage` visible to
+ * production code in the first place.
+ *
+ * A real seeded repository is used rather than a stub `GitOps`: the `ready` handler's own fan-out
+ * (`sendBranches`, `loadInitial`, `refreshCommitPanelData`) calls real `GitOps` methods, matching the
+ * construction recipe `tests/visual/recorder/recordUndockedWebviewFixture.ts` already uses to drive
+ * this same provider through this same message.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+// Hoisted above the imports below -- see `CommitInfoViewProvider.test.ts` /
+// `recordCommitInfoWebviewFixture.test.ts` for why this must be a plain, non-mocked import ahead of
+// the `vi.mock` call it feeds.
+vi.mock("vscode", () => createCommitInfoVscodeDouble());
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { CommitDetail } from "../../../src/types";
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+import { UndockedViewProvider } from "../../../src/views/UndockedViewProvider";
+import { seedFixtureTemplate } from "../../fixtures/repo/seed";
+import { toGitEnvironment } from "../../visual/recorder/recordingGitEnvironment";
+import {
+    buildUndockedProviderConstructorArguments,
+    buildUndockedWorkspaceConfiguration,
+} from "../../visual/recorder/recordUndockedWebviewFixture";
+import {
+    type FakeWebviewPanel,
+    getCreatedWebviewPanels,
+    resetCreatedWebviewPanelsForTests,
+} from "../../visual/recorder/webviewPanelDouble";
+import {
+    resetFakeWorkspaceConfigurationForTests,
+    setFakeWorkspaceConfiguration,
+} from "../../visual/recorder/workspaceConfigurationDouble";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** Resolves once every microtask queued synchronously up to this call has drained -- same technique
+ * (and same justification) as `CommitInfoViewProvider.test.ts`'s own `flushMicrotasks`: nothing in
+ * this double's chain does real timer or I/O work, so a single `setImmediate` tick is enough to
+ * observe `setCommitDetail`'s fire-and-forget decoration settle. */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+function sampleCommitDetail(): CommitDetail {
+    return {
+        hash: "a1b2c3d4e5f60718293a4b5c6d7e8f901234567",
+        shortHash: "a1b2c3d4",
+        message: "Add conflict target",
+        body: "",
+        author: "IntelliGit Fixture Repo",
+        email: "intelligit-fixture@example.invalid",
+        date: "2000-01-01T01:00:00Z",
+        parentHashes: ["70fa528600605d9b3f1fce7aa04ec799ed494ffd"],
+        refs: [],
+        files: [{ path: "conflict.txt", status: "A", additions: 3, deletions: 0 }],
+    };
+}
+
+function setCommitDetailMessages(posted: readonly unknown[]): Record<string, unknown>[] {
+    return posted.filter(
+        (message): message is Record<string, unknown> =>
+            isRecord(message) && message.type === "setCommitDetail",
+    );
+}
+
+/**
+ * Replaces `panel.webview.postMessage` -- which the shared double discards unconditionally -- with a
+ * local recorder, and returns the array it appends to. See this file's own header for why the plain
+ * property write is guaranteed to be seen by the provider's own later calls.
+ */
+function attachPostedMessageRecorder(panel: FakeWebviewPanel): unknown[] {
+    const posted: unknown[] = [];
+    panel.webview.postMessage = (message: unknown) => {
+        posted.push(message);
+        return Promise.resolve(true);
+    };
+    return posted;
+}
+
+describe("UndockedViewProvider commit-detail re-post on webview reload", () => {
+    it(
+        "re-posts the selected commit detail when `ready` fires again without a new panel, even " +
+            "though the payload is byte-identical to what the previous webview context received",
+        async () => {
+            const parentDir = await mkdtemp(
+                path.join(tmpdir(), "intelligit-undocked-provider-test-"),
+            );
+            resetCreatedWebviewPanelsForTests();
+            resetFakeWorkspaceConfigurationForTests();
+            try {
+                const template = await seedFixtureTemplate(path.join(parentDir, "repo"), {
+                    homeParent: parentDir,
+                });
+                const gitOps = new GitOps(
+                    new GitExecutor(template.root, undefined, toGitEnvironment(template.env)),
+                );
+                setFakeWorkspaceConfiguration(buildUndockedWorkspaceConfiguration());
+
+                const provider = new UndockedViewProvider(
+                    ...buildUndockedProviderConstructorArguments({
+                        repoRoot: template.root,
+                        gitOps,
+                    }),
+                );
+
+                provider.open();
+                const createdPanels = getCreatedWebviewPanels();
+                expect(
+                    createdPanels.length,
+                    "open() must create exactly one webview panel",
+                ).toEqual(1);
+                const [panel] = createdPanels;
+                if (!panel) {
+                    throw new Error("UndockedViewProvider.open() did not create a webview panel.");
+                }
+                const posted = attachPostedMessageRecorder(panel);
+
+                await panel.receiveMessage({ type: "ready" });
+
+                const detail = sampleCommitDetail();
+                provider.setCommitDetail(detail);
+                // setCommitDetail's own icon-theme decoration runs as a fire-and-forget async chain
+                // (see UndockedViewProvider.ts:601); flush the microtask queue so its settled
+                // effects -- including any second post it makes on top of the immediate one -- are
+                // captured before reading the count below.
+                await flushMicrotasks();
+
+                const beforeReload = setCommitDetailMessages(posted);
+                expect(
+                    beforeReload.length,
+                    "setCommitDetail must post the selected commit detail at least once before " +
+                        "the reload",
+                ).toBeGreaterThanOrEqual(1);
+                const countBeforeReload = beforeReload.length;
+                const lastPayloadBeforeReload = beforeReload[countBeforeReload - 1];
+
+                // The point of this test: a second `ready` fires WITHOUT a second `open()` call, so
+                // open()'s own create-panel reset (UndockedViewProvider.ts:688) never runs again --
+                // only the reset inside the `ready` case itself (:949) can save this repost.
+                await panel.receiveMessage({ type: "ready" });
+                await flushMicrotasks();
+
+                const afterReload = setCommitDetailMessages(posted);
+                expect(
+                    afterReload.length,
+                    "the reloaded webview context must receive a fresh setCommitDetail post " +
+                        "instead of being silently suppressed as a duplicate of what the " +
+                        "previous, now-dead webview context already received",
+                ).toBeGreaterThan(countBeforeReload);
+                expect(
+                    afterReload[afterReload.length - 1],
+                    "the re-post must carry the exact same commit-detail payload as before the " +
+                        "reload -- byte-identical is the whole point; a duplicate guard keyed only " +
+                        "on the payload would have swallowed this post",
+                ).toEqual(lastPayloadBeforeReload);
+            } finally {
+                for (const createdPanel of getCreatedWebviewPanels()) createdPanel.dispose();
+                resetCreatedWebviewPanelsForTests();
+                resetFakeWorkspaceConfigurationForTests();
+                await rm(parentDir, { recursive: true, force: true });
+            }
+        },
+    );
+});

--- a/tests/unit/views/shared/postedPayload.test.ts
+++ b/tests/unit/views/shared/postedPayload.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Spec-derived tests for `src/views/shared/postedPayload.ts` -- the two pure functions that decide
+ * whether an outgoing `setCommitDetail` webview payload is byte-identical to the last one actually
+ * posted (see `CommitInfoViewProvider.decorateAndStoreDetail` and its three siblings for the
+ * redundant-post defect these functions exist to guard against).
+ *
+ * The trap this module exists to avoid: `IconThemeService.decorateCommitDetailWithFolderIcons`
+ * awaits `initIconThemeData()` BEFORE decorating, so a second post can legitimately carry
+ * `iconFonts` / `folderIcon` / `folderExpandedIcon` / `folderIconsByName` that were not yet
+ * initialized when the FIRST post went out. `isRedundantPost` must therefore compare the fully
+ * built outgoing payload, not just the commit detail -- case 2 below ("iconFonts only") is the one
+ * test in this file that a naive "did the commit detail change" guard would get wrong.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+    isRedundantPost,
+    serializeWebviewPayload,
+} from "../../../../src/views/shared/postedPayload";
+
+/** A minimal, representative `setCommitDetail` payload shape -- mirrors what
+ * `CommitInfoViewProvider`'s `postCurrentState` (and its three siblings) actually build. Kept as a
+ * plain object literal, not the real `CommitInfoOutbound` type, since these are pure-function tests
+ * of serialization/comparison, not of any one provider's exact message contract. */
+function basePayload(): Record<string, unknown> {
+    return {
+        type: "setCommitDetail",
+        detail: {
+            hash: "b08ddf030532f359194329a212f0d9ba54bb6a02",
+            shortHash: "b08ddf03",
+            message: "Add conflict target",
+            body: "",
+            author: "IntelliGit Fixture Repo",
+            email: "intelligit-fixture@example.invalid",
+            date: "2000-01-01T01:00:00Z",
+            parentHashes: ["70fa528600605d9b3f1fce7aa04ec799ed494ffd"],
+            refs: [],
+            files: [{ path: "conflict.txt", status: "A", additions: 3, deletions: 0 }],
+        },
+        folderIcon: undefined,
+        folderExpandedIcon: undefined,
+        folderIconsByName: {},
+        iconFonts: [],
+    };
+}
+
+describe("serializeWebviewPayload", () => {
+    it("produces the same string for two structurally-identical payloads", () => {
+        expect(serializeWebviewPayload(basePayload())).toBe(serializeWebviewPayload(basePayload()));
+    });
+
+    it("is sensitive to key insertion order -- documented honestly, not papered over", () => {
+        // Two objects with the SAME keys and values, inserted in a different order. This
+        // implementation is `JSON.stringify` underneath, which preserves insertion order and does
+        // NOT canonicalize it -- so these two serialize to DIFFERENT strings even though they are
+        // semantically the same object. This is an accepted limitation, not a bug: every real
+        // caller (`postCurrentState` and its three siblings) builds the compared payload from the
+        // SAME object-literal source on every call, so insertion order is stable in production: the
+        // two posts being compared always construct their top-level payload the same way, and
+        // `IconThemeService.decorateCommitDetail`'s `{ ...detail, files }` spread preserves the
+        // original `detail`'s key order rather than reordering it (see that function's own
+        // implementation). A key-order-agnostic comparison would need to canonicalize keys
+        // recursively, which nothing in this codebase currently needs.
+        const orderedOne = { a: 1, b: 2 };
+        const orderedTwo = { b: 2, a: 1 };
+
+        expect(serializeWebviewPayload(orderedOne)).not.toBe(serializeWebviewPayload(orderedTwo));
+    });
+});
+
+describe("isRedundantPost", () => {
+    it("case 1: two identical payloads -> redundant", () => {
+        const serialized = serializeWebviewPayload(basePayload());
+        expect(isRedundantPost(serialized, serialized)).toBe(true);
+    });
+
+    it(
+        "case 2 (THE TRAP): payloads differing ONLY in iconFonts -> NOT redundant -- late " +
+            "initIconThemeData() completion must never be suppressed",
+        () => {
+            const before = serializeWebviewPayload(basePayload());
+            const after = serializeWebviewPayload({
+                ...basePayload(),
+                iconFonts: [{ id: "seti", fontCharacter: "\\E001" }],
+            });
+
+            expect(isRedundantPost(after, before)).toBe(false);
+        },
+    );
+
+    it("case 3: payloads differing ONLY in folderIconsByName -> NOT redundant", () => {
+        const before = serializeWebviewPayload(basePayload());
+        const after = serializeWebviewPayload({
+            ...basePayload(),
+            folderIconsByName: { src: "folder-src-icon" },
+        });
+
+        expect(isRedundantPost(after, before)).toBe(false);
+    });
+
+    it("case 4: payloads differing ONLY in folderIcon/folderExpandedIcon -> NOT redundant", () => {
+        const before = serializeWebviewPayload(basePayload());
+        const after = serializeWebviewPayload({
+            ...basePayload(),
+            folderIcon: "folder-icon-id",
+            folderExpandedIcon: "folder-expanded-icon-id",
+        });
+
+        expect(isRedundantPost(after, before)).toBe(false);
+    });
+
+    it("case 5: payloads differing only deep inside detail.files[n].path -> NOT redundant", () => {
+        const before = serializeWebviewPayload(basePayload());
+        const changed = basePayload();
+        (changed.detail as { files: Array<{ path: string }> }).files[0].path = "renamed.txt";
+        const after = serializeWebviewPayload(changed);
+
+        expect(isRedundantPost(after, before)).toBe(false);
+    });
+
+    it(
+        "case 6: lastPosted === undefined -> NOT redundant, even if byte-identical to a payload " +
+            "posted to a PREVIOUS webview -- a fresh webview must always receive a full post, or " +
+            "view restoration renders an empty pane",
+        () => {
+            const serialized = serializeWebviewPayload(basePayload());
+            expect(isRedundantPost(serialized, undefined)).toBe(false);
+        },
+    );
+
+    it("case 7: a real-shaped payload compared against itself twice stays redundant on the third post", () => {
+        // Not a new case on its own -- reinforces case 1 with the exact shape `basePayload()`
+        // mirrors (nested `detail`, arrays, an empty `folderIconsByName`) rather than the trivial
+        // `{a,b}` shape `serializeWebviewPayload`'s own key-order test uses.
+        const serialized = serializeWebviewPayload(basePayload());
+        expect(isRedundantPost(serialized, serialized)).toBe(true);
+        expect(isRedundantPost(serialized, serialized)).toBe(true);
+    });
+});

--- a/tests/visual/fixtures/commit-info/clean.json
+++ b/tests/visual/fixtures/commit-info/clean.json
@@ -37,35 +37,6 @@
                 "folderIconsByName": {},
                 "iconFonts": []
             }
-        },
-        {
-            "contextId": "commit-info",
-            "message": {
-                "type": "setCommitDetail",
-                "detail": {
-                    "hash": "b08ddf030532f359194329a212f0d9ba54bb6a02",
-                    "shortHash": "b08ddf03",
-                    "message": "Add conflict target",
-                    "body": "",
-                    "author": "IntelliGit Fixture Repo",
-                    "email": "intelligit-fixture@example.invalid",
-                    "date": "2000-01-01T01:00:00Z",
-                    "parentHashes": [
-                        "70fa528600605d9b3f1fce7aa04ec799ed494ffd"
-                    ],
-                    "refs": [],
-                    "files": [
-                        {
-                            "path": "conflict.txt",
-                            "status": "A",
-                            "additions": 3,
-                            "deletions": 0
-                        }
-                    ]
-                },
-                "folderIconsByName": {},
-                "iconFonts": []
-            }
         }
     ]
 }

--- a/tests/visual/recorder/recordCommitInfoWebviewFixture.ts
+++ b/tests/visual/recorder/recordCommitInfoWebviewFixture.ts
@@ -34,8 +34,17 @@
  * in this double (icon-theme resolution failing over to its declared fallback, see the module doc
  * comment on `commitInfoVscodeDouble.ts`) is already-resolved Promise chaining with no real timer or
  * I/O wait, so a single `setImmediate` tick -- which only runs after Node's microtask queue is fully
- * drained, including microtasks newly enqueued while draining -- is sufficient to observe the
- * second, decorated `setCommitDetail` post this module's own tests assert on.
+ * drained, including microtasks newly enqueued while draining -- is sufficient to let that chain
+ * settle deterministically before this function returns and reads the capture sink.
+ *
+ * This scenario's "clean" recording no longer observes a SECOND `setCommitDetail` post here: with
+ * no icon resolver attached (see above), `decorateAndStoreDetail`'s decoration pass is a byte-for-
+ * byte no-op, and `CommitInfoViewProvider.postCurrentState` now suppresses a repost that is
+ * identical to the last one actually sent (`src/views/shared/postedPayload.ts`,
+ * `CommitInfoViewProvider.ts`'s `lastPostedPayload` field). The flush is kept anyway: without it,
+ * `decorateAndStoreDetail`'s promise chain would still be in flight when this function reads the
+ * capture sink and resets it for the next recording, racing whichever call runs next against the
+ * same process-wide sink.
  */
 
 import type * as vscode from "vscode";


### PR DESCRIPTION
## What

Stops the four webview providers from posting a second, byte-identical `setCommitDetail` right after the first one.

`CommitInfoViewProvider`, `CommitGraphViewProvider`, `CommitPanelViewProvider`, and `UndockedViewProvider` each post a raw commit detail immediately, then post again — unconditionally — once async icon-theme decoration settles. When no icon resolver is attached, or decoration otherwise changes nothing, that second post is byte-identical to the first, and the webview re-renders the same content for no reason.

## How

A small shared module, `src/views/shared/postedPayload.ts`, holds two pure functions: `serializeWebviewPayload` and `isRedundantPost`. Each provider tracks the serialized form of the last payload it actually posted and skips a post that matches it.

Two design points, because both are places a "simpler" version is wrong:

- **The comparison is on the fully-built outgoing payload, not the commit detail or the decoration result.** `IconThemeService.decorateCommitDetailWithFolderIcons` awaits `initIconThemeData()` before decorating, which can populate `folderIcon` / `folderExpandedIcon` / `iconFonts` **for the first time** between the two posts. Those fields are read from `IconThemeService.getThemeData()` at post time, not returned by the decoration call — so a guard keyed on "did decoration change the detail?" would silently drop legitimately new theme data.
- **`lastPosted === undefined` always sends.** Nothing has been posted to the *current* webview, so skipping there renders an empty pane on view restoration. The tracker is reset on `resolveWebviewView`, on the webview's `ready` message, and on cache clear.

## Tests

- `tests/unit/views/shared/postedPayload.test.ts` — the two pure functions, including the first-post case.
- `tests/unit/views/*ViewProvider.test.ts` — per-provider coverage of the suppressed repost, plus ready-reset coverage for the three providers that lacked it, so a provider that forgets to reset on re-resolve goes red.
- `tests/visual/fixtures/commit-info/clean.json` loses the duplicate post it had been recording; the recorder's doc comment now explains why its `setImmediate` flush is still required (the decoration chain must settle before the capture sink is read and reset, or the next recording races it).

## Verification

- Unit suite: 251 files / 3600 tests passed
- `typecheck`, `lint:strict`, `lint:complexity`, `format:check`, `architecture:check`, `deps:check:strict`, `verify:manifest` — all pass
- Container visual suite: 336 passed, no pixel-baseline or `knownFindings.json` drift

## Release

Bumps to **0.25.1** with the matching CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant commit-detail updates, improving webview responsiveness and minimizing unnecessary refresh activity.
  * Ensured commit details are sent correctly when a view is reopened, refreshed, or becomes ready.
* **Tests**
  * Updated visual test fixtures and recording guidance to reflect the removal of duplicate commit-detail messages.
* **Chores**
  * Updated the extension version to 0.25.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents byte-identical commit-detail messages from being reposted after asynchronous icon decoration while preserving the first post to each webview context.
- Adds shared payload serialization and equality helpers.
- Tracks the last posted commit-detail payload across four webview providers, resetting the tracker on lifecycle and clear boundaries.
- Adds provider, helper, and visual-fixture coverage and bumps the extension to 0.25.1.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/views/shared/postedPayload.ts | Adds pure serialization and duplicate-comparison helpers with explicit first-post behavior. |
| src/views/CommitGraphViewProvider.ts | Suppresses unchanged commit-detail reposts and resets tracking when graph webview state is recreated or cleared. |
| src/views/CommitInfoViewProvider.ts | Applies payload deduplication behind the existing readiness gate and resets it across view lifecycles. |
| src/views/CommitPanelViewProvider.ts | Deduplicates embedded graph commit-detail messages while preserving ready and clear hydration. |
| src/views/UndockedViewProvider.ts | Adds equivalent deduplication for the retained undocked panel and resets it on new panel contexts. |
| tests/unit/views/shared/postedPayload.test.ts | Covers first-post, identical-payload, differing-payload, and serialization behavior. |
| tests/visual/fixtures/commit-info/clean.json | Updates the recorded fixture to remove the intentionally eliminated duplicate message. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Build commit-detail payload] --> B[Serialize payload]
  B --> C{Matches last posted payload?}
  C -- Yes --> D[Skip redundant post]
  C -- No --> E[Post to current webview]
  E --> F[Record serialized payload]
  G[Resolve, ready, or clear] --> H[Reset tracker]
  H --> A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reset the webview dedup record befo..."](https://github.com/maheshkok/intelligit/commit/b70586de93ea240cd46d061ba1a5fc5aa980857f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53621955)</sub>

<!-- /greptile_comment -->