### PR TITLE
chore(ci): move both halves of the CodeQL scan to the same commit (supersedes #185)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,10 @@ jobs:
                   persist-credentials: false
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@bb16b9baa2ec4010b29f5c606d57d01190139edd # v4.37.1
+              uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
               with:
                   languages: javascript-typescript
                   build-mode: none
 
             - name: Analyze JavaScript and TypeScript
-              uses: github/codeql-action/analyze@bb16b9baa2ec4010b29f5c606d57d01190139edd # v4.37.1
+              uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1


### PR DESCRIPTION
## What

Moves **both** halves of the CodeQL scan — `codeql-action/init` and `codeql-action/analyze` — to `7188fc363630916deb702c7fdcf4e481b751f97a` together.

Supersedes #185, which can be closed.

## Why #185 cannot merge on its own

Dependabot #185 proposes bumping `init` alone. `init` and `analyze` are two halves of one scan and share an on-disk database format, so advancing one without the other pairs two versions of the action against a single format. `tests/unit/publishing/ciHardeningWorkflows.test.ts` asserts the two stay pinned to the same commit, and goes red for exactly that — which is why #185 is permanently red and Dependabot cannot fix it itself (it cannot edit the test in the same PR).

That assertion is deliberately *not* an exact-SHA check. An exact-SHA assertion goes red for a correct bump and a split bump alike, so it cannot tell them apart; asserting the two halves **match** catches the split and stays quiet for a correct bump.

## This is not a version bump

Both references stay on `# v4.37.1`. Only the commit that tag resolves to moves:

```
gh api repos/github/codeql-action/tags  ->  v4.37.1 = 7188fc363630916deb702c7fdcf4e481b751f97a
```

There is a second, unrelated reason this is worth taking. The previous pin `bb16b9baa2ec4010b29f5c606d57d01190139edd` **carries no tag and is unreachable from any ref upstream** — `gh api repos/github/codeql-action/commits/bb16b9ba…` returns `422 No commit found for SHA`. Actions still resolves it from the object store (the scan has been green), but codeql-action force-pushes `releases/v4`, which is what orphaned it. A tagged commit cannot be orphaned the same way, so this also removes a latent fragility rather than only satisfying Dependabot.

## Proof

Mutation-proven, not merely green.

| run | codeql.yml state | result | red names the split-bump assertion? |
|---|---|---|---|
| baseline | both halves on `7188fc36` | **green**, 6/6 | — |
| mutation | `analyze` reverted to `bb16b9ba` (byte-for-byte what #185 leaves behind) | **red** | **yes** |

The red line:

```
× keeps the static analysis and dependency-review grants narrowly scoped
  -> codeql-action/init and /analyze must be pinned to the SAME commit; a split bump
     pairs two versions of one scan against a shared database format
```

The other five tests in that file stay green under the mutation, so the red is attributable to the split-bump assertion rather than to collateral breakage.

## Version

No version bump and no CHANGELOG entry. `0.25.5` is already on `main` and **has not been released** — the `release` job is skipped behind the failing `e2e-full` job, so there is no `v0.25.5` tag. Bumping to `0.25.6` here would strand `0.25.5` as another never-published version, which is the exact problem `0.25.2`/`0.25.3` caused. The pinned action *version* is unchanged (v4.37.1 → v4.37.1), so there is nothing user-facing to record.

## Test plan

- [x] `bunx vitest run tests/unit/publishing/ciHardeningWorkflows.test.ts` — 6/6 green
- [x] Mutation: revert `analyze` alone → red, naming the split-bump assertion
- [x] `v4.37.1` tag verified to resolve to the pinned SHA via the GitHub API
- [ ] CodeQL workflow green on this PR (the real end-to-end check — it runs on `pull_request`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use refreshed CodeQL action references.
  * Existing workflow settings and scanning behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates both CodeQL action phases to the same immutable commit while retaining CodeQL v4.37.1.
- Moves `github/codeql-action/init` and `github/codeql-action/analyze` together to commit `7188fc363630916deb702c7fdcf4e481b751f97a`.
- Preserves matching pins across the shared CodeQL scan and leaves workflow triggers, permissions, and configuration unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both CodeQL phases remain consistently pinned to the same valid commit.

The change preserves the workflow’s paired-action invariant, immutable SHA pinning, and existing scan configuration without introducing a reachable failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Both CodeQL phases are consistently updated to the same full-length immutable commit, with no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): move both halves of the CodeQ..."](https://github.com/maheshkok/intelligit/commit/2749cb822e826cf61a8a98ca51c2e7fdcbc6ddd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53898276)</sub>

<!-- /greptile_comment -->