### PR TITLE
chore(review): skip CodeRabbit review on Dependabot PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -58,3 +58,17 @@ reviews:
         - "!tests/unit/activation/**"
         - "!tests/unit/localization/**"
         - "!tests/unit/services/**"
+    # Dependabot pull requests. CodeRabbit already skips them today -- zero
+    # review comments across all 17 dependabot PRs this repo has opened, against
+    # 1-18 on every human PR in the same window -- but that skip comes from a
+    # default we neither control nor can see from the repository. Pinning it
+    # here makes the behaviour explicit and keeps it if that default ever
+    # changes. What gates a dependency bump is CI, not a reviewer's opinion of a
+    # version string.
+    #
+    # The match is exact, and the raw login is `dependabot[bot]`. The `gh` CLI
+    # renders the same actor as `app/dependabot`, which is a rendering of a
+    # GitHub App rather than a username and would silently never match.
+    auto_review:
+        ignore_usernames:
+            - "dependabot[bot]"


### PR DESCRIPTION
## What

Adds `reviews.auto_review.ignore_usernames: ["dependabot[bot]"]` to `.coderabbit.yaml`, so CodeRabbit skips Dependabot pull requests.

## This pins existing behaviour rather than changing it

Worth stating plainly, because it changes how the PR should be read: **CodeRabbit already skips Dependabot PRs.** It has never reviewed one in this repository.

| author | PRs | with any `coderabbitai[bot]` comment |
|---|---|---|
| `dependabot[bot]` | 17 (#171–#195) | **0** |
| `MaheshKok` | 8 sampled in the same window | **8** (1–18 comments each) |

Counted across all three comment surfaces — issue comments, reviews, and review comments. A single silent PR could mean "nothing to review"; 0-for-17 against a human control that is 8-for-8 in the same days is a policy.

That policy currently lives in a default outside the repository. It is invisible to anyone reading the config, and free to change without notice. This commit makes it explicit and version-controlled.

## The exact-match trap

The schema says of `ignore_usernames`: *"Skip reviews for PRs authored by these usernames (exact match; not email addresses)."*

The raw login is `dependabot[bot]` — that is what the REST payload and the webhook carry (`user.login`, `type: Bot`, `id: 49699333`). The `gh` CLI renders the same actor as `app/dependabot`, which is its rendering of a GitHub App rather than a username. Configuring `app/dependabot` would parse, validate, read back correctly, and never match anything. The comment in the file records this so the next editor does not "fix" it.

## Not a reduction in security coverage

Dependabot PRs are where supply-chain risk enters, so the question is fair. The controls that actually cover them are independent of CodeRabbit, and all pass on Dependabot PRs today (verified on #190 and #191):

```
dependency-review              pass   <- the supply-chain gate proper
CodeQL / Analyze (js-ts)       pass
GitGuardian Security Checks    pass
build, visual, e2e-full,       pass
package-smoke, guard-no-skip-ci
```

None of these read `.coderabbit.yaml`. What a dependency bump needs is a gate, and it has five; what it does not need is a prose opinion on a version string.

## Proof

Mutation-proven, not merely parsed. A structural walk validates the file against the real published schema (`schema.v2.json`, fetched live), and both failure modes it exists to catch were induced:

| run | file state | result | red names which assertion |
|---|---|---|---|
| baseline | as committed | **green** | — |
| mutation 1 | `auto_review` block moved to document root | **red** | `UNKNOWN KEY auto_review`, `misplaced=true` |
| mutation 2 | login written as `app/dependabot` | **red** | `contains exact raw login "dependabot[bot]": false` |

The two reds are distinguishable rather than a generic failure: mutation 1 reports `unknownOrMistyped=1 misplaced=true`, mutation 2 reports `unknownOrMistyped=0 misplaced=false correctPath=false`. Mutation 1 is the one that matters — a block nested one level off parses cleanly, reads back cleanly, and is silently ignored, which is how a config change becomes a no-op that looks like a success.

File restored byte-identical after the mutations (`diff -q` → identical).

## Version

No version bump and no CHANGELOG entry. `0.25.5` is already on `main` and **has not been released** — there is no `v0.25.5` tag, because `release` is skipped behind the failing `e2e-full` gate. Bumping to `0.25.6` would strand `0.25.5` as another never-published version, the same way `0.25.2` and `0.25.3` were stranded. `.coderabbit.yaml` is also excluded from the packaged VSIX by `scripts/verifyVsixPackage.js`, so nothing here is user-facing.

## Test plan

- [x] Structural validation against the live `schema.v2.json` — every key resolves at its schema path
- [x] Mutation 1 (misplaced block) → red, naming the unknown key
- [x] Mutation 2 (wrong login spelling) → red, naming the exact-match assertion
- [x] `bun run format:check` — green (yaml is outside its glob; no formatting gate applies to this file)
- [x] Pre-commit hook — all checks pass, including the VSIX packaging verification
- [x] Raw login confirmed as `dependabot[bot]` against the REST API on #185, #190, #195

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes CodeRabbit’s existing Dependabot-review exclusion explicit in repository configuration.
- Adds `dependabot[bot]` to `reviews.auto_review.ignore_usernames`.
- Documents why the raw GitHub login must be used instead of the GitHub CLI’s `app/dependabot` rendering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .coderabbit.yaml | Adds a correctly nested exact-match exclusion so CodeRabbit skips automated reviews for Dependabot-authored pull requests. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/coderabbi..."](https://github.com/maheshkok/intelligit/commit/d9b9f82aef52ca65a193aeab5cb5ef71a51524bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53902751)</sub>

<!-- /greptile_comment -->