### PR TITLE
chore(ci): group minor and patch dependency bumps into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,25 @@ updates:
           prefix: "chore(ci)"
       labels:
           - dependencies
+      # Minor and patch bumps arrive as ONE pull request; majors stay ungrouped and keep arriving
+      # individually, because a major is the one that needs a human reading the changelog.
+      #
+      # Grouping is the answer to pull-request volume, and narrowing to majors-only is not. Every
+      # red Dependabot proposal this repository has held open was a MAJOR -- react-dom 19 against
+      # react 18, jsdom 28->30 lowercasing CSS custom property names, setup-node 4->7 -- while the
+      # minor and patch ones merged clean. A majors-only feed therefore drops exactly the updates
+      # that are safe to take and keeps exactly the ones that are not. It also drops most security
+      # fixes, which ship as patches: a CVE is remediated in 4.37.7, not in 5.0.0.
+      #
+      # The cost is real and worth stating: a group is all-or-nothing, so one member failing CI
+      # holds back every healthy member sharing its pull request. That is why the bun ecosystem
+      # below splits production from development instead of using a single group -- a broken
+      # development bump cannot then block a production one, or the reverse.
+      groups:
+          actions-minor-and-patch:
+              patterns:
+                  - "*"
+              update-types: ["minor", "patch"]
     # `bun`, not `npm`, because this repository's lockfile is `bun.lock` and every job installs with
     # `bun install --frozen-lockfile`. The npm ecosystem edits `package.json` and cannot write that
     # lockfile, so each proposal arrived with the two out of step and died on the install step
@@ -31,7 +50,12 @@ updates:
           prefix: "chore(deps)"
       labels:
           - dependencies
+      # Two groups rather than one, for the blast-radius reason given on the github-actions
+      # ecosystem above. Majors match neither and still open one pull request each.
       groups:
           safe-development-dependencies:
               dependency-type: development
+              update-types: ["minor", "patch"]
+          production-dependencies:
+              dependency-type: production
               update-types: ["minor", "patch"]


### PR DESCRIPTION
## What

Adds the two missing Dependabot groups so minor and patch bumps arrive as **one pull request per ecosystem**, and leaves majors ungrouped so each still gets its own review.

| Ecosystem | Group | Matches |
|---|---|---|
| `github-actions` | `actions-minor-and-patch` (new) | `patterns: ["*"]`, minor + patch |
| `bun` | `safe-development-dependencies` (existing) | dev deps, minor + patch |
| `bun` | `production-dependencies` (new) | prod deps, minor + patch |

Majors match no group and keep opening one PR each.

## Why not majors-only

The alternative on the table was narrowing Dependabot to majors only. That is the wrong direction:

- **Majors are the ones that break.** Every red proposal this repo has held open is a major — react-dom 19 against react 18 (#193), jsdom 28→30 lowercasing CSS custom property names (#195), setup-node 4→7 (#174). The minor and patch ones merged clean.
- **Security fixes ship as patches.** A CVE is remediated in 4.37.7, not in 5.0.0.

So majors-only drops exactly the updates that are safe to take and keeps exactly the ones that need a human. The fourteen open PRs were caused by *not grouping*, not by minor/patch existing.

Two groups on `bun` rather than one, because a grouped PR is all-or-nothing: one member failing CI holds back every healthy member sharing it. Splitting production from development bounds that.

## No version bump

Same reasoning as the CodeRabbit config in #197 — `.github/` is repository configuration, is not packaged into the VSIX, and has nothing user-facing to record.

## Test plan

Validated against the published Dependabot v2 schema (`schemastore dependabot-2.0.json`), **25 structural assertions, 0 failures**:

- each group resolves at `updates[].groups.<name>`, with its `update-types`, `patterns` / `dependency-type`
- no group matches `major`
- negative controls: no top-level `groups`; none under `schedule`; none under `commit-message`; `groups` is a mapping, not a list

**Mutation-proven** — each mutation goes red naming its own assertion:

| Mutation | Result |
|---|---|
| block relocated under `commit-message` (valid YAML, silently inert) | 4 red, incl. the `no groups under commit-message` negative control |
| `major` added to `update-types` | red on `excludes major` + the update-types equality |
| `production-dependencies` deleted | red on `exists` + both its properties |
| `dependency-type: production` → `prod` | red on the dependency-type equality |

A first attempt at the misnesting mutation added a duplicate `schedule:` key, which is a YAML parse error — it exited nonzero while printing no assertion at all. That is a crash, not proof, so it was redone as valid-but-misnested YAML, which is the failure actually being guarded against.

`prettier --check .github/dependabot.yml` clean; pre-commit ran lint, knip, dependency-cruiser, l10n validate + audit, all three typechecks, build, and package — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency update pull requests are now grouped monthly for minor and patch updates.
  * Development and production dependency updates are separated for easier review.
  * Major updates continue to be proposed individually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->