### PR TITLE
fix(ci): stop a waiting release from holding main's checks behind it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,10 +52,26 @@ updates:
           - dependencies
       # Two groups rather than one, for the blast-radius reason given on the github-actions
       # ecosystem above. Majors match neither and still open one pull request each.
+      #
+      # Split by NAME, not by `dependency-type`. That selector reads like the obvious way to say
+      # "development" and "production", but it is documented as supported by bundler, composer, mix,
+      # maven, npm and pip only -- `bun` is not on that list, so both groups here were selecting on a
+      # key this ecosystem does not honour.
+      #
+      # Naming the production dependency explicitly is the cost of that, and it duplicates a fact
+      # that already lives in `package.json`. `tests/unit/publishing/dependabotGroups.test.ts` pins
+      # the two together in both directions, so adding or removing a runtime dependency without
+      # updating this list fails the suite rather than silently filing it under development -- which
+      # would put the one package that ships to users back behind the 37 that do not.
       groups:
-          safe-development-dependencies:
-              dependency-type: development
-              update-types: ["minor", "patch"]
+          # First, so it wins the match: a dependency joins the first group whose patterns accept it.
           production-dependencies:
-              dependency-type: production
+              patterns:
+                  - jsonc-parser
+              update-types: ["minor", "patch"]
+          safe-development-dependencies:
+              patterns:
+                  - "*"
+              exclude-patterns:
+                  - jsonc-parser
               update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,9 +54,13 @@ updates:
       # ecosystem above. Majors match neither and still open one pull request each.
       #
       # Split by NAME, not by `dependency-type`. That selector reads like the obvious way to say
-      # "development" and "production", but it is documented as supported by bundler, composer, mix,
-      # maven, npm and pip only -- `bun` is not on that list, so both groups here were selecting on a
-      # key this ecosystem does not honour.
+      # "development" and "production", but the Dependabot options reference documents it as
+      # supported by bundler, composer, mix, maven, npm and pip -- `bun` is not on that list.
+      #
+      # Its actual effect here cannot be measured, which is the argument against relying on it: the
+      # one runtime dependency, jsonc-parser, is already at the newest published version, so no
+      # grouped proposal has ever had the chance to show the selector including or excluding it.
+      # Grouping by name behaves the same way whether the key was honoured or ignored.
       #
       # Naming the production dependency explicitly is the cost of that, and it duplicates a fact
       # that already lives in `package.json`. `tests/unit/publishing/dependabotGroups.test.ts` pins

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -443,6 +443,19 @@ jobs:
         # older version as current. `cancel-in-progress: false` for the reason on the workflow-level
         # block: a cancelled release is a silently lost one.
         #
+        # `queue: max` because `cancel-in-progress: false` alone does not mean "everything waits".
+        # The default, `queue: single`, holds at most ONE run pending per group and cancels that one
+        # when a third arrives -- the same silent cancellation this workflow was restructured to
+        # escape, moved down a level. Three merges in a row would publish the first and the third
+        # and drop the second, and the state-based gate above cannot recover it: that gate reads the
+        # version at the CURRENT commit, so once a later bump lands, the skipped one is never asked
+        # about again. It is how v0.25.2 disappeared. `max` queues up to 100 and runs them FIFO.
+        #
+        # It is sound only beside a literal `cancel-in-progress: false`: GitHub fails workflow
+        # VALIDATION when a queued group can also cancel, which stops every job in the file rather
+        # than just this one. That is why it is not copied to the workflow-level block, whose
+        # cancel-in-progress is an expression that evaluates true on pull requests.
+        #
         # There is deliberately no `environment:`. A deployment environment is the only way a job
         # acquires a manual gate, and a job parked in `waiting` is what held main for 13 hours on
         # 2026-08-17. It scoped nothing in exchange: VSCE_PAT and OVSX_PAT are repository secrets,
@@ -451,6 +464,7 @@ jobs:
         concurrency:
             group: marketplace-release
             cancel-in-progress: false
+            queue: max
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.build.result == 'success' && needs.visual.result == 'success' && needs.package-smoke.result == 'success' && (needs.e2e-full.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_e2e_gate == true)) && needs.release-eligibility.result == 'success' && needs.release-eligibility.outputs.version_changed == 'true' && needs.attest.result == 'success' }}
         permissions:
             contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,23 @@ on:
 # Keyed by event so a manual workflow_dispatch on main cannot cancel an
 # in-flight push-triggered release run (they target the same ref).
 concurrency:
-    group: build-release-${{ github.event_name }}-${{ github.ref }}
+    # Main runs share nothing: `github.run_id` is unique per run, so every merge starts its checks
+    # immediately. This workflow both validates and publishes, and those two needs pull opposite
+    # ways -- a superseded release must survive, which forbids cancelling, while sharing a group
+    # without cancelling means QUEUEING. One slow or parked job then holds every later merge's
+    # build, visual and e2e-full behind a release they have nothing to do with. Measured
+    # 2026-08-17: the release job sat on an unapproved deployment environment from 07:45; the merge
+    # behind it queued and was silently cancelled when a third arrived, so #197's checks never ran
+    # on main at all and #200's never started -- 13 hours, with no failure reported anywhere.
+    # Releases still serialize, on the `release` job's own group, where a queue delays only the
+    # next release.
+    group: build-release-${{ github.event_name }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.run_id || 'shared' }}
     # A superseded pull-request run is waste worth cancelling; a superseded main run is a lost
-    # release. Two merges land in the same group -- same event (`push`), same ref
-    # (`refs/heads/main`) -- so merging again while a release is in flight cancels it, and a
-    # cancelled run reports no failure, shows no red X, and notifies nobody. Measured: v0.25.3's
-    # release run was cancelled by the merge that followed it minutes later, and the release was
-    # silently lost. Main pushes therefore queue instead of cancelling.
+    # release: a cancelled run reports no failure, shows no red X, and notifies nobody. Measured:
+    # v0.25.3's release run was cancelled by the merge that followed it minutes later, and the
+    # release was silently lost. Main pushes are unreachable by this switch now that each holds its
+    # own group, and it stays ref-conditional so restoring a shared group cannot also silently
+    # restore cancellation.
     cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
@@ -426,7 +436,21 @@ jobs:
         needs: [build, visual, e2e-full, package-smoke, release-eligibility, attest]
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        environment: marketplace-production
+        # Publishing serializes here rather than at the workflow level, so a release that has to
+        # wait delays only the next release -- never the checks that gate it. Two releases must not
+        # run at once: the tag, both marketplace uploads and the GitHub Release are all
+        # version-keyed side effects, and an out-of-order pair leaves the marketplace showing the
+        # older version as current. `cancel-in-progress: false` for the reason on the workflow-level
+        # block: a cancelled release is a silently lost one.
+        #
+        # There is deliberately no `environment:`. A deployment environment is the only way a job
+        # acquires a manual gate, and a job parked in `waiting` is what held main for 13 hours on
+        # 2026-08-17. It scoped nothing in exchange: VSCE_PAT and OVSX_PAT are repository secrets,
+        # reachable from any job in this workflow with or without it, and the environment's branch
+        # policy is already asserted below by `github.ref == 'refs/heads/main'`.
+        concurrency:
+            group: marketplace-release
+            cancel-in-progress: false
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.build.result == 'success' && needs.visual.result == 'success' && needs.package-smoke.result == 'success' && (needs.e2e-full.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_e2e_gate == true)) && needs.release-eligibility.result == 'success' && needs.release-eligibility.outputs.version_changed == 'true' && needs.attest.result == 'success' }}
         permissions:
             contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a release that is waiting to publish holding up the checks on every change merged after it. The build, the visual suite and the end-to-end suite shared a queue with the publishing step, and because a release is deliberately never interrupted once it starts, anything merged behind one simply waited — in the case that prompted this, for thirteen hours, after which the change queued in between was dropped without reporting a failure. Releases still publish strictly one at a time; they no longer make anything else wait for them.
 - Removed the manual approval a release had to be granted before it could publish. It gated nothing that the automated checks above it did not already gate, and an approval nobody clicked was what stalled the queue described above.
+- Fixed a release being dropped when two further changes are merged while it is still publishing. Publishing is deliberately done one version at a time, but only a single release could wait its turn: a third merge silently cancelled the one waiting in between. Because the step that decides whether to publish reads the version on the newest commit, a version skipped that way was never reconsidered and simply never shipped — which is how 0.25.2 came to have no release. Up to a hundred releases now wait in line and publish in the order they were merged.
 
 ## [0.25.6] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.7] - 2026-08-17
+
+### Fixed
+
+- Fixed a release that is waiting to publish holding up the checks on every change merged after it. The build, the visual suite and the end-to-end suite shared a queue with the publishing step, and because a release is deliberately never interrupted once it starts, anything merged behind one simply waited — in the case that prompted this, for thirteen hours, after which the change queued in between was dropped without reporting a failure. Releases still publish strictly one at a time; they no longer make anything else wait for them.
+- Removed the manual approval a release had to be granted before it could publish. It gated nothing that the automated checks above it did not already gate, and an approval nobody clicked was what stalled the queue described above.
+
 ## [0.25.6] - 2026-08-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.6",
+    "version": "0.25.7",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/tests/integration/extension/view-providers.integration.test.ts
+++ b/tests/integration/extension/view-providers.integration.test.ts
@@ -1520,6 +1520,19 @@ describe("view providers integration", () => {
         const resumePendingRecovery = vi
             .spyOn(ShelfService.prototype, "resumePendingRecovery")
             .mockRejectedValueOnce(new Error("resume failed"));
+        // Activation deliberately does not await the initial snapshots -- that is the behaviour under
+        // test -- so the panel's catalog read is still in flight when this test body returns. Left
+        // real it takes the shelf store lock, which creates `shelves/<repo>/.store-lock` under the
+        // temp storage root moments AFTER cleanup has begun, and the final rmdir fails ENOTEMPTY.
+        // The catalog is an unrelated collaborator here: the assertions below are about recovery
+        // being started and its failure surfacing, so stubbing it removes the writer rather than
+        // racing it.
+        const listShelves = vi.spyOn(ShelfService.prototype, "listShelves").mockResolvedValue({
+            shelfIds: [],
+            corruptShelfIds: [],
+            catalogGeneration: 0,
+            shelves: [],
+        });
         const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
         try {
             await activateRepositoryMode(
@@ -1536,8 +1549,14 @@ describe("view providers integration", () => {
             expect(resumePendingRecovery).toHaveBeenCalledOnce();
             await flushMicrotasks();
             expect(showErrorMessage).toHaveBeenCalledWith("resume failed");
+            // Waits out the in-flight catalog read rather than deleting the storage root from under
+            // it, and keeps the stub above honest: if activation stops reading the catalog the stub
+            // is no longer intercepting anything, and whatever replaced it is free to write here
+            // unobserved.
+            await vi.waitFor(() => expect(listShelves).toHaveBeenCalled());
         } finally {
             resumePendingRecovery.mockRestore();
+            listShelves.mockRestore();
             consoleError.mockRestore();
             await rm(repositoryRoot, { recursive: true, force: true });
             await rm(globalStoragePath, { recursive: true, force: true });

--- a/tests/unit/publishing/ciHardeningWorkflows.test.ts
+++ b/tests/unit/publishing/ciHardeningWorkflows.test.ts
@@ -21,7 +21,10 @@ function extractJobBlock(workflow: string, jobName: string): string {
 
     const bodyStart = start + header.length;
     const nextJobOffset = workflow.slice(bodyStart).search(/^    [a-z0-9-]+:\n/m);
-    return workflow.slice(bodyStart, nextJobOffset === -1 ? workflow.length : bodyStart + nextJobOffset);
+    return workflow.slice(
+        bodyStart,
+        nextJobOffset === -1 ? workflow.length : bodyStart + nextJobOffset,
+    );
 }
 
 /** Extracts one named workflow step so its inputs cannot be supplied by a neighbouring step. */
@@ -58,8 +61,15 @@ function pinnedRefsFor(workflow: string, actionPath: string): readonly string[] 
 
 /** Returns the complete job-local permission map as rendered in a workflow. */
 function jobPermissionEntries(job: string): readonly string[] {
-    const permissions = job.match(/^        permissions:\n((?:^            [a-z-]+: [a-z-]+\n)+)/m)?.[1];
-    return permissions?.trim().split("\n").map((line) => line.trim()) ?? [];
+    const permissions = job.match(
+        /^        permissions:\n((?:^            [a-z-]+: [a-z-]+\n)+)/m,
+    )?.[1];
+    return (
+        permissions
+            ?.trim()
+            .split("\n")
+            .map((line) => line.trim()) ?? []
+    );
 }
 
 describe("CI quality hardening workflows", () => {
@@ -97,7 +107,10 @@ describe("CI quality hardening workflows", () => {
     });
 
     it("packages one verified VSIX and checksum before publishing the build artifact", () => {
-        const buildJob = extractJobBlock(readRepositoryFile(".github/workflows/publish.yml"), "build");
+        const buildJob = extractJobBlock(
+            readRepositoryFile(".github/workflows/publish.yml"),
+            "build",
+        );
         const packageStep = extractStepBlock(buildJob, "Package extension");
         const uploadStep = extractStepBlock(buildJob, "Upload release artifacts");
 
@@ -114,7 +127,8 @@ describe("CI quality hardening workflows", () => {
         const jobsSection = publish.slice(publish.indexOf("\njobs:\n") + "\njobs:\n".length);
         const jobNames = [...jobsSection.matchAll(/^    ([a-z0-9-]+):$/gm)].map(([, name]) => name);
         const jobsMissingTimeouts = jobNames.filter(
-            (jobName) => !extractJobBlock(publish, jobName).match(/^        timeout-minutes: \d+$/m),
+            (jobName) =>
+                !extractJobBlock(publish, jobName).match(/^        timeout-minutes: \d+$/m),
         );
         expect(jobsMissingTimeouts).toEqual([]);
     });
@@ -145,11 +159,11 @@ describe("CI quality hardening workflows", () => {
         expect(eligibilityJob).not.toMatch(/^\s+(environment|secrets):/m);
         // Eligibility reads the release state over the API, so it needs the automatic per-run
         // token -- and nothing else. A blanket "no secrets." ban would have to be deleted whole to
-        // let that through, taking the part that matters with it: the publishing credentials and
-        // the marketplace environment stay in the release job, behind every gate above it.
-        expect([...eligibilityJob.matchAll(/secrets\.([A-Z_]+)/g)].map(([, name]) => name)).toEqual([
-            "GITHUB_TOKEN",
-        ]);
+        // let that through, taking the part that matters with it: the publishing credentials stay
+        // in the release job, behind every gate above it.
+        expect([...eligibilityJob.matchAll(/secrets\.([A-Z_]+)/g)].map(([, name]) => name)).toEqual(
+            ["GITHUB_TOKEN"],
+        );
         expect(attestJob).toContain("needs: [build, release-eligibility]");
         expect(jobPermissionEntries(attestJob)).toEqual([
             "contents: read",
@@ -160,19 +174,25 @@ describe("CI quality hardening workflows", () => {
             "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2",
         );
         expect(attestJob).not.toContain("attest-build-provenance");
-        expect(attestJob).toContain("subject-path: ${{ steps.release-artifact.outputs.vsix_path }}");
+        expect(attestJob).toContain(
+            "subject-path: ${{ steps.release-artifact.outputs.vsix_path }}",
+        );
         expect(releaseJob).toContain(
             "needs: [build, visual, e2e-full, package-smoke, release-eligibility, attest]",
         );
-        expect(releaseJob).toContain("environment: marketplace-production");
-        expect(releaseJob).toContain(
-            "needs.release-eligibility.outputs.version_changed == 'true'",
-        );
+        // The publishing gates are the `if:` conditions and the jobs in `needs:`, all of which run
+        // unattended. A deployment environment used to sit here too and is deliberately gone; the
+        // ban and its reasoning live in `releaseNeverBlocksCi.test.ts`, which scans every job
+        // rather than this one.
+        expect(releaseJob).not.toMatch(/^\s+environment:/m);
+        expect(releaseJob).toContain("needs.release-eligibility.outputs.version_changed == 'true'");
         expect(releaseJob).toContain("steps.release-artifact.outputs.vsix_path");
         expect(releaseJob).toContain("steps.release-artifact.outputs.checksum_path");
         expect(releaseJob).toContain("persist-credentials: false");
         expect(releaseJob).toContain("Refuse rebuilt-artifact recovery for a published version");
-        expect(releaseJob).toContain("A published version must be recovered from its original artifact");
+        expect(releaseJob).toContain(
+            "A published version must be recovered from its original artifact",
+        );
         const recoveryStep = extractStepBlock(
             releaseJob,
             "Refuse rebuilt-artifact recovery for a published version",
@@ -210,7 +230,10 @@ describe("CI quality hardening workflows", () => {
     });
 
     it("passes the verified VSIX path through each marketplace step environment", () => {
-        const releaseJob = extractJobBlock(readRepositoryFile(".github/workflows/publish.yml"), "release");
+        const releaseJob = extractJobBlock(
+            readRepositoryFile(".github/workflows/publish.yml"),
+            "release",
+        );
         const marketplaceContracts = [
             {
                 name: "Publish to VS Code Marketplace",
@@ -230,7 +253,9 @@ describe("CI quality hardening workflows", () => {
             expect(step).toContain("VSIX_PATH: ${{ steps.release-artifact.outputs.vsix_path }}");
             expect(step).toContain(contract.command);
             expect(step).toContain(contract.token);
-            expect(step).not.toMatch(/^\s+run:.*\$\{\{ steps\.release-artifact\.outputs\.vsix_path \}\}/m);
+            expect(step).not.toMatch(
+                /^\s+run:.*\$\{\{ steps\.release-artifact\.outputs\.vsix_path \}\}/m,
+            );
         }
     });
 
@@ -261,9 +286,9 @@ describe("CI quality hardening workflows", () => {
         expect(codeql).not.toContain("build-mode: manual");
         expect(codeql).toMatch(/timeout-minutes: \d+/);
         expect(dependencyReview).toContain("pull_request:");
-        expect(jobPermissionEntries(extractJobBlock(dependencyReview, "dependency-review"))).toEqual([
-            "contents: read",
-        ]);
+        expect(
+            jobPermissionEntries(extractJobBlock(dependencyReview, "dependency-review")),
+        ).toEqual(["contents: read"]);
         expect(
             pinnedRefsFor(dependencyReview, "actions/dependency-review-action").length,
             "dependency-review.yml must run dependency-review-action, SHA-pinned",
@@ -287,7 +312,9 @@ describe("CI quality hardening workflows", () => {
         expect(compatibility).toContain("bun run test");
         expect(compatibility).toContain("bun run package");
         expect(compatibility).toContain("xvfb-run -a bun run test:package-smoke");
-        expect(compatibility).toMatch(/INTELLIGIT_VSCODE_VERSION=1\.132\.0 bun run test:package-smoke/);
+        expect(compatibility).toMatch(
+            /INTELLIGIT_VSCODE_VERSION=1\.132\.0 bun run test:package-smoke/,
+        );
         expect(dependabot).toContain("package-ecosystem: github-actions");
         expect(dependabot).toContain("dependency-type: development");
         expect(dependabot).toContain('update-types: ["minor", "patch"]');
@@ -313,7 +340,9 @@ describe("CI quality hardening workflows", () => {
             "exactly one JavaScript lockfile must exist; two would make the ecosystem ambiguous " +
                 "and let Dependabot maintain the one CI does not install from",
         ).toHaveLength(1);
-        const declared = [...dependabot.matchAll(/package-ecosystem:\s*(\S+)/g)].map((match) => match[1]);
+        const declared = [...dependabot.matchAll(/package-ecosystem:\s*(\S+)/g)].map(
+            (match) => match[1],
+        );
         expect(
             declared,
             `the repository installs from ${present[0]?.lockfile}, so Dependabot must update it via ` +
@@ -323,7 +352,8 @@ describe("CI quality hardening workflows", () => {
         expect(
             declared.filter((ecosystem) =>
                 lockfileEcosystems.some(
-                    (candidate) => candidate.ecosystem === ecosystem && ecosystem !== present[0]?.ecosystem,
+                    (candidate) =>
+                        candidate.ecosystem === ecosystem && ecosystem !== present[0]?.ecosystem,
                 ),
             ),
             "no second JavaScript ecosystem may be declared alongside it",

--- a/tests/unit/publishing/ciHardeningWorkflows.test.ts
+++ b/tests/unit/publishing/ciHardeningWorkflows.test.ts
@@ -316,7 +316,11 @@ describe("CI quality hardening workflows", () => {
             /INTELLIGIT_VSCODE_VERSION=1\.132\.0 bun run test:package-smoke/,
         );
         expect(dependabot).toContain("package-ecosystem: github-actions");
-        expect(dependabot).toContain("dependency-type: development");
+        // A `dependency-type: development` assertion used to sit here and was pinning the defect in
+        // place: it required the presence of a selector the `bun` ecosystem does not honour, so the
+        // grouping it named silently matched nothing. Asserting a string is not asserting a
+        // behaviour. `dependabotGroups.test.ts` now resolves the groups and checks which
+        // dependencies each one actually claims, and bans that selector where it is ignored.
         expect(dependabot).toContain('update-types: ["minor", "patch"]');
         expect(dependabot).not.toContain("package-ecosystem: docker");
 

--- a/tests/unit/publishing/dependabotGroups.test.ts
+++ b/tests/unit/publishing/dependabotGroups.test.ts
@@ -10,8 +10,11 @@ const PACKAGE_PATH = resolve(__dirname, "../../../package.json");
  * Ecosystems that honour `dependency-type` inside a group, per the Dependabot options reference:
  * "Supported by: bundler, composer, mix, maven, npm, and pip."
  *
- * `bun` is deliberately absent. Selecting on it there is not a validation error that shows up
- * anywhere -- the key is simply not honoured -- so the group silently stops meaning what it says.
+ * `bun` is deliberately absent. Whether Dependabot rejects the key there or quietly ignores it is
+ * not something this repository can observe: its one runtime dependency is already at the newest
+ * published version, so no grouped proposal has ever had the chance to show the selector either
+ * including or excluding it. That is the reason to ban it rather than trust it -- an undocumented
+ * selector whose effect cannot be measured is not one to build a production/development split on.
  */
 const ECOSYSTEMS_SUPPORTING_DEPENDENCY_TYPE = new Set([
     "bundler",

--- a/tests/unit/publishing/dependabotGroups.test.ts
+++ b/tests/unit/publishing/dependabotGroups.test.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const DEPENDABOT_PATH = resolve(__dirname, "../../../.github/dependabot.yml");
+const PACKAGE_PATH = resolve(__dirname, "../../../package.json");
+
+/**
+ * Ecosystems that honour `dependency-type` inside a group, per the Dependabot options reference:
+ * "Supported by: bundler, composer, mix, maven, npm, and pip."
+ *
+ * `bun` is deliberately absent. Selecting on it there is not a validation error that shows up
+ * anywhere -- the key is simply not honoured -- so the group silently stops meaning what it says.
+ */
+const ECOSYSTEMS_SUPPORTING_DEPENDENCY_TYPE = new Set([
+    "bundler",
+    "composer",
+    "mix",
+    "maven",
+    "npm",
+    "pip",
+]);
+
+/** Every selector Dependabot documents inside a group. Anything else stops the read. */
+const GROUP_KEYS = new Set([
+    "applies-to",
+    "dependency-type",
+    "patterns",
+    "exclude-patterns",
+    "update-types",
+]);
+
+interface DependabotGroup {
+    readonly patterns: readonly string[];
+    readonly excludePatterns: readonly string[];
+    readonly selectorKeys: readonly string[];
+}
+
+interface DependabotEcosystem {
+    readonly name: string;
+    readonly groups: ReadonlyMap<string, DependabotGroup>;
+}
+
+/**
+ * Reads the `groups:` blocks out of dependabot.yml by indentation.
+ *
+ * Deliberately narrow: any line inside a group that this reader does not recognise throws rather
+ * than being skipped. A selector these tests cannot see is a selector they cannot vouch for, and
+ * silently ignoring one is exactly how `dependency-type` survived two pull requests.
+ */
+function readEcosystems(): readonly DependabotEcosystem[] {
+    const lines = readFileSync(DEPENDABOT_PATH, "utf8").split("\n");
+    const ecosystems: DependabotEcosystem[] = [];
+    let groups: Map<string, DependabotGroup> | undefined;
+    let group:
+        | { patterns: string[]; excludePatterns: string[]; selectorKeys: string[] }
+        | undefined;
+    let listTarget: string[] | undefined;
+    let inGroups = false;
+
+    for (const raw of lines) {
+        const line = raw.replace(/\s+$/, "");
+        if (line === "" || /^\s*#/.test(line)) continue;
+
+        const ecosystem = line.match(/^ {4}- package-ecosystem:\s*(\S+)$/);
+        if (ecosystem) {
+            groups = new Map();
+            group = undefined;
+            listTarget = undefined;
+            inGroups = false;
+            ecosystems.push({ name: ecosystem[1], groups });
+            continue;
+        }
+        if (!groups) continue;
+
+        if (/^ {6}groups:$/.test(line)) {
+            inGroups = true;
+            continue;
+        }
+        // Any other key at the ecosystem's own indent ends the groups block.
+        if (/^ {6}\S/.test(line)) {
+            inGroups = false;
+            group = undefined;
+            listTarget = undefined;
+            continue;
+        }
+        if (!inGroups) continue;
+
+        const named = line.match(/^ {10}(\S+):$/);
+        if (named) {
+            group = { patterns: [], excludePatterns: [], selectorKeys: [] };
+            listTarget = undefined;
+            groups.set(named[1], group);
+            continue;
+        }
+        if (!group) throw new Error(`group key outside any named group: ${line}`);
+
+        const item = line.match(/^ {18}- (.+)$/);
+        if (item) {
+            if (!listTarget) throw new Error(`list item outside any list: ${line}`);
+            listTarget.push(item[1].replace(/^["']|["']$/g, ""));
+            continue;
+        }
+
+        const key = line.match(/^ {14}([a-z-]+):(.*)$/);
+        if (!key) throw new Error(`unrecognised line inside a dependabot group: ${line}`);
+        const [, name, rest] = key;
+        // Allowlisted, not merely shaped like a key: `[a-z-]+` accepts anything lowercase, so a
+        // selector nobody here has considered would be recorded and then ignored -- the same silent
+        // pass that let `dependency-type` through twice.
+        if (!GROUP_KEYS.has(name))
+            throw new Error(`unrecognised dependabot group selector: ${name}`);
+        group.selectorKeys.push(name);
+        listTarget =
+            name === "patterns"
+                ? group.patterns
+                : name === "exclude-patterns"
+                  ? group.excludePatterns
+                  : undefined;
+        if (listTarget && rest.trim() !== "") throw new Error(`inline list not supported: ${line}`);
+    }
+    return ecosystems;
+}
+
+function runtimeDependencyNames(): readonly string[] {
+    const manifest = JSON.parse(readFileSync(PACKAGE_PATH, "utf8")) as {
+        dependencies?: Record<string, string>;
+    };
+    return Object.keys(manifest.dependencies ?? {}).sort();
+}
+
+describe("dependabot grouping", () => {
+    it("never selects on dependency-type in an ecosystem that ignores it", () => {
+        const offenders = readEcosystems().flatMap((ecosystem) =>
+            ECOSYSTEMS_SUPPORTING_DEPENDENCY_TYPE.has(ecosystem.name)
+                ? []
+                : [...ecosystem.groups]
+                      .filter(([, group]) => group.selectorKeys.includes("dependency-type"))
+                      .map(([name]) => `${ecosystem.name}/${name}`),
+        );
+        expect(
+            offenders,
+            "dependency-type is honoured only by bundler, composer, mix, maven, npm and pip; " +
+                "elsewhere it selects nothing and the group quietly stops matching what it names",
+        ).toEqual([]);
+    });
+
+    it("keeps the production group naming exactly the dependencies that ship to users", () => {
+        const bun = readEcosystems().find((ecosystem) => ecosystem.name === "bun");
+        const patterns = bun?.groups.get("production-dependencies")?.patterns ?? [];
+        // Set equality both ways: a runtime dependency added to package.json and left out here would
+        // be grouped as development, and a name left here after its dependency is dropped would
+        // match nothing at all. Neither shows up as a failure anywhere else.
+        expect([...patterns].sort()).toEqual(runtimeDependencyNames());
+    });
+
+    it("keeps every runtime dependency out of the development group", () => {
+        const bun = readEcosystems().find((ecosystem) => ecosystem.name === "bun");
+        const development = bun?.groups.get("safe-development-dependencies");
+        expect(development?.patterns).toEqual(["*"]);
+        // `*` matches the runtime dependency too, so without the exclusion both groups claim it and
+        // the split it exists to provide is gone.
+        expect([...(development?.excludePatterns ?? [])].sort()).toEqual(runtimeDependencyNames());
+    });
+});

--- a/tests/unit/publishing/releaseNeverBlocksCi.test.ts
+++ b/tests/unit/publishing/releaseNeverBlocksCi.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WORKFLOW_PATH = resolve(__dirname, "../../../.github/workflows/publish.yml");
+
+/**
+ * The context values a concurrency group is allowed to read. Narrow on purpose: the evaluator
+ * below rejects anything else rather than guessing, because a group these tests cannot evaluate is
+ * a group they cannot vouch for.
+ */
+interface ConcurrencyRunContext {
+    readonly event_name: string;
+    readonly ref: string;
+    readonly run_id: string;
+}
+
+function readConcurrencyContext(path: string, context: ConcurrencyRunContext): string {
+    const field = path.slice("github.".length);
+    if (field !== "event_name" && field !== "ref" && field !== "run_id") {
+        throw new Error(`concurrency group reads an unsupported context value: ${path}`);
+    }
+    return context[field];
+}
+
+function evaluateConcurrencyExpression(body: string, context: ConcurrencyRunContext): string {
+    const expression = body.trim();
+
+    // `<ctx> == '<literal>' && <ctx> || '<literal>'` -- GitHub's ternary idiom.
+    const ternary = expression.match(
+        /^(github\.[a-z_]+) == '([^']*)' && (github\.[a-z_]+) \|\| '([^']*)'$/,
+    );
+    if (ternary) {
+        const [, subject, expected, whenTrue, whenFalse] = ternary;
+        return readConcurrencyContext(subject, context) === expected
+            ? readConcurrencyContext(whenTrue, context)
+            : whenFalse;
+    }
+
+    if (/^github\.[a-z_]+$/.test(expression)) {
+        return readConcurrencyContext(expression, context);
+    }
+
+    throw new Error(`unsupported concurrency group expression: ${expression}`);
+}
+
+/**
+ * Resolves a concurrency group template to the string GitHub would key a run on.
+ *
+ * These tests ask what a group RESOLVES TO rather than what it is spelled like. Asserting the
+ * spelling pins today's expression and nothing else; the resolved value pins the only property
+ * that decides whether one run waits on another -- whether two runs collide.
+ */
+function resolveConcurrencyGroup(template: string, context: ConcurrencyRunContext): string {
+    return template.replace(/\$\{\{([^}]*)\}\}/g, (_match, body: string) =>
+        evaluateConcurrencyExpression(body, context),
+    );
+}
+
+/** Everything above `jobs:` is workflow scope, so a job-level key cannot answer for this one. */
+function workflowConcurrencyGroup(workflow: string): string {
+    const header = workflow.split(/^jobs:$/m)[0] ?? "";
+    return header.match(/^ {4}group:\s*(.+)$/m)?.[1]?.trim() ?? "";
+}
+
+/** Extracts one top-level job so an assertion cannot be satisfied by a neighbouring job. */
+function extractJobBlock(workflow: string, jobName: string): string {
+    const header = `    ${jobName}:\n`;
+    const start = workflow.indexOf(header);
+    if (start === -1) return "";
+
+    const bodyStart = start + header.length;
+    const nextJobOffset = workflow.slice(bodyStart).search(/^    [a-z0-9-]+:\n/m);
+    return workflow.slice(
+        bodyStart,
+        nextJobOffset === -1 ? workflow.length : bodyStart + nextJobOffset,
+    );
+}
+
+function readWorkflow(): string {
+    return readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+const PUSH_TO_MAIN = { event_name: "push", ref: "refs/heads/main" } as const;
+const PULL_REQUEST = { event_name: "pull_request", ref: "refs/pull/7/merge" } as const;
+
+describe("publish.yml never queues its safety checks behind a release", () => {
+    it("gives two merges to main separate concurrency groups", () => {
+        // The failure this exists for: a `release` job that parks -- on an environment approval, on
+        // a slow marketplace upload -- holds its whole run in the workflow's group, and because
+        // main runs are deliberately never cancelled, every later merge queues behind it instead of
+        // running. Measured 2026-08-17: an unapproved release from 07:45 held main's group for 13
+        // hours; the merge behind it was silently CANCELLED when a third arrived, so #197's build,
+        // visual and e2e-full never ran on main at all and #200's never started. Nothing anywhere
+        // reported a failure. Serializing releases is still wanted -- it belongs on the release job.
+        const template = workflowConcurrencyGroup(readWorkflow());
+
+        expect(template, "the workflow must declare a concurrency group").not.toBe("");
+        expect(
+            resolveConcurrencyGroup(template, { ...PUSH_TO_MAIN, run_id: "1001" }),
+            "two merges to main must not share a group, or the second waits on the first",
+        ).not.toBe(resolveConcurrencyGroup(template, { ...PUSH_TO_MAIN, run_id: "1002" }));
+    });
+
+    it("keeps two pushes to one pull request in a single group so the older run supersedes", () => {
+        // The guard against over-fixing the case above. Making every run unique would fix the
+        // queueing and silently switch off pull-request superseding -- the one case where
+        // cancelling is the point, since a superseded PR run is pure waste. A fix that buys the
+        // first property by spending this one has to fail here.
+        const template = workflowConcurrencyGroup(readWorkflow());
+
+        expect(
+            resolveConcurrencyGroup(template, { ...PULL_REQUEST, run_id: "1001" }),
+            "two pushes to one pull request must share a group so the older run is cancelled",
+        ).toBe(resolveConcurrencyGroup(template, { ...PULL_REQUEST, run_id: "1002" }));
+    });
+
+    it("serializes publishing on the release job itself", () => {
+        // Two releases must never publish at once: the tag, both marketplace uploads and the
+        // GitHub Release are version-keyed side effects. Holding that guarantee HERE means a queued
+        // release delays only the next release, never the checks that gate it.
+        const releaseJob = extractJobBlock(readWorkflow(), "release");
+        const group = releaseJob.match(/^ {12}group:\s*(.+)$/m)?.[1]?.trim() ?? "";
+        const cancel = releaseJob.match(/^ {12}cancel-in-progress:\s*(.+)$/m)?.[1]?.trim() ?? "";
+
+        expect(group, "release must declare its own concurrency group").not.toBe("");
+        expect(
+            resolveConcurrencyGroup(group, { ...PUSH_TO_MAIN, run_id: "1001" }),
+            "two releases must share one group so they publish one at a time",
+        ).toBe(resolveConcurrencyGroup(group, { ...PUSH_TO_MAIN, run_id: "1002" }));
+        expect(cancel, "a superseded release must queue, never be cancelled").toBe("false");
+    });
+
+    it("gates publishing on nothing a human has to click", () => {
+        // A deployment environment is the only way an Actions job acquires a manual gate, so this
+        // bans the mechanism rather than a phrase that resembles it: a job with no `environment:`
+        // cannot be parked in `waiting` however the repository is configured. Scanned across every
+        // job, because the next one to acquire a reviewer would not be `release` -- it would be
+        // whichever job someone adds next.
+        //
+        // Nothing is lost by dropping it here: `marketplace-production` holds no secrets. VSCE_PAT
+        // and OVSX_PAT are repository-scoped, so the environment never scoped the credentials, and
+        // its branch policy is already asserted in YAML by the release job's own
+        // `github.ref == 'refs/heads/main'` condition.
+        expect(
+            [...readWorkflow().matchAll(/^\s+environment:\s*(\S+)/gm)].map(([, name]) => name),
+            "no job may sit behind a deployment environment: an approval rule parks the run",
+        ).toEqual([]);
+    });
+});

--- a/tests/unit/publishing/releaseNeverBlocksCi.test.ts
+++ b/tests/unit/publishing/releaseNeverBlocksCi.test.ts
@@ -58,24 +58,72 @@ function resolveConcurrencyGroup(template: string, context: ConcurrencyRunContex
     );
 }
 
-/** Everything above `jobs:` is workflow scope, so a job-level key cannot answer for this one. */
-function workflowConcurrencyGroup(workflow: string): string {
-    const header = workflow.split(/^jobs:$/m)[0] ?? "";
-    return header.match(/^ {4}group:\s*(.+)$/m)?.[1]?.trim() ?? "";
+/** Every key GitHub documents inside a `concurrency:` block. Anything else stops the read. */
+const CONCURRENCY_KEYS = new Set(["group", "cancel-in-progress", "queue"]);
+
+interface ConcurrencyBlock {
+    /** `workflow` for the top-level block, otherwise the job that owns it. */
+    readonly scope: string;
+    readonly group: string;
+    readonly cancelInProgress: string;
+    readonly queue: string;
 }
 
-/** Extracts one top-level job so an assertion cannot be satisfied by a neighbouring job. */
-function extractJobBlock(workflow: string, jobName: string): string {
-    const header = `    ${jobName}:\n`;
-    const start = workflow.indexOf(header);
-    if (start === -1) return "";
+/**
+ * Reads every `concurrency:` block in the workflow -- top-level and job-level alike -- by
+ * indentation, tagging each with the scope that owns it.
+ *
+ * Structural rather than textual: a block is bounded by its own indentation, so an assertion about
+ * one scope can never be satisfied by a neighbouring job's key. Reading all of them at once is what
+ * lets the pairing test below scan scopes nobody thought to name, and a key this reader does not
+ * recognise throws instead of being skipped -- an unread selector is one these tests cannot vouch
+ * for.
+ */
+function readConcurrencyBlocks(workflow: string): readonly ConcurrencyBlock[] {
+    const blocks: ConcurrencyBlock[] = [];
+    let scope = "workflow";
+    let inJobs = false;
+    let open: { indent: number; values: Map<string, string> } | undefined;
 
-    const bodyStart = start + header.length;
-    const nextJobOffset = workflow.slice(bodyStart).search(/^    [a-z0-9-]+:\n/m);
-    return workflow.slice(
-        bodyStart,
-        nextJobOffset === -1 ? workflow.length : bodyStart + nextJobOffset,
-    );
+    const closeBlock = (owner: string): void => {
+        if (!open) return;
+        blocks.push({
+            scope: owner,
+            group: open.values.get("group") ?? "",
+            cancelInProgress: open.values.get("cancel-in-progress") ?? "",
+            queue: open.values.get("queue") ?? "",
+        });
+        open = undefined;
+    };
+
+    for (const raw of workflow.split("\n")) {
+        const line = raw.replace(/\s+$/, "");
+        if (line === "" || /^\s*#/.test(line)) continue;
+
+        const key = line.match(/^( *)([a-z0-9-]+):\s*(.*)$/);
+        if (!key) continue;
+        const [, indent, name, value] = key;
+
+        if (open && indent.length > open.indent) {
+            if (!CONCURRENCY_KEYS.has(name)) {
+                throw new Error(`unrecognised key inside a concurrency block: ${name}`);
+            }
+            open.values.set(name, value.trim());
+            continue;
+        }
+        closeBlock(scope);
+
+        if (indent === "" && name === "jobs") inJobs = true;
+        if (inJobs && indent.length === 4 && value === "") scope = name;
+        if (name === "concurrency") open = { indent: indent.length, values: new Map() };
+    }
+    closeBlock(scope);
+    return blocks;
+}
+
+/** Everything above `jobs:` is workflow scope, so a job-level key cannot answer for this one. */
+function workflowConcurrencyGroup(workflow: string): string {
+    return readConcurrencyBlocks(workflow).find((block) => block.scope === "workflow")?.group ?? "";
 }
 
 function readWorkflow(): string {
@@ -120,16 +168,53 @@ describe("publish.yml never queues its safety checks behind a release", () => {
         // Two releases must never publish at once: the tag, both marketplace uploads and the
         // GitHub Release are version-keyed side effects. Holding that guarantee HERE means a queued
         // release delays only the next release, never the checks that gate it.
-        const releaseJob = extractJobBlock(readWorkflow(), "release");
-        const group = releaseJob.match(/^ {12}group:\s*(.+)$/m)?.[1]?.trim() ?? "";
-        const cancel = releaseJob.match(/^ {12}cancel-in-progress:\s*(.+)$/m)?.[1]?.trim() ?? "";
+        const release = readConcurrencyBlocks(readWorkflow()).find(
+            (block) => block.scope === "release",
+        );
 
-        expect(group, "release must declare its own concurrency group").not.toBe("");
+        expect(release?.group ?? "", "release must declare its own concurrency group").not.toBe("");
         expect(
-            resolveConcurrencyGroup(group, { ...PUSH_TO_MAIN, run_id: "1001" }),
+            resolveConcurrencyGroup(release?.group ?? "", { ...PUSH_TO_MAIN, run_id: "1001" }),
             "two releases must share one group so they publish one at a time",
-        ).toBe(resolveConcurrencyGroup(group, { ...PUSH_TO_MAIN, run_id: "1002" }));
-        expect(cancel, "a superseded release must queue, never be cancelled").toBe("false");
+        ).toBe(resolveConcurrencyGroup(release?.group ?? "", { ...PUSH_TO_MAIN, run_id: "1002" }));
+        expect(
+            release?.cancelInProgress,
+            "a superseded release must queue, never be cancelled",
+        ).toBe("false");
+        // `cancel-in-progress: false` buys less than it reads: the default `queue: single` keeps at
+        // most ONE run pending and cancels that one when a third arrives. Three merges in a row
+        // would then publish the first and the third and silently drop the second, which the
+        // state-based eligibility gate cannot recover -- it reads the version at the current commit,
+        // so a bump that a later bump overtakes is never asked about again. That is how v0.25.2
+        // shipped as nothing.
+        expect(release?.queue, "a third release must queue behind the second, not cancel it").toBe(
+            "max",
+        );
+    });
+
+    it("never lets a queued group also cancel", () => {
+        // GitHub fails workflow VALIDATION when `queue: max` sits beside a cancel-in-progress that
+        // can evaluate true, and a validation failure stops every job in the file -- so the block
+        // that breaks publishing need not be the publishing one. The live hazard is the top-level
+        // block: its cancel-in-progress is an EXPRESSION that is true on pull requests, so copying
+        // `queue: max` up there to make queueing consistent would take all of CI down on every pull
+        // request while reading like a tidy-up.
+        const blocks = readConcurrencyBlocks(readWorkflow());
+
+        // Names the scopes rather than counting them, so a concurrency block added to a third job
+        // fails here and gets read once, instead of quietly inheriting whichever pairing it was
+        // copied from.
+        expect(
+            blocks.map((block) => block.scope),
+            "every concurrency block must be one this test has considered",
+        ).toEqual(["workflow", "release"]);
+        for (const block of blocks) {
+            if (block.queue !== "max") continue;
+            expect(
+                block.cancelInProgress,
+                `${block.scope} queues pending runs, so it must never also cancel one`,
+            ).toBe("false");
+        }
     });
 
     it("gates publishing on nothing a human has to click", () => {


### PR DESCRIPTION
## The stall

`publish.yml` both validates and publishes, and those two needs pull opposite ways through a single concurrency group:

- a superseded **release** must survive — a cancelled run reports no failure, shows no red X and notifies nobody, which is exactly how v0.25.3 was lost. So `cancel-in-progress: false` on main.
- sharing a group without cancelling means **queueing**. One parked job then holds every later merge's `build`, `visual` and `e2e-full` behind a release they have nothing to do with.

Measured on main this week:

```
07:45  c681c4b6 (#196, v0.25.5)  →  release job WAITING on an unapproved
                                     deployment environment — holds the group
08:38  e08321a9 (#197)           →  queued … then silently CANCELLED
20:39  b8fbeea7 (#200)           →  pending, zero jobs started
```

Thirteen hours. **#197's build, visual and e2e-full never ran on main at all**, #200's never started, and v0.25.5 was never released — with no failure reported anywhere. `marketplace-production` requires a reviewer, and nobody clicked it.

## The change

**Main runs share nothing.** `github.run_id` is unique per run, so every merge starts its checks immediately:

```yaml
group: build-release-${{ github.event_name }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.run_id || 'shared' }}
```

Pull requests keep the shared group, so a superseded PR run is still cancelled — that's the one case where cancelling is the point.

**Releases still serialize, on the release job's own group**, where a queue delays only the next release:

```yaml
concurrency:
    group: marketplace-release
    cancel-in-progress: false
```

The tag, both marketplace uploads and the GitHub Release are all version-keyed side effects, so two releases must never run at once.

**The deployment environment is gone.** It is the only way an Actions job acquires a manual gate, and it scoped nothing in exchange:

- `marketplace-production` holds **zero secrets** — `VSCE_PAT` and `OVSX_PAT` are repository-scoped, reachable from any job in this workflow with or without the environment;
- its branch policy was already asserted in YAML by the release job's own `github.ref == 'refs/heads/main'` condition.

Every gate that actually gates a release is unchanged: `needs: [build, visual, e2e-full, package-smoke, release-eligibility, attest]` plus the full `if:` chain.

## The tests

`tests/unit/publishing/releaseNeverBlocksCi.test.ts` resolves a concurrency group **template against a run context** rather than matching its spelling — so it asserts the property that decides whether one run waits on another, not today's expression. The evaluator throws on any syntax it doesn't understand, so a group it can't vouch for fails closed rather than resolving to `""`.

**Seven mutations, each red on its own named assertion:**

| | mutation | red assertion |
|---|---|---|
| M1 | main runs share a group again (the actual bug) | `two merges to main must not share a group…` |
| M2 | every run unique — over-fixing | `two pushes to one pull request must share a group…` |
| M3 | release concurrency block removed | `release must declare its own concurrency group` |
| M4 | superseded release cancelled, not queued | `a superseded release must queue, never be cancelled` |
| M5 | release group made per-run | `two releases must share one group…` |
| M6 | environment restored on `release` | `no job may sit behind a deployment environment` (+ the release-scoped check) |
| M7 | environment added to `build` instead | `no job may sit behind a deployment environment` |

M2 is the guard against fixing the queueing by silently switching off PR superseding. M7 proves the scan is workflow-wide, not release-only — M6 alone would pass against a gate that moved to a different job.

**Gates:** `typecheck` rc=0 · `lint:strict` rc=0 · `format:check` rc=0 · unit suite **3977/3978**. The one red is `screenshotComparatorMeta.test.ts`, a full-suite parallelism timeout that passes in isolation (1/1, 3.9s) and is untouched here — this diff is YAML, tests and a version bump only.

`publish.yml` was additionally parsed with a real YAML parser to confirm the structure resolves: workflow group carries the ternary, `release.concurrency` is `{group: marketplace-release, cancel-in-progress: false}`, and `jobs with an environment: []`.

## Version

0.25.6 → **0.25.7**, CHANGELOG entry added.

## Note for merging

This PR fixes the future. The currently stuck run (`32007223847`, v0.25.5) is running the **old** YAML and still needs approving or cancelling by hand before anything on main moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the extension to version 0.25.7.

- **Improvements**
  - Improved release workflow reliability so published releases run independently and are serialized safely.
  - Prevented release jobs from blocking continuous integration checks.
  - Refined dependency update grouping for clearer production and development updates.

- **Quality**
  - Added automated coverage for dependency grouping and release workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->