### PR TITLE
fix: report webview messages that never reach their view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.6] - 2026-08-17
+
+### Fixed
+
+- Fixed all four webview views throwing away the result of every message they send. VS Code answers a send three ways — delivered, accepted but not delivered, and failed outright — and each view discarded the answer, so a view that never received what it was sent looked, from the extension's side, exactly like one that did. This is the missing half of the blank commit panel addressed in 0.25.4: that release made the panel keep asking until it gets an answer, but when an answer never came there was no record anywhere of which direction the message was lost in, and the report left behind by a failed run could say only that the panel was empty. A send that does not land is now recorded with the view that sent it and the message that was lost.
+- Fixed a failed send to a closed view surfacing as an unhandled promise rejection inside the extension host — a crash report about a message the user never needed to know had a promise behind it. The same send failing on the spot rather than asynchronously could also interrupt whatever the extension was doing at the time, including displacing an error that was in the middle of being reported.
+
 ## [0.25.5] - 2026-08-16
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.5",
+    "version": "0.25.6",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";
+import { postWebviewMessage } from "./webviewDelivery";
 import type { Branch, Commit, CommitDetail, GitWorktree, ThemeFolderIconMap } from "../types";
 import type {
     BranchAction,
@@ -716,8 +717,14 @@ export class CommitGraphViewProvider implements vscode.WebviewViewProvider, Revi
         if (!valid) throw new Error("Unsupported review prompt answer.");
     }
 
+    /**
+     * A missing view is deliberately silent -- a closed graph is an ordinary state, not a fault.
+     * A message the view refuses or rejects is not; see {@link postWebviewMessage}.
+     */
     private postToWebview(msg: CommitGraphInbound): void {
-        this.view?.webview.postMessage(msg);
+        const view = this.view;
+        if (!view) return;
+        postWebviewMessage(view.webview, msg, "Commit graph");
     }
 
     /**

--- a/src/views/CommitInfoViewProvider.ts
+++ b/src/views/CommitInfoViewProvider.ts
@@ -5,6 +5,7 @@ import { IconThemeService } from "./shared/IconThemeService";
 import { isRedundantPost, serializeWebviewPayload } from "./shared/postedPayload";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { getErrorMessage } from "../utils/errors";
+import { postWebviewMessage } from "./webviewDelivery";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { isValidGitHash } from "../services/gitHelpers";
 
@@ -192,8 +193,14 @@ export class CommitInfoViewProvider implements vscode.WebviewViewProvider {
         this.lastPostedPayload = serialized;
     }
 
+    /**
+     * A missing view is deliberately silent -- a closed view is an ordinary state, not a fault.
+     * A message the view refuses or rejects is not; see {@link postWebviewMessage}.
+     */
     private postToWebview(msg: CommitInfoInbound): void {
-        this.view?.webview.postMessage(msg);
+        const view = this.view;
+        if (!view) return;
+        postWebviewMessage(view.webview, msg, "Commit info");
     }
 
     /**

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -14,6 +14,7 @@ import type { Branch, CommitDetail, ThemeFolderIconMap } from "../types";
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { decorateShelfFiles, shelfFilePaths } from "./shelfIconDecoration";
 import { getErrorMessage } from "../utils/errors";
+import { postWebviewMessage } from "./webviewDelivery";
 import { mapWithConcurrency } from "../utils/concurrency";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { abortMergeWithConfirmation } from "./mergeAbort";
@@ -2063,8 +2064,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         return true;
     }
 
+    /**
+     * A missing view is deliberately silent -- a closed panel is an ordinary state, not a fault.
+     * A message the view refuses or rejects is not; see {@link postWebviewMessage}.
+     */
     private postToWebview(msg: InboundMessage | CommitGraphInbound): void {
-        this.view?.webview.postMessage(msg);
+        const view = this.view;
+        if (!view) return;
+        postWebviewMessage(view.webview, msg, "Commit panel");
     }
     /**
      * Resolves the repository root used by file actions in the active panel.

--- a/src/views/UndockedViewProvider.ts
+++ b/src/views/UndockedViewProvider.ts
@@ -19,6 +19,7 @@ import { registerThemeChangeListeners, disposeAll } from "./shared/themeListener
 import { buildWebviewShellHtml } from "./webviewHtml";
 import { decorateShelfFiles, shelfFilePaths } from "./shelfIconDecoration";
 import { getErrorMessage } from "../utils/errors";
+import { postWebviewMessage } from "./webviewDelivery";
 import { assertRepoRelativePath } from "../utils/fileOps";
 import { assertValidBranchName } from "../utils/gitRefs";
 import {
@@ -2082,7 +2083,13 @@ export class UndockedViewProvider {
         return delivered;
     }
 
+    /**
+     * A missing panel is deliberately silent -- a closed panel is an ordinary state, not a fault.
+     * A message the panel refuses or rejects is not; see {@link postWebviewMessage}.
+     */
     private postToWebview(msg: UnifiedInbound): void {
-        this.panel?.webview.postMessage(msg);
+        const panel = this.panel;
+        if (!panel) return;
+        postWebviewMessage(panel.webview, msg, "Undocked panel");
     }
 }

--- a/src/views/webviewDelivery.ts
+++ b/src/views/webviewDelivery.ts
@@ -1,0 +1,67 @@
+import type * as vscode from "vscode";
+
+import { getErrorMessage } from "../utils/errors";
+
+/**
+ * The shape every host-to-webview message shares: a discriminator the report can name. Widening it
+ * to the individual protocol unions would tie the helper to four of them for no gain -- the only
+ * field it reads is the one they all agree on.
+ */
+interface TypedWebviewMessage {
+    readonly type: string;
+}
+
+function reportFailedPost(source: string, type: string, error: unknown): void {
+    console.error(
+        `[IntelliGit] ${source} failed to post a "${type}" message:`,
+        getErrorMessage(error),
+    );
+}
+
+/**
+ * Sends a message to a webview and reports a send that does not land.
+ *
+ * VS Code answers `postMessage` three ways -- delivered, accepted-but-not-delivered (a resolved
+ * `false`), and rejected -- and every view provider used to drop the returned promise, which
+ * collapsed all three into "success". A view that never received its hydration then looks, from the
+ * host's side, exactly like one that did; that is how a blank commit panel reaches CI carrying no
+ * host-side evidence at all. Dropping the promise also turned a rejecting `postMessage` into an
+ * unhandled rejection in the extension host.
+ *
+ * The report goes to `console.error` because that is the channel the E2E harness reads:
+ * `tests/e2e/pageObjects/intelliGitView.ts` folds the host's console into its failure message, so a
+ * message that never arrives names itself rather than only surfacing as an empty view.
+ *
+ * Nothing here retries, and nothing here throws -- including when `postMessage` fails synchronously
+ * rather than by rejecting. A webview that refused one message is not made healthier by a second,
+ * and callers post status updates from disposal and finally paths, where turning a lost message
+ * into a thrown error would break an operation that had otherwise succeeded.
+ *
+ * @param webview - Destination webview. Callers hold the "is there a view at all" check, because a
+ *   closed panel is an ordinary state rather than a fault worth logging.
+ * @param message - The payload; its `type` is what the report names.
+ * @param source - Human-readable name of the sending view, e.g. `"Commit panel"`. It is the only
+ *   way a reader can tell which of the four providers dropped the message.
+ */
+export function postWebviewMessage(
+    webview: Pick<vscode.Webview, "postMessage">,
+    message: TypedWebviewMessage,
+    source: string,
+): void {
+    let sent: Thenable<boolean>;
+    try {
+        sent = webview.postMessage(message);
+    } catch (error: unknown) {
+        reportFailedPost(source, message.type, error);
+        return;
+    }
+    void Promise.resolve(sent).then(
+        (delivered) => {
+            if (delivered) return;
+            console.error(
+                `[IntelliGit] ${source} webview did not receive a "${message.type}" message.`,
+            );
+        },
+        (error: unknown) => reportFailedPost(source, message.type, error),
+    );
+}

--- a/tests/e2e/pageObjects/intelliGitView.ts
+++ b/tests/e2e/pageObjects/intelliGitView.ts
@@ -28,9 +28,47 @@ const REVEAL_POLL_INTERVAL_MS = 250;
  */
 const ACTIVITY_BAR_ITEM = ".activitybar .action-item";
 
+/** How many console lines the timeout message may carry. The workbench is chatty, so keeping every
+ * message would evict the interesting one long before the failure; the trail keeps errors and
+ * warnings only, and `consoleSeen` accounts for the rest. */
+const CONSOLE_TRAIL_LIMIT = 25;
+
+/** How much of one console line survives into the message. A stack trace pasted whole would push
+ * every other line out of a bounded trail. */
+const CONSOLE_LINE_LIMIT = 300;
+
+/** Webview documents are served from this scheme, so a console message's source URL says whether it
+ * came from a webview or from the workbench shell around it. */
+const WEBVIEW_URL_SCHEME = "vscode-webview://";
+
 /** Locates IntelliGit's webview surfaces: the activity-bar view and the full-width graph panel. */
 export class IntelliGitView {
-    public constructor(private readonly page: Page) {}
+    /** Errors and warnings the page emitted, newest last. See `describeConsole`. */
+    private consoleTrail: readonly string[] = [];
+
+    /** How many console messages arrived at all, and how many of those came from a webview
+     * document. These are the instrument's own proof -- see `describeConsole`. */
+    private consoleSeen = 0;
+    private webviewConsoleSeen = 0;
+
+    public constructor(private readonly page: Page) {
+        page.on("console", (message) => {
+            const fromWebview = message.location().url.startsWith(WEBVIEW_URL_SCHEME);
+            this.consoleSeen += 1;
+            if (fromWebview) this.webviewConsoleSeen += 1;
+            const type = message.type();
+            if (type !== "error" && type !== "warning") return;
+            this.record(`${type}${fromWebview ? "(webview)" : ""}: ${message.text()}`);
+        });
+        page.on("pageerror", (error) => this.record(`pageerror: ${error.message}`));
+    }
+
+    /** Appends `line` to the trail, keeping the newest `CONSOLE_TRAIL_LIMIT` entries. */
+    private record(line: string): void {
+        const bounded =
+            line.length > CONSOLE_LINE_LIMIT ? `${line.slice(0, CONSOLE_LINE_LIMIT)}…` : line;
+        this.consoleTrail = [...this.consoleTrail, bounded].slice(-CONSOLE_TRAIL_LIMIT);
+    }
 
     /** Reveals IntelliGit in the sidebar and returns its webview document. */
     public async reveal(timeoutMs = DEFAULT_REVEAL_TIMEOUT_MS): Promise<FrameLocator> {
@@ -66,7 +104,8 @@ export class IntelliGitView {
             if (Date.now() > deadline) {
                 throw new Error(
                     `No IntelliGit webview rendered "${marker}" within ${timeoutMs}ms.\n` +
-                        `  webviews present:\n  ${await this.describeWebviews()}`,
+                        `  webviews present:\n  ${await this.describeWebviews()}\n` +
+                        `  console: ${this.describeConsole()}`,
                 );
             }
             await this.page.waitForTimeout(REVEAL_POLL_INTERVAL_MS);
@@ -150,5 +189,28 @@ export class IntelliGitView {
             }),
         );
         return described.join("\n  ");
+    }
+
+    /**
+     * Reports what the page logged, for the timeout message only.
+     *
+     * The commit panel fails this way while its document renders `commit-panel-awaiting-hydration`,
+     * which is React's FIRST render -- so React mounted, and what did not finish is the effect that
+     * acquires the VS Code API and posts `ready`. If that effect threw, the reason is a console
+     * error and nothing else in the harness can see it: the retained Playwright trace carries action
+     * events only, with no console stream at all.
+     *
+     * The counts are here because a blind listener and a quiet page produce the same empty list, and
+     * a clean console is the finding that would send the next instrument elsewhere -- so it has to
+     * be worth believing. `seen` proves the listener was attached and receiving; `from webviews`
+     * proves it was receiving from webview documents specifically, rather than only from the
+     * workbench shell around them. `from webviews: 0` means this line answers nothing.
+     */
+    private describeConsole(): string {
+        const counts = `${this.consoleSeen} seen (${this.webviewConsoleSeen} from webviews)`;
+        return this.consoleTrail.length === 0
+            ? `${counts}; no errors or warnings`
+            : `${counts}; ${this.consoleTrail.length} error/warning:\n    ` +
+                  this.consoleTrail.join("\n    ");
     }
 }

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -112,7 +112,10 @@ const showTextDocument = vi.fn(async () => undefined);
 const executeCommand = vi.fn(async () => undefined);
 const openExternal = vi.fn(async () => true);
 const openTextDocument = vi.fn(async () => ({ getText: () => "local file contents" }));
-const postMessageSpy = vi.fn();
+// Resolves `true` because that is what a live `vscode.Webview.postMessage` returns; a bare
+// `vi.fn()` hands back `undefined`, which the host now correctly reads as "the view never got it"
+// and reports. Every provider in this file would otherwise log an undelivered message per post.
+const postMessageSpy = vi.fn().mockResolvedValue(true);
 const fileSystemWatchers: FakeFileSystemWatcher[] = [];
 const createdWebviewPanels: Array<{
     panel: Record<string, unknown>;

--- a/tests/unit/e2e/pageObjects.test.ts
+++ b/tests/unit/e2e/pageObjects.test.ts
@@ -109,8 +109,14 @@ describe("Workbench", () => {
 
             // The second chord is the finding. Retrying only the failed step would keep driving the
             // widget that already went away, which is the timeout this fixes.
-            expect(keyboard.press, "a closed palette has to be re-opened, not re-driven").toHaveBeenCalledTimes(2);
-            expect(commandInput.fill, "the re-opened palette has to be typed into again").toHaveBeenCalledTimes(2);
+            expect(
+                keyboard.press,
+                "a closed palette has to be re-opened, not re-driven",
+            ).toHaveBeenCalledTimes(2);
+            expect(
+                commandInput.fill,
+                "the re-opened palette has to be typed into again",
+            ).toHaveBeenCalledTimes(2);
             expect(option.click).toHaveBeenCalledTimes(step === "click" ? 2 : 1);
         },
     );
@@ -319,6 +325,9 @@ describe("IntelliGitView", () => {
     const SIDEBAR_MARKER = '[data-testid="commit-panel-tab-row"]';
     const GRAPH_PANEL_MARKER = '[data-testid="commit-list-viewport"]';
 
+    /** Source URL of a console message that came from a webview document rather than the shell. */
+    const WEBVIEW_URL = "vscode-webview://0x1/index.html";
+
     /** `[data-testid="x"]` -> `x`, so a fake body can carry the ids its selectors ask for. */
     function testIdOf(selector: string): string {
         return selector.replace('[data-testid="', "").replace('"]', "");
@@ -403,8 +412,14 @@ describe("IntelliGitView", () => {
     function workbenchPage(webviews: readonly { outer: unknown }[]): {
         page: Page;
         click: ReturnType<typeof vi.fn>;
+        emitConsole: (type: string, text: string, url: string) => void;
     } {
         const click = vi.fn();
+        // The page object attaches `console`/`pageerror` listeners in its constructor. Modelling
+        // `on` as a real registry rather than a no-op is what lets the tests below DRIVE the
+        // console instrument; a no-op fake would merely tolerate it, and an instrument nothing
+        // feeds is the one thing a report about a silent page must not be.
+        const listeners = new Map<string, ((payload: never) => void)[]>();
         const intelliGitLabel = Symbol("getByLabel(IntelliGit, { exact: true })");
         const page = {
             locator: (selector: string) => {
@@ -428,8 +443,20 @@ describe("IntelliGitView", () => {
                 return intelliGitLabel;
             },
             waitForTimeout: vi.fn().mockResolvedValue(undefined),
+            on: (event: string, listener: (payload: never) => void) => {
+                listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+            },
         } as unknown as Page;
-        return { page, click };
+        const emitConsole = (type: string, text: string, url: string): void => {
+            for (const listener of listeners.get("console") ?? []) {
+                (listener as unknown as (message: unknown) => void)({
+                    type: () => type,
+                    text: () => text,
+                    location: () => ({ url }),
+                });
+            }
+        };
+        return { page, click, emitConsole };
     }
 
     // VS Code renders a view's badge as a sibling of the labelled anchor, overlapping it, so an
@@ -504,6 +531,55 @@ describe("IntelliGitView", () => {
         const { page } = workbenchPage([]);
 
         await expect(new IntelliGitView(page).revealPanel(50)).rejects.toThrow("(none attached)");
+    });
+
+    // The panel fails while rendering `commit-panel-awaiting-hydration` -- React's FIRST render --
+    // so what did not finish is the effect that acquires the VS Code API and posts `ready`. If that
+    // effect threw, the reason is a console error, and the retained Playwright trace carries action
+    // events only: no console stream at all. A report that drops the console drops the one place
+    // the cause could still be.
+    it("carries the page's errors and warnings into the timeout message", async () => {
+        const { page, emitConsole } = workbenchPage([webview([])]);
+        const view = new IntelliGitView(page);
+
+        emitConsole("error", "Uncaught TypeError: acquireVsCodeApi is not a function", WEBVIEW_URL);
+        emitConsole("log", "ordinary chatter nobody needs", WEBVIEW_URL);
+
+        await expect(view.revealPanel(50)).rejects.toThrow(
+            /console: 2 seen \(2 from webviews\); 1 error\/warning:\s+error\(webview\): Uncaught TypeError/,
+        );
+    });
+
+    /**
+     * The counts are the instrument's own proof, and this is the case that needs them: a listener
+     * that was never attached and a page that logged nothing produce the same empty trail. Without
+     * `seen`, "no errors or warnings" is the most misleading line in the report -- it is the finding
+     * that would send the next investigation somewhere else entirely.
+     */
+    it("shows a quiet page was heard, not merely unlistened-to", async () => {
+        const { page, emitConsole } = workbenchPage([webview([])]);
+        const view = new IntelliGitView(page);
+
+        emitConsole("log", "ordinary chatter nobody needs", WEBVIEW_URL);
+
+        await expect(view.revealPanel(50)).rejects.toThrow(
+            /console: 1 seen \(1 from webviews\); no errors or warnings/,
+        );
+    });
+
+    // Webview documents and the workbench shell around them both log here, and only the first kind
+    // can explain an unhydrated panel. A count that lumps them together reads as evidence about the
+    // webview when it may be entirely about the shell.
+    it("separates workbench-shell console output from webview output", async () => {
+        const { page, emitConsole } = workbenchPage([webview([])]);
+        const view = new IntelliGitView(page);
+
+        emitConsole("warning", "shell warning", "vscode-file://vscode-app/workbench.html");
+        emitConsole("warning", "webview warning", WEBVIEW_URL);
+
+        await expect(view.revealPanel(50)).rejects.toThrow(
+            /console: 2 seen \(1 from webviews\); 2 error\/warning/,
+        );
     });
 });
 

--- a/tests/unit/views/CommitPanelViewProvider.test.ts
+++ b/tests/unit/views/CommitPanelViewProvider.test.ts
@@ -62,6 +62,7 @@ import { assertDirtyPostcondition } from "../../fixtures/repo/scenarios";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { createScratchWorkspaces } from "../fixtures/scratchWorkspaces";
 import type { CommitDetail } from "../../../src/types";
+import type { CommitGraphInbound } from "../../../src/webviews/protocol/commitGraphTypes";
 
 /** A resolve-context/token stand-in `resolveWebviewView` never reads -- same reasoning as
  * `recordCommitPanelWebviewFixture.ts`'s own `INERT_RESOLVE_CONTEXT`/`INERT_CANCELLATION_TOKEN`. */
@@ -90,7 +91,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * `webview.*`, `onDidDispose`, `visible`, `onDidChangeVisibility` -- rather than the narrower set
  * `CommitInfoViewProvider.test.ts`'s own inspectable double needs.
  */
-function createInspectableCommitPanelWebviewView(): {
+/**
+ * The three answers a real VS Code host gives `webview.postMessage`. `"refused"` is a resolved
+ * `false` -- the host took the call and did not deliver it -- and `"rejected"` is the promise
+ * failing outright. Both are indistinguishable from `"delivered"` to a caller that drops the
+ * returned promise, which is what the delivery-failure block at the bottom of this file pins down.
+ */
+type DeliveryOutcome = "delivered" | "refused" | "rejected";
+
+function createInspectableCommitPanelWebviewView(outcome: DeliveryOutcome = "delivered"): {
     readonly webviewView: vscode.WebviewView;
     readonly posted: unknown[];
     receiveMessage(message: unknown): Promise<void>;
@@ -109,7 +118,10 @@ function createInspectableCommitPanelWebviewView(): {
         },
         postMessage: (message: unknown) => {
             posted.push(message);
-            return Promise.resolve(true);
+            if (outcome === "rejected") {
+                return Promise.reject(new Error("Webview is disposed"));
+            }
+            return Promise.resolve(outcome === "delivered");
         },
     };
 
@@ -141,8 +153,7 @@ function setCommitDetailMessages(posted: readonly unknown[]): Record<string, unk
 
 function messagesOfType(posted: readonly unknown[], type: string): Record<string, unknown>[] {
     return posted.filter(
-        (message): message is Record<string, unknown> =>
-            isRecord(message) && message.type === type,
+        (message): message is Record<string, unknown> => isRecord(message) && message.type === type,
     );
 }
 
@@ -267,74 +278,67 @@ describe("CommitPanelViewProvider hydration re-ask", () => {
         await scratch.removeAll();
     });
 
-    it(
-        "answers a re-ask from state it already holds, without repeating the startup Git reads",
-        async () => {
-            const parentDir = await mkdtemp(
-                path.join(tmpdir(), "intelligit-commit-panel-reask-test-"),
-            );
-            scratch.register(parentDir);
-            const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+    it("answers a re-ask from state it already holds, without repeating the startup Git reads", async () => {
+        const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-commit-panel-reask-test-"));
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
 
-            const constructorOptions = buildCommitPanelConstructorOptions();
-            const gitOps = new GitOps(
-                new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
-            );
-            const provider = new CommitPanelViewProvider(
-                createFakeExtensionUri(),
-                gitOps,
-                createFakeUriFromPath(workspace.root),
-                createEmptyWorkspaceMemento(),
-                undefined, // secrets -- nothing on this path reads a secret.
-                constructorOptions.shelfServiceForRepository,
-                constructorOptions.shelfRemoveOnUnshelve,
-                constructorOptions.commitMessageGenerationCoordinator,
-                constructorOptions.interactiveRebaseStorageRoot,
-            );
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const gitOps = new GitOps(
+            new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
+        );
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            gitOps,
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
 
-            const { webviewView, posted, receiveMessage } =
-                createInspectableCommitPanelWebviewView();
-            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const { webviewView, posted, receiveMessage } = createInspectableCommitPanelWebviewView();
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
 
-            await receiveMessage({ type: "ready", attempt: 1 });
-            await flushMicrotasks();
-            const afterFirst = posted.length;
-            expect(
-                messagesOfType(posted, "setRepositories").length,
-                "a first announcement must be hydrated",
-            ).toBeGreaterThanOrEqual(1);
-            expect(
-                messagesOfType(posted, "refreshing").length,
-                "a first announcement must run the startup refresh -- otherwise the assertion " +
-                    "below proves nothing, because `refreshing` would be absent either way",
-            ).toBeGreaterThan(0);
+        await receiveMessage({ type: "ready", attempt: 1 });
+        await flushMicrotasks();
+        const afterFirst = posted.length;
+        expect(
+            messagesOfType(posted, "setRepositories").length,
+            "a first announcement must be hydrated",
+        ).toBeGreaterThanOrEqual(1);
+        expect(
+            messagesOfType(posted, "refreshing").length,
+            "a first announcement must run the startup refresh -- otherwise the assertion " +
+                "below proves nothing, because `refreshing` would be absent either way",
+        ).toBeGreaterThan(0);
 
-            const hydrationsBeforeReAsk = messagesOfType(posted, "setRepositories").length;
-            const refreshesBeforeReAsk = messagesOfType(posted, "refreshing").length;
+        const hydrationsBeforeReAsk = messagesOfType(posted, "setRepositories").length;
+        const refreshesBeforeReAsk = messagesOfType(posted, "refreshing").length;
 
-            // The webview is still mounted and still empty: it never received the answer above.
-            await receiveMessage({ type: "ready", attempt: 2 });
-            await flushMicrotasks();
+        // The webview is still mounted and still empty: it never received the answer above.
+        await receiveMessage({ type: "ready", attempt: 2 });
+        await flushMicrotasks();
 
-            expect(
-                messagesOfType(posted, "setRepositories").length,
-                "a re-ask must be answered -- the panel is unhydrated precisely because the " +
-                    "previous answer never arrived, so withholding this one strands it forever",
-            ).toBeGreaterThan(hydrationsBeforeReAsk);
-            expect(
-                messagesOfType(posted, "refreshing").length,
-                "a re-ask must NOT repeat the startup Git refresh; the webview re-asks on a " +
-                    "timer, so paying full price per attempt is the cost that forced the retry " +
-                    "to give up and leave the panel blank",
-            ).toBe(refreshesBeforeReAsk);
-            expect(
-                posted.length,
-                "a re-ask must still deliver the host's cached working-tree state, not the " +
-                    "repository list alone -- the dropped answer took the file list with it",
-            ).toBeGreaterThan(afterFirst + 1);
-        },
-        30_000,
-    );
+        expect(
+            messagesOfType(posted, "setRepositories").length,
+            "a re-ask must be answered -- the panel is unhydrated precisely because the " +
+                "previous answer never arrived, so withholding this one strands it forever",
+        ).toBeGreaterThan(hydrationsBeforeReAsk);
+        expect(
+            messagesOfType(posted, "refreshing").length,
+            "a re-ask must NOT repeat the startup Git refresh; the webview re-asks on a " +
+                "timer, so paying full price per attempt is the cost that forced the retry " +
+                "to give up and leave the panel blank",
+        ).toBe(refreshesBeforeReAsk);
+        expect(
+            posted.length,
+            "a re-ask must still deliver the host's cached working-tree state, not the " +
+                "repository list alone -- the dropped answer took the file list with it",
+        ).toBeGreaterThan(afterFirst + 1);
+    }, 30_000);
 
     /**
      * The other direction of the same drop, and the one that makes "answer a re-ask from cache" a
@@ -349,50 +353,158 @@ describe("CommitPanelViewProvider hydration re-ask", () => {
      * alone. The assertion is on the delivered file list rather than on any internal marker: an
      * unhydrated panel's whole problem is what it did or did not receive.
      */
-    it(
-        "does the full startup read for a re-ask when the first attempt never reached the host",
-        async () => {
-            const parentDir = await mkdtemp(
-                path.join(tmpdir(), "intelligit-commit-panel-cold-reask-test-"),
-            );
-            scratch.register(parentDir);
-            const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+    it("does the full startup read for a re-ask when the first attempt never reached the host", async () => {
+        const parentDir = await mkdtemp(
+            path.join(tmpdir(), "intelligit-commit-panel-cold-reask-test-"),
+        );
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
 
-            const constructorOptions = buildCommitPanelConstructorOptions();
-            const gitOps = new GitOps(
-                new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
-            );
-            const provider = new CommitPanelViewProvider(
-                createFakeExtensionUri(),
-                gitOps,
-                createFakeUriFromPath(workspace.root),
-                createEmptyWorkspaceMemento(),
-                undefined, // secrets -- nothing on this path reads a secret.
-                constructorOptions.shelfServiceForRepository,
-                constructorOptions.shelfRemoveOnUnshelve,
-                constructorOptions.commitMessageGenerationCoordinator,
-                constructorOptions.interactiveRebaseStorageRoot,
-            );
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const gitOps = new GitOps(
+            new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env)),
+        );
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            gitOps,
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
 
-            const { webviewView, posted, receiveMessage } =
-                createInspectableCommitPanelWebviewView();
-            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const { webviewView, posted, receiveMessage } = createInspectableCommitPanelWebviewView();
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
 
-            // No attempt 1 anywhere: this is what a `ready` lost on the way in looks like from the
-            // host's side -- the panel is on its second try and the host is hearing from it first.
-            await receiveMessage({ type: "ready", attempt: 2 });
-            await flushMicrotasks();
+        // No attempt 1 anywhere: this is what a `ready` lost on the way in looks like from the
+        // host's side -- the panel is on its second try and the host is hearing from it first.
+        await receiveMessage({ type: "ready", attempt: 2 });
+        await flushMicrotasks();
 
-            const deliveredFileCounts = messagesOfType(posted, "update").map((message) =>
-                Array.isArray(message.files) ? message.files.length : -1,
-            );
-            expect(
-                Math.max(-1, ...deliveredFileCounts),
-                "the workspace is dirty, so at least one delivered snapshot must carry files; " +
-                    "skipping the startup read here posts an empty tree the panel cannot tell " +
-                    "apart from a clean one",
-            ).toBeGreaterThan(0);
-        },
-        30_000,
-    );
+        const deliveredFileCounts = messagesOfType(posted, "update").map((message) =>
+            Array.isArray(message.files) ? message.files.length : -1,
+        );
+        expect(
+            Math.max(-1, ...deliveredFileCounts),
+            "the workspace is dirty, so at least one delivered snapshot must carry files; " +
+                "skipping the startup read here posts an empty tree the panel cannot tell " +
+                "apart from a clean one",
+        ).toBeGreaterThan(0);
+    }, 30_000);
+});
+
+/**
+ * `postMessage` is the only wire the panel has, and VS Code answers it three ways: delivered,
+ * accepted-but-not-delivered (a resolved `false`), and rejected. The host used to treat all three
+ * as success -- `this.view?.webview.postMessage(msg)`, promise dropped -- so a panel that never
+ * received its hydration looked, from the extension's side, exactly like one that did. That is the
+ * shape of the intermittent blank commit panel in CI: the panel sits at `awaiting-hydration`
+ * through every retry while the host believes it answered each one.
+ *
+ * These tests are about the DIAGNOSTIC, not about recovery. Nothing here can make a dead webview
+ * accept a message; what it can do is stop a failure from being indistinguishable from a success.
+ * The assertion is on `console.error` specifically because that is the channel the E2E harness
+ * reads -- `tests/e2e/pageObjects/intelliGitView.ts` folds the extension host's console into its
+ * failure message -- so the next CI red names which leg dropped the message instead of only
+ * reporting that the panel came up blank.
+ *
+ * The rejection case carries a second defect: the old code left the returned promise floating, so
+ * a rejecting `postMessage` surfaced in the host as an unhandled rejection. Asserting the reason
+ * reaches the log proves a rejection handler is attached, which is what prevents it.
+ *
+ * `showRebaseDialog` is the vehicle because it is the one public method that reaches
+ * `postToWebview` in a single call with no git I/O behind it -- the wire is the subject here, not
+ * whatever payload happens to be travelling on it.
+ */
+describe("CommitPanelViewProvider webview delivery failures", () => {
+    let restoreConsole: (() => void) | undefined;
+
+    afterEach(() => {
+        restoreConsole?.();
+        restoreConsole = undefined;
+    });
+
+    function captureConsoleErrors(): string[] {
+        const lines: string[] = [];
+        const spy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+            lines.push(args.map((arg) => String(arg)).join(" "));
+        });
+        restoreConsole = () => spy.mockRestore();
+        return lines;
+    }
+
+    /** No disk is touched on this path: nothing between construction and `postToWebview` runs git. */
+    function resolveProviderWith(outcome: DeliveryOutcome): {
+        provider: CommitPanelViewProvider;
+        posted: unknown[];
+    } {
+        const repoRoot = path.join(tmpdir(), "intelligit-delivery-failure-no-io");
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(repoRoot)),
+            createFakeUriFromPath(repoRoot),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+        const { webviewView, posted } = createInspectableCommitPanelWebviewView(outcome);
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        return { provider, posted };
+    }
+
+    function rebaseDialogMessage(): Extract<CommitGraphInbound, { type: "showRebaseDialog" }> {
+        return {
+            type: "showRebaseDialog",
+            requestId: "delivery-failure-test",
+            commits: [],
+            branch: "refs/heads/main",
+            hasPushed: false,
+        };
+    }
+
+    it("reports a message the webview accepted and never delivered", async () => {
+        const errors = captureConsoleErrors();
+        const { provider, posted } = resolveProviderWith("refused");
+
+        provider.showRebaseDialog(rebaseDialogMessage());
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(posted, "showRebaseDialog"),
+            "the message must still be handed to VS Code -- this is about the answer, not the send",
+        ).toHaveLength(1);
+        expect(
+            errors.join("\n"),
+            "a resolved `false` means the panel never got the message; saying nothing about it " +
+                "leaves an unhydrated panel indistinguishable from a hydrated one, which is " +
+                "precisely why the blank-panel failures in CI carry no host-side evidence",
+        ).toContain("showRebaseDialog");
+    });
+
+    it("reports a message postMessage rejected, and keeps the reason", async () => {
+        const errors = captureConsoleErrors();
+        const { provider } = resolveProviderWith("rejected");
+
+        provider.showRebaseDialog(rebaseDialogMessage());
+        await flushMicrotasks();
+
+        const reported = errors.join("\n");
+        expect(
+            reported,
+            "a rejected postMessage was dropped on an un-awaited promise, which both hid the " +
+                "failure and raised an unhandled rejection in the extension host",
+        ).toContain("showRebaseDialog");
+        expect(
+            reported,
+            "reporting that a post failed without the reason leaves the next reader exactly " +
+                "where the silent version did -- the cause is the whole payload",
+        ).toContain("Webview is disposed");
+    });
 });

--- a/tests/unit/views/webviewDelivery.test.ts
+++ b/tests/unit/views/webviewDelivery.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Contract tests for the one place four view providers now send through.
+ *
+ * The bug this replaced was `this.view?.webview.postMessage(msg)` -- promise dropped -- repeated in
+ * `CommitPanelViewProvider`, `CommitGraphViewProvider`, `CommitInfoViewProvider`, and
+ * `UndockedViewProvider`. VS Code answers `postMessage` three ways and that line treated all three
+ * as success, so a view that never received its hydration was indistinguishable, from the host's
+ * side, from one that did. It also left a rejecting `postMessage` as an unhandled rejection in the
+ * extension host.
+ *
+ * These tests are written against the three answers rather than against the implementation: each
+ * one names an outcome a real host produces and asserts what a reader of the log can then tell.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { postWebviewMessage } from "../../../src/views/webviewDelivery";
+
+/** Drains the microtask queue so a `then` handler attached inside the call under test has run. */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("postWebviewMessage", () => {
+    let restoreConsole: (() => void) | undefined;
+
+    afterEach(() => {
+        restoreConsole?.();
+        restoreConsole = undefined;
+    });
+
+    function captureConsoleErrors(): string[] {
+        const lines: string[] = [];
+        const spy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+            lines.push(args.map((arg) => String(arg)).join(" "));
+        });
+        restoreConsole = () => spy.mockRestore();
+        return lines;
+    }
+
+    /**
+     * VS Code types `postMessage` as `Thenable<boolean>`, which is `then`-only -- there is no
+     * `.catch` on it. Tests that hand back a real `Promise` would keep passing an implementation
+     * that reached for `.catch`, and that implementation would throw against the real API. So the
+     * doubles here are deliberately `then`-only.
+     */
+    function thenableWebview(settled: PromiseLike<boolean>): {
+        postMessage: () => PromiseLike<boolean>;
+    } {
+        return {
+            postMessage: () => ({
+                then: <A, B>(
+                    onFulfilled?: (value: boolean) => A | PromiseLike<A>,
+                    onRejected?: (reason: unknown) => B | PromiseLike<B>,
+                ) => settled.then(onFulfilled, onRejected),
+            }),
+        };
+    }
+
+    it("says nothing when the message is delivered", async () => {
+        const errors = captureConsoleErrors();
+
+        postWebviewMessage(
+            thenableWebview(Promise.resolve(true)),
+            { type: "update" },
+            "Commit panel",
+        );
+        await flushMicrotasks();
+
+        expect(
+            errors,
+            "a delivered message is the ordinary case; logging it would bury the failures this " +
+                "helper exists to surface",
+        ).toEqual([]);
+    });
+
+    it("reports a message the host accepted and did not deliver", async () => {
+        const errors = captureConsoleErrors();
+
+        postWebviewMessage(
+            thenableWebview(Promise.resolve(false)),
+            { type: "setRepositories" },
+            "Commit panel",
+        );
+        await flushMicrotasks();
+
+        const reported = errors.join("\n");
+        expect(
+            reported,
+            "a resolved `false` is the host saying the view never got it -- the type is how a " +
+                "reader knows WHICH message was lost",
+        ).toContain("setRepositories");
+        expect(
+            reported,
+            "four providers send through this helper, so a report that does not name its source " +
+                "cannot be traced back to a view",
+        ).toContain("Commit panel");
+    });
+
+    it("reports a rejected send together with its reason", async () => {
+        const errors = captureConsoleErrors();
+
+        postWebviewMessage(
+            thenableWebview(Promise.reject(new Error("Webview is disposed"))),
+            { type: "setCommitDetail" },
+            "Commit graph",
+        );
+        await flushMicrotasks();
+
+        const reported = errors.join("\n");
+        expect(reported, "the lost message must be identifiable").toContain("setCommitDetail");
+        expect(reported, "the sending view must be identifiable").toContain("Commit graph");
+        expect(
+            reported,
+            "reporting that a post failed without the reason leaves the reader exactly where the " +
+                "silent version did",
+        ).toContain("Webview is disposed");
+    });
+
+    /**
+     * The rejection arm is not only a log line. Without it the promise rejects with nothing
+     * attached, and Node raises `unhandledRejection` in the extension host -- a crash report for
+     * what is really a lost message. Listening for the event directly, rather than relying on
+     * Vitest failing the run, is what makes this an assertion instead of a formality: it fails on
+     * this test's own line, and it fails whether or not the runner happens to police the process.
+     */
+    it("handles a rejection rather than leaving it to the extension host", async () => {
+        captureConsoleErrors();
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown): void => {
+            unhandled.push(reason);
+        };
+        process.on("unhandledRejection", onUnhandled);
+        try {
+            postWebviewMessage(
+                thenableWebview(Promise.reject(new Error("channel closed"))),
+                { type: "error" },
+                "Undocked panel",
+            );
+            // Node raises the event a full turn after the microtask queue drains, so one flush is
+            // not enough to observe it.
+            await flushMicrotasks();
+            await flushMicrotasks();
+        } finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+
+        expect(
+            unhandled.map((reason) => String(reason)),
+            "an unattended rejection reaches the host as a crash report about a message the user " +
+                "never needed to know had a promise behind it",
+        ).toEqual([]);
+    });
+
+    /**
+     * The other way a real `postMessage` fails: throwing on the spot rather than rejecting. Every
+     * caller reaches this helper from a plain synchronous statement -- several from disposal and
+     * error-handling paths -- so a throw here would replace a lost message with a broken operation,
+     * and in a `catch` block would displace the error being reported.
+     */
+    it("reports rather than throws when postMessage fails synchronously", async () => {
+        const errors = captureConsoleErrors();
+        const throwingWebview = {
+            postMessage: (): Thenable<boolean> => {
+                throw new Error("Webview is disposed");
+            },
+        };
+
+        expect(() =>
+            postWebviewMessage(throwingWebview, { type: "update" }, "Commit info"),
+        ).not.toThrow();
+        await flushMicrotasks();
+
+        const reported = errors.join("\n");
+        expect(reported, "the lost message must still be identifiable").toContain("update");
+        expect(reported, "the sending view must still be identifiable").toContain("Commit info");
+        expect(
+            reported,
+            "a synchronous failure is as invisible as a rejected one if it is only swallowed",
+        ).toContain("Webview is disposed");
+    });
+});


### PR DESCRIPTION
## What this is

Investigating the intermittent blank commit panel (Bug A), I found the host cannot tell a delivered message from a lost one. **This is not yet a root cause for the blank panel** — it makes the failure legible so the next CI red names which leg dropped the `ready`.

## The defect

All four view providers sent through:

```ts
private postToWebview(msg: InboundMessage): void {
    this.view?.webview.postMessage(msg);   // returned promise dropped
}
```

VS Code answers `postMessage` **three** ways — delivered (`true`), accepted-but-not-delivered (a resolved `false`), and rejected. Dropping the answer collapsed all three into "success", so a view that never received its hydration looked, from the host's side, exactly like one that did. That is why the blank panel reaches CI carrying no host-side evidence.

Dropping the promise had two further consequences:

- a rejecting `postMessage` became an **unhandled rejection** in the extension host (reproduced live — vitest traced it to `CommitPanelViewProvider.postToWebview` at `src/views/CommitPanelViewProvider.ts:2067`);
- a `postMessage` that failed **synchronously** escaped into callers that reach this from disposal and `finally` paths, where it would displace the error already being reported.

`UndockedViewProvider` already had the correct awaited pattern four lines above its broken `postToWebview` — the house knew better and this one method was missed.

## The change

One `postWebviewMessage` helper (`src/views/webviewDelivery.ts`) replaces four identical silent drops. It reports a send that does not land, naming both the sending view and the message type. It reports to `console.error` because that is the channel the E2E harness reads.

`IntelliGitView` now folds the page's console into its timeout message, with counts — `N seen (M from webviews)` — so a clean console is worth believing. A blind listener and a quiet page otherwise produce the same empty list.

Two test doubles were unfaithful to the API they stand in for, and each hid one half of this:

- `postMessageSpy = vi.fn()` returned `undefined` where a live webview returns `Thenable<boolean>`;
- the workbench page fake had no `.on`, so nothing could feed the console instrument.

Both corrected. That is making a double faithful, not weakening an assertion.

## Proof

**13 mutations, every one red on a named assertion:**

| | mutation | red assertion |
|---|---|---|
| H1 | no report on refused delivery | `reports a message the host accepted and did not deliver` |
| H2 | rejection arm removed | `handles a rejection rather than leaving it to the extension host` |
| H3 | synchronous throw no longer caught | `reports rather than throws when postMessage fails synchronously` |
| H4 | reports every delivery, success included | `says nothing when the message is delivered` |
| H5 | failure reported without its reason | `expected '…failed to p…' to contain 'Webview is disposed'` |
| I1 | console listener never attached | all 3 instrument tests |
| I2 | counts dropped from the report | all 3 instrument tests |
| I3 | shell output counted as webview output | `separates workbench-shell console output from webview output` |
| I4 | severity filter dropped | 2 instrument tests |

Plus 4 on the provider before extraction. One mutation was **discarded for going red on the wrong assertion** and redone — it removed `${msg.type}` as well as the reason, so the first assertion fired instead of the one under test.

**Gates:** `bun run typecheck` rc=0 · `bun run lint:strict` rc=0 · `bun run format:check` rc=0 · `bun run test` → **288 files / 3974 tests, rc=0**.

**Blast radius:** `detect_changes(scope: "compare", base_ref: "main")` — 9 changed symbols, `affected_count: 0`, `risk_level: low`, no affected execution flows.

## Version

0.25.5 → **0.25.6**, CHANGELOG entry added.

## Found in passing, not fixed here

The instrument surfaced `RepositoryLockBusyError: Repository mutation is already in progress` from shelf recovery at startup (`src/repository/repositoryMode.ts:176`) on an otherwise-green run. Tracked separately.
