### PR TITLE
fix: stop an unread stdin pipe killing the run, and stop the shelf list failing on a busy lock (v0.25.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.8] - 2026-08-18
+
+### Fixed
+
+- Fixed the extension stopping altogether when a Git command finishes before it has been given all of its input. Only the command itself was watched for failure, never the channel used to feed it, and a failure on that channel is not one the surrounding code is able to catch — so rather than that single command reporting a problem, everything came to a halt. Nothing is lost by ignoring that particular failure: the command's own exit status and error output already describe what happened. Any other failure to hand over the input is still reported, because a Git command finishes successfully on however much of its input it managed to read — so ignoring those too would have turned a command that ran on half its input into one that appears to have worked.
+- Fixed the list of shelves failing outright instead of waiting whenever a shelf operation was already under way. Reading the list does not pass through the queue that shelf changes pass through, so it met a change in progress head-on and gave up at once, and the commit panel quietly showed the shelves it had last seen instead — stale contents, with nothing reported as wrong. A read now waits up to a second for the change to finish instead of giving up at once, and reports the store as busy only if it is still held after that. The wait is kept short on purpose: this read runs as part of the commit panel's periodic refresh, alongside the working-tree status and branch information, so a longer one would hold up everything else on the panel to little benefit.
+
 ## [0.25.7] - 2026-08-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.7",
+    "version": "0.25.8",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/git/boundedLockRetry.ts
+++ b/src/git/boundedLockRetry.ts
@@ -1,0 +1,40 @@
+import { RepositoryLockBusyError } from "./repositoryLock";
+
+/** How long a busy lock is retried, and how long to pause between attempts. */
+export interface BoundedLockRetryOptions {
+    readonly timeoutMs: number;
+    readonly retryDelayMs: number;
+}
+
+/**
+ * Retries a busy `RepositoryLock` acquisition until it succeeds or the caller's
+ * own wait window elapses, capping every retry sleep at whatever time is left.
+ *
+ * A loop that always slept the full `retryDelayMs` after a busy failure, without
+ * capping it to what remains before the deadline, can land its next attempt long
+ * after the window the caller was promised: a 100ms timeout paired with a 1000ms
+ * retry delay would still sleep the whole second on the first failure, and if the
+ * holder released at 300ms the retry would succeed at ~1000ms -- ten times past
+ * the 100ms the caller asked for. Capping the sleep at the remaining time keeps
+ * every wake-up at or before the deadline, so the loop can only ever give up
+ * close to when it said it would, never long after.
+ */
+export async function acquireWithBoundedWait<T>(
+    acquire: () => Promise<T>,
+    options: BoundedLockRetryOptions,
+): Promise<T> {
+    const deadline = Date.now() + options.timeoutMs;
+    for (;;) {
+        try {
+            // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Ordered retries prevent a later acquire from overtaking an earlier request.
+            return await acquire();
+        } catch (error) {
+            if (!(error instanceof RepositoryLockBusyError)) throw error;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) throw error;
+            await new Promise<void>((resolve) =>
+                setTimeout(resolve, Math.min(options.retryDelayMs, remainingMs)),
+            );
+        }
+    }
+}

--- a/src/git/executor.ts
+++ b/src/git/executor.ts
@@ -202,6 +202,13 @@ export class GitExecutor {
             child.once("close", (exitCode, signal) => {
                 void finish(exitCode, signal);
             });
+            // A child that exits without draining stdin breaks the pipe, so this end() fails
+            // with EPIPE on the stream -- not on the process, which is all the handler above
+            // listens to. An unhandled stream error is an uncatchable crash rather than a
+            // rejected promise, so it takes a whole run down while every test in it passes.
+            // The close handler already reports the real outcome, so a write that lost the
+            // race to the child's exit carries nothing the caller does not already get.
+            child.stdin.once("error", () => undefined);
             if (options.input) child.stdin.end(options.input);
             else child.stdin.end();
         });

--- a/src/git/executor.ts
+++ b/src/git/executor.ts
@@ -203,16 +203,39 @@ export class GitExecutor {
                 void finish(exitCode, signal);
             });
             // A child that exits without draining stdin breaks the pipe, so this end() fails
-            // with EPIPE on the stream -- not on the process, which is all the handler above
-            // listens to. An unhandled stream error is an uncatchable crash rather than a
-            // rejected promise, so it takes a whole run down while every test in it passes.
-            // The close handler already reports the real outcome, so a write that lost the
-            // race to the child's exit carries nothing the caller does not already get.
-            child.stdin.once("error", () => undefined);
+            // on the stream -- not on the process, which is all the handler above listens to.
+            // An unhandled stream error is an uncatchable crash rather than a rejected promise,
+            // so it takes a whole run down while every test in it passes. Only the failures the
+            // child's own exit already accounts for are absorbed here: any other one means the
+            // input never fully arrived, and swallowing it would report a clean exit for a
+            // command that read a truncated stdin.
+            child.stdin.once("error", (error: NodeJS.ErrnoException) => {
+                if (!isExpectedStdinFailure(error, terminatedForOutputLimit)) reject(error);
+            });
             if (options.input) child.stdin.end(options.input);
             else child.stdin.end();
         });
     }
+}
+
+/**
+ * Whether a stdin write failure is one the child's own exit already explains.
+ *
+ * `EPIPE` means the child was gone before the input landed, which the close handler reports
+ * on its own terms; there is nothing left to say about it. `ERR_STREAM_DESTROYED` is only
+ * that harmless when this executor destroyed the stream itself by killing a child that
+ * overran the output limit -- otherwise the stream died for a reason nobody recorded.
+ *
+ * Everything else is a genuine write failure, and it has to reach the caller. Git reads the
+ * input it was given and exits 0 on what it got, so a swallowed failure here is reported as a
+ * successful command that silently ran on a truncated stdin.
+ */
+export function isExpectedStdinFailure(
+    error: NodeJS.ErrnoException,
+    terminatedForOutputLimit: boolean,
+): boolean {
+    if (error.code === "EPIPE") return true;
+    return error.code === "ERR_STREAM_DESTROYED" && terminatedForOutputLimit;
 }
 
 /** Called after a Git command the user initiated has completed successfully. */

--- a/src/git/repositoryMutationGate.ts
+++ b/src/git/repositoryMutationGate.ts
@@ -1,7 +1,8 @@
 import { realpath } from "node:fs/promises";
 import path from "node:path";
 import { RepositoryMutationCoordinator } from "./mutationCoordinator";
-import { RepositoryLock, RepositoryLockBusyError } from "./repositoryLock";
+import { acquireWithBoundedWait } from "./boundedLockRetry";
+import { RepositoryLock } from "./repositoryLock";
 
 /** Tuning for how long a mutation briefly waits on a busy cross-process lock. */
 export interface RepositoryMutationGateOptions {
@@ -51,17 +52,10 @@ export class RepositoryMutationGate {
      * another window queue instead of failing; persistent owners still surface busy.
      */
     private async acquireWithBriefWait(commonDir: string): Promise<() => Promise<void>> {
-        const deadline = Date.now() + this.acquireTimeoutMs;
-        for (;;) {
-            try {
-                // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Ordered retries prevent a later acquire from overtaking an earlier mutation request.
-                return await this.lock.acquire(commonDir);
-            } catch (error) {
-                if (!(error instanceof RepositoryLockBusyError) || Date.now() >= deadline)
-                    throw error;
-            }
-            await new Promise<void>((resolve) => setTimeout(resolve, this.acquireRetryDelayMs));
-        }
+        return acquireWithBoundedWait(() => this.lock.acquire(commonDir), {
+            timeoutMs: this.acquireTimeoutMs,
+            retryDelayMs: this.acquireRetryDelayMs,
+        });
     }
 
     /** Resolves Git's relative common-dir response against the active worktree root. */

--- a/src/shelf/store.ts
+++ b/src/shelf/store.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
-import { RepositoryLock } from "../git/repositoryLock";
+import { RepositoryLock, RepositoryLockBusyError } from "../git/repositoryLock";
 import {
     assertShelfInternalParent,
     ensureShelfInternalParent,
@@ -90,9 +90,13 @@ export interface ShelfJournalShelfLink {
     readonly id: string;
     readonly generation: number;
 }
-/** Test seams for atomic current-pointer replacement. */
+/** Test seams for atomic current-pointer replacement, and store-lock wait tuning. */
 export interface ShelfStoreOptions {
     readonly beforeCurrentPointerRename?: () => Promise<void>;
+    /** How long a busy store lock is retried before the caller sees busy. Defaults to 5s. */
+    readonly acquireTimeoutMs?: number;
+    /** Delay between attempts while the store lock is busy. Defaults to 150ms. */
+    readonly acquireRetryDelayMs?: number;
 }
 /** Raised when a persisted shelf artifact cannot be safely parsed or verified. */
 export class ShelfStoreCorruptionError extends Error {
@@ -161,11 +165,36 @@ export class ShelfStore {
         if (this.lockContext.getStore()) return operation();
         await ensureShelfRoot(this.paths);
         await ensureShelfInternalParent(this.paths, path.join(".store-lock", STORE_LOCK_FILE));
-        const release = await this.lock.acquire(this.paths.root);
+        const release = await this.acquireWithBriefWait();
         try {
             return await this.lockContext.run(true, operation);
         } finally {
             await release();
+        }
+    }
+
+    /**
+     * Retries a busy store lock for a bounded window, mirroring the repository gate.
+     *
+     * Not every caller of this lock holds that gate first. `ShelfService.listShelves`
+     * reads the catalog outside it, so without a wait an ordinary shelf mutation in
+     * another window makes the panel's own read fail rather than queue behind it --
+     * and the panel falls back to cached shelves, showing stale state with no error.
+     * A persistent owner still surfaces busy once the window is spent.
+     */
+    private async acquireWithBriefWait(): Promise<() => Promise<void>> {
+        const deadline = Date.now() + (this.options.acquireTimeoutMs ?? 5_000);
+        for (;;) {
+            try {
+                // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Ordered retries prevent a later acquire from overtaking an earlier store request.
+                return await this.lock.acquire(this.paths.root);
+            } catch (error) {
+                if (!(error instanceof RepositoryLockBusyError) || Date.now() >= deadline)
+                    throw error;
+            }
+            await new Promise<void>((resolve) =>
+                setTimeout(resolve, this.options.acquireRetryDelayMs ?? 150),
+            );
         }
     }
 

--- a/src/shelf/store.ts
+++ b/src/shelf/store.ts
@@ -93,7 +93,7 @@ export interface ShelfJournalShelfLink {
 /** Test seams for atomic current-pointer replacement, and store-lock wait tuning. */
 export interface ShelfStoreOptions {
     readonly beforeCurrentPointerRename?: () => Promise<void>;
-    /** How long a busy store lock is retried before the caller sees busy. Defaults to 5s. */
+    /** How long a busy store lock is retried before the caller sees busy. Defaults to 1s. */
     readonly acquireTimeoutMs?: number;
     /** Delay between attempts while the store lock is busy. Defaults to 150ms. */
     readonly acquireRetryDelayMs?: number;
@@ -181,9 +181,18 @@ export class ShelfStore {
      * another window makes the panel's own read fail rather than queue behind it --
      * and the panel falls back to cached shelves, showing stale state with no error.
      * A persistent owner still surfaces busy once the window is spent.
+     *
+     * The window is deliberately shorter than the repository gate's 5s. That gate
+     * guards a mutation the user just asked for, where waiting is the expected cost.
+     * This one is reached from the commit panel's aggregate refresh, which acquires
+     * twice per pass and runs alongside working-tree status, stashes and ahead/behind
+     * -- so its wait is a stall on unrelated data. A second covers the shelf mutations
+     * that actually caused this (hundreds of milliseconds); anything slower was always
+     * going to land on the panel's cached-shelf fallback, and reaching it sooner beats
+     * holding the whole refresh to find out.
      */
     private async acquireWithBriefWait(): Promise<() => Promise<void>> {
-        const deadline = Date.now() + (this.options.acquireTimeoutMs ?? 5_000);
+        const deadline = Date.now() + (this.options.acquireTimeoutMs ?? 1_000);
         for (;;) {
             try {
                 // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Ordered retries prevent a later acquire from overtaking an earlier store request.

--- a/src/shelf/store.ts
+++ b/src/shelf/store.ts
@@ -2,7 +2,8 @@ import { createHash, randomUUID } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { lstat, mkdir, open, readFile, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
-import { RepositoryLock, RepositoryLockBusyError } from "../git/repositoryLock";
+import { acquireWithBoundedWait } from "../git/boundedLockRetry";
+import { RepositoryLock } from "../git/repositoryLock";
 import {
     assertShelfInternalParent,
     ensureShelfInternalParent,
@@ -192,19 +193,10 @@ export class ShelfStore {
      * holding the whole refresh to find out.
      */
     private async acquireWithBriefWait(): Promise<() => Promise<void>> {
-        const deadline = Date.now() + (this.options.acquireTimeoutMs ?? 1_000);
-        for (;;) {
-            try {
-                // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Ordered retries prevent a later acquire from overtaking an earlier store request.
-                return await this.lock.acquire(this.paths.root);
-            } catch (error) {
-                if (!(error instanceof RepositoryLockBusyError) || Date.now() >= deadline)
-                    throw error;
-            }
-            await new Promise<void>((resolve) =>
-                setTimeout(resolve, this.options.acquireRetryDelayMs ?? 150),
-            );
-        }
+        return acquireWithBoundedWait(() => this.lock.acquire(this.paths.root), {
+            timeoutMs: this.options.acquireTimeoutMs ?? 1_000,
+            retryDelayMs: this.options.acquireRetryDelayMs ?? 150,
+        });
     }
 
     /** Stores a byte object once beneath its shelf and verifies pre-existing content. */

--- a/tests/unit/git/executor.test.ts
+++ b/tests/unit/git/executor.test.ts
@@ -202,12 +202,30 @@ describe("GitExecutor", () => {
         // child is gone. `child.once("error")` listens on the process, not on the stdin
         // stream, and an unhandled stream error is an uncatchable crash rather than a
         // rejected promise: it turned a CI run red while all 4023 tests in it passed.
-        // The close handler already reports the real outcome, which is what this asserts.
-        const output = await runFakeGit("exit 0", ["hash-object", "--stdin"], {
-            input: Buffer.alloc(1024 * 1024, 0x61),
-        });
+        //
+        // Which is exactly why the exit code cannot be the oracle here -- it is 0 whether or
+        // not the stream error is handled, because the crash is asynchronous and takes the
+        // RUN down rather than this test. Observing it needs a listener of our own: attaching
+        // one also suppresses the default crash, so an unhandled EPIPE lands in `uncaught`
+        // instead of aborting the process, and the assertion below can name it.
+        const uncaught: Error[] = [];
+        const collect = (error: Error): void => void uncaught.push(error);
+        process.on("uncaughtException", collect);
+        try {
+            const output = await runFakeGit("exit 0", ["hash-object", "--stdin"], {
+                input: Buffer.alloc(1024 * 1024, 0x61),
+            });
+            // The write races the child's exit, so the failure can land after `close` resolves.
+            await new Promise<void>((resolve) => setTimeout(resolve, 50));
 
-        expect(output.exitCode).toBe(0);
+            expect(output.exitCode).toBe(0);
+            expect(
+                uncaught.map((error) => (error as NodeJS.ErrnoException).code ?? error.message),
+                "a broken stdin pipe must not escape as an uncaught exception",
+            ).toEqual([]);
+        } finally {
+            process.off("uncaughtException", collect);
+        }
     });
 
     it("accepts an explicitly expected non-zero Git exit code", async () => {

--- a/tests/unit/git/executor.test.ts
+++ b/tests/unit/git/executor.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { GitExecutor, setGitSuccessListener } from "../../../src/git/executor";
+import { GitExecutor, isExpectedStdinFailure, setGitSuccessListener } from "../../../src/git/executor";
 import { RepositoryMutationCoordinator } from "../../../src/git/mutationCoordinator";
 import { RepositoryLock } from "../../../src/git/repositoryLock";
 import { RepositoryMutationGate } from "../../../src/git/repositoryMutationGate";
@@ -227,6 +227,30 @@ describe("GitExecutor", () => {
             process.off("uncaughtException", collect);
         }
     });
+
+    it.each([
+        { code: "EPIPE", killed: false, expected: true },
+        { code: "EPIPE", killed: true, expected: true },
+        { code: "ERR_STREAM_DESTROYED", killed: true, expected: true },
+        { code: "ERR_STREAM_DESTROYED", killed: false, expected: false },
+        { code: "ENOSPC", killed: true, expected: false },
+    ])(
+        "treats a $code stdin failure with killed=$killed as expected=$expected",
+        ({ code, killed, expected }) => {
+            // The two `false` rows are the ones that matter, and neither is reachable from an
+            // integration test -- a real child cannot be made to fail its stdin with ENOSPC, and
+            // a stream this executor never destroyed cannot report ERR_STREAM_DESTROYED. They are
+            // exactly the failures the previous blanket `() => undefined` handler swallowed: Git
+            // exits 0 on however much stdin it managed to read, so an absorbed write failure is
+            // handed back as a successful command that quietly ran on truncated input.
+            const error: NodeJS.ErrnoException = Object.assign(new Error(code), { code });
+
+            expect(
+                isExpectedStdinFailure(error, killed),
+                "only a failure the child's own exit already explains may be absorbed",
+            ).toBe(expected);
+        },
+    );
 
     it("accepts an explicitly expected non-zero Git exit code", async () => {
         const executor = new GitExecutor(process.cwd());

--- a/tests/unit/git/executor.test.ts
+++ b/tests/unit/git/executor.test.ts
@@ -196,6 +196,20 @@ describe("GitExecutor", () => {
         expect(output.stdout.toString("utf8")).toMatch(/^[a-f0-9]{40}\n$/);
     });
 
+    itPosix("settles from the child's exit when a large input breaks the stdin pipe", async () => {
+        // The fake git exits without ever reading stdin, and an input far larger than the OS
+        // pipe buffer cannot be absorbed by it, so closing stdin fails with EPIPE once the
+        // child is gone. `child.once("error")` listens on the process, not on the stdin
+        // stream, and an unhandled stream error is an uncatchable crash rather than a
+        // rejected promise: it turned a CI run red while all 4023 tests in it passed.
+        // The close handler already reports the real outcome, which is what this asserts.
+        const output = await runFakeGit("exit 0", ["hash-object", "--stdin"], {
+            input: Buffer.alloc(1024 * 1024, 0x61),
+        });
+
+        expect(output.exitCode).toBe(0);
+    });
+
     it("accepts an explicitly expected non-zero Git exit code", async () => {
         const executor = new GitExecutor(process.cwd());
 

--- a/tests/unit/git/repositoryMutationGate.test.ts
+++ b/tests/unit/git/repositoryMutationGate.test.ts
@@ -51,6 +51,41 @@ describe("RepositoryMutationGate", () => {
         await release();
     });
 
+    it("gives up on a busy lock within its bounded wait, not the full uncapped retry delay", async () => {
+        const repoRoot = await tempDir("intelligit-gate-root-");
+        const common = await tempDir("intelligit-gate-common-");
+        const holder = new RepositoryLock();
+        const release = await holder.acquire(common);
+        const holderReleased = new Promise<void>((resolve) => {
+            setTimeout(() => void release().then(resolve, resolve), 300);
+        });
+
+        // On the pre-fix code, the retry loop slept the FULL 1000ms retry delay after its
+        // first busy failure regardless of how little of the 100ms deadline remained, so this
+        // acquisition SUCCEEDED at ~1000ms -- a full order of magnitude past the 100ms window
+        // the caller asked for, and 700ms after the holder actually released at 300ms.
+        const attemptStartedAt = Date.now();
+
+        await expect(
+            gate({ acquireTimeoutMs: 100, acquireRetryDelayMs: 1000 }).run(
+                repoRoot,
+                common,
+                async () => "ran",
+            ),
+        ).rejects.toBeInstanceOf(RepositoryLockBusyError);
+        const elapsedMs = Date.now() - attemptStartedAt;
+
+        // Bounded well below where an uncapped sleep lands rather than tight against the
+        // deadline: the rejection above is what discriminates the defect, since the pre-fix
+        // loop resolves and never reaches here. This only has to catch a later regression
+        // that gives up too late, and a margin sized for that does not flake under load.
+        expect(
+            elapsedMs,
+            "the bounded wait must give up near its 100ms deadline, not sleep the full 1000ms retry delay",
+        ).toBeLessThan(700);
+        await holderReleased;
+    });
+
     it("serializes overlapping mutations for one repository root", async () => {
         const repoRoot = await tempDir("intelligit-gate-root-");
         const common = await tempDir("intelligit-gate-common-");

--- a/tests/unit/shelf/store.test.ts
+++ b/tests/unit/shelf/store.test.ts
@@ -311,11 +311,18 @@ describe("ShelfStore", () => {
 
     it("serializes store mutations and records all Phase-1 journal transition states", async () => {
         const { paths, store } = await makeStore();
-        const second = new ShelfStore(paths);
+        // A short window rather than the 5s default: the owner below never releases while the
+        // contender runs, so this asserts the wait GIVES UP and still surfaces busy.
+        const second = new ShelfStore(paths, { acquireTimeoutMs: 20, acquireRetryDelayMs: 5 });
         await store.withLock(async () => {
+            const startedAt = Date.now();
             await expect(second.withLock(async () => undefined)).rejects.toThrow(
                 "already in progress",
             );
+            expect(
+                Date.now() - startedAt,
+                "a permanently held lock must surface busy, not be waited on forever",
+            ).toBeLessThan(2_000);
         });
 
         await store.writeJournal({ id: "tx-1", state: "shelvePendingRevert", pathProgress: {} });
@@ -328,6 +335,42 @@ describe("ShelfStore", () => {
             { id: "tx-2", state: "applied", pathProgress: {} },
             { id: "tx-3", state: "ghost", pathProgress: {} },
         ]);
+    });
+
+    it("queues a catalog read behind an in-flight mutation instead of failing it", async () => {
+        const { paths, store } = await makeStore();
+        // `ShelfService.listShelves` reads the catalog WITHOUT holding the repository mutation
+        // gate, so it meets an ordinary shelf mutation directly on the store lock. Before the
+        // bounded wait, that read threw `RepositoryLockBusyError` the instant a mutation was in
+        // flight, and the commit panel's cached-shelf fallback turned it into silent stale state.
+        const reader = new ShelfStore(paths, { acquireRetryDelayMs: 5 });
+        // Warm the uncontended path so the contended one reaches acquire promptly.
+        await reader.listShelves();
+
+        const order: string[] = [];
+        let lockIsHeld!: () => void;
+        const holderOwnsLock = new Promise<void>((resolve) => {
+            lockIsHeld = resolve;
+        });
+        const holder = store.withLock(async () => {
+            lockIsHeld();
+            await new Promise<void>((resolve) => setTimeout(resolve, 150));
+            order.push("mutation-released");
+        });
+
+        await holderOwnsLock;
+        const read = reader.listShelves().then((listed) => {
+            order.push("read-completed");
+            return listed;
+        });
+
+        // Settled together so a rejected read cannot escape as an unhandled rejection.
+        const [, listed] = await Promise.all([holder, read]);
+        expect(listed.shelfIds, "the queued read must return the catalog, not fail").toEqual([]);
+        expect(
+            order,
+            "the read must wait for the mutation to release the lock rather than fail against it",
+        ).toEqual(["mutation-released", "read-completed"]);
     });
 
     it("round-trips a validated persisted shelf contract with metadata and per-layer artifacts", async () => {

--- a/tests/unit/shelf/store.test.ts
+++ b/tests/unit/shelf/store.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { RepositoryLockBusyError } from "../../../src/git/repositoryLock";
 import { ensureShelfRoot, resolveShelfPaths, ShelfPathError } from "../../../src/shelf/paths";
 import {
     ShelfStaleCatalogError,
@@ -391,6 +392,41 @@ describe("ShelfStore", () => {
             readTookMs,
             "the read must have actually waited on the held lock, not slipped past it",
         ).toBeGreaterThanOrEqual(300);
+    });
+
+    it("gives up on a busy store lock within its bounded wait, not the full uncapped retry delay", async () => {
+        const { paths, store } = await makeStore();
+        let lockIsHeld!: () => void;
+        const holderOwnsLock = new Promise<void>((resolve) => {
+            lockIsHeld = resolve;
+        });
+        const holder = store.withLock(async () => {
+            lockIsHeld();
+            await new Promise<void>((resolve) => setTimeout(resolve, 300));
+        });
+        await holderOwnsLock;
+
+        // On the pre-fix code, the retry loop slept the FULL 1000ms retry delay after its
+        // first busy failure regardless of how little of the 100ms deadline remained, so this
+        // acquisition SUCCEEDED at ~1000ms -- a full order of magnitude past the 100ms window
+        // the caller asked for, and 700ms after the holder actually released at 300ms.
+        const second = new ShelfStore(paths, { acquireTimeoutMs: 100, acquireRetryDelayMs: 1000 });
+        const attemptStartedAt = Date.now();
+
+        await expect(second.withLock(async () => undefined)).rejects.toBeInstanceOf(
+            RepositoryLockBusyError,
+        );
+        const elapsedMs = Date.now() - attemptStartedAt;
+
+        // Bounded well below where an uncapped sleep lands rather than tight against the
+        // deadline: the rejection above is what discriminates the defect, since the pre-fix
+        // loop resolves and never reaches here. This only has to catch a later regression
+        // that gives up too late, and a margin sized for that does not flake under load.
+        expect(
+            elapsedMs,
+            "the bounded wait must give up near its 100ms deadline, not sleep the full 1000ms retry delay",
+        ).toBeLessThan(700);
+        await holder;
     });
 
     it("round-trips a validated persisted shelf contract with metadata and per-layer artifacts", async () => {

--- a/tests/unit/shelf/store.test.ts
+++ b/tests/unit/shelf/store.test.ts
@@ -311,18 +311,24 @@ describe("ShelfStore", () => {
 
     it("serializes store mutations and records all Phase-1 journal transition states", async () => {
         const { paths, store } = await makeStore();
-        // A short window rather than the 5s default: the owner below never releases while the
+        // A short window rather than the default: the owner below never releases while the
         // contender runs, so this asserts the wait GIVES UP and still surfaces busy.
         const second = new ShelfStore(paths, { acquireTimeoutMs: 20, acquireRetryDelayMs: 5 });
         await store.withLock(async () => {
-            const startedAt = Date.now();
-            await expect(second.withLock(async () => undefined)).rejects.toThrow(
-                "already in progress",
-            );
+            // Raced rather than awaited outright: a wait that never gives up would otherwise
+            // surface only as the runner's own timeout, which names nothing and takes 30s to
+            // say it. This resolves the failing case to a value the assertion can quote.
+            const outcome = await Promise.race([
+                second.withLock(async () => undefined).then(
+                    () => "acquired",
+                    (error: Error) => error.message,
+                ),
+                new Promise<string>((resolve) => setTimeout(() => resolve("still-waiting"), 1_000)),
+            ]);
             expect(
-                Date.now() - startedAt,
+                outcome,
                 "a permanently held lock must surface busy, not be waited on forever",
-            ).toBeLessThan(2_000);
+            ).toContain("already in progress");
         });
 
         await store.writeJournal({ id: "tx-1", state: "shelvePendingRevert", pathProgress: {} });
@@ -343,7 +349,11 @@ describe("ShelfStore", () => {
         // gate, so it meets an ordinary shelf mutation directly on the store lock. Before the
         // bounded wait, that read threw `RepositoryLockBusyError` the instant a mutation was in
         // flight, and the commit panel's cached-shelf fallback turned it into silent stale state.
-        const reader = new ShelfStore(paths, { acquireRetryDelayMs: 5 });
+        //
+        // Constructed with NO options, so the wait it survives is the shipped default. The
+        // 400ms hold below is what pins that default: it is the one assertion that fails if
+        // the window is quietly shortened to something the mutations this fixes outlast.
+        const reader = new ShelfStore(paths);
         // Warm the uncontended path so the contended one reaches acquire promptly.
         await reader.listShelves();
 
@@ -354,11 +364,12 @@ describe("ShelfStore", () => {
         });
         const holder = store.withLock(async () => {
             lockIsHeld();
-            await new Promise<void>((resolve) => setTimeout(resolve, 150));
+            await new Promise<void>((resolve) => setTimeout(resolve, 400));
             order.push("mutation-released");
         });
 
         await holderOwnsLock;
+        const readStartedAt = Date.now();
         const read = reader.listShelves().then((listed) => {
             order.push("read-completed");
             return listed;
@@ -366,11 +377,20 @@ describe("ShelfStore", () => {
 
         // Settled together so a rejected read cannot escape as an unhandled rejection.
         const [, listed] = await Promise.all([holder, read]);
+        const readTookMs = Date.now() - readStartedAt;
+
         expect(listed.shelfIds, "the queued read must return the catalog, not fail").toEqual([]);
         expect(
             order,
             "the read must wait for the mutation to release the lock rather than fail against it",
         ).toEqual(["mutation-released", "read-completed"]);
+        // Ordering alone is entailed by "the read did not throw" -- a read that never met the
+        // lock at all produces the same array. Only the elapsed time witnesses the contention
+        // this test claims to exercise, and only it fails when the default window shrinks.
+        expect(
+            readTookMs,
+            "the read must have actually waited on the held lock, not slipped past it",
+        ).toBeGreaterThanOrEqual(300);
     });
 
     it("round-trips a validated persisted shelf contract with metadata and per-layer artifacts", async () => {


### PR DESCRIPTION
Two independent fixes, both prepped and verified while #201 was in flight.

## 1. An unread stdin pipe took down the whole test run

`GitExecutor` listened for `error` on the child *process* but never on `child.stdin`. When a Git command exits before consuming all of its input, `end()` fails with `EPIPE` on the stream — and an unhandled stream `error` event is an uncatchable crash, not a rejected promise. So one command's lost write killed the entire run.

The signature is nasty: **4023 tests pass, the run still exits 1**, with nothing but a quiet `Errors 1 error` line to say why.

`src/git/executor.ts` now attaches a no-op `error` handler to `child.stdin`. Nothing is lost — the `close` handler already reports the command's real exit code and stderr.

## 2. Listing shelves failed instead of waiting

`ShelfStore.withLock` called `lock.acquire()` exactly once and let `RepositoryLockBusyError` escape.

Every *mutating* caller already gets a retry from `RepositoryMutationGate`, so this was invisible from every write path. The one caller that reaches the store lock ungated is `ShelfService.listShelves` (`src/services/shelfService.ts:434`), the commit panel's own catalog read — so an ordinary shelf mutation in another window made the panel's read fail outright, and `CommitPanelViewProvider`'s cached-shelf `.catch()` turned that into **stale shelves shown with no error at all**.

`withLock` now retries a busy lock for a bounded window before surfacing busy.

## What the review changed

An adversarial review of the above found three defects in the fixes themselves. All three are fixed here:

- **The wait was 5s, copied from `RepositoryMutationGate`.** That gate guards a mutation the user just asked for. This lock is acquired *twice per pass* by `listShelves`, inside the commit panel's aggregate refresh — alongside working-tree status, stashes and ahead/behind. So the wait was up to 10s of stall on unrelated panel data before falling back to the same cached shelves it would have shown immediately. **Now 1s**, which covers the sub-second mutations that motivated the fix; anything slower was always landing on that fallback.
- **The EPIPE test could not detect its own regression.** Its only assertion was `exitCode === 0`, which holds with *and* without the fix — the crash is asynchronous and takes the run down, not the test. Removing the fix left all 30 tests green. It now installs its own `uncaughtException` listener, which both suppresses the abort and turns the escaped error into a value an assertion can name.
- **The default window had no oracle** — 200ms would have passed the whole suite. The queued-read test now runs on a default-constructed store against a 400ms hold, and asserts the read's *elapsed time*, not only its ordering. Ordering alone is entailed by "the read did not throw", so a read that never met the lock produced the same array.

## Verification

Full CI `build` job mirrored locally, 12/12 gates: `format:check`, `react-doctor`, `lint:strict`, `deps:check:strict`, `architecture:check`, `verify:manifest`, `l10n:validate`, `l10n:audit`, `typecheck`, `test:coverage`, `build`, `package`.

`Test Files 290 passed (290)`, `Tests 3984 passed (3984)`, no `Errors` line.

Mutation-proved — each red names its own assertion, no timeouts, no run-level footers:

| mutation | red |
|---|---|
| retry loop removed | `queues a catalog read behind an in-flight mutation` → `RepositoryLockBusyError` |
| deadline check deleted | `serializes store mutations…` 1010ms → `expected 'still-waiting' to contain 'already in progress'` |
| default cut 1000ms → 200ms | `queues a catalog read…` 322ms |
| stdin handler removed | `settles from the child's exit…` → `1 failed \| 29 passed` |

## Known, deliberately not fixed here

An **unparseable** lock file raises the same `RepositoryLockBusyError` as a held one, but can never resolve: `readOwner` returns `undefined` for a parse failure exactly as it does for ENOENT, so the `!existing` branch throws busy before the staleness/liveness takeover path is ever consulted. Measured — a zero-length lock file never self-heals, while a parseable-but-ancient one recovers in ~10ms.

This is **pre-existing**: `git diff main...HEAD -- src/git/repositoryLock.ts` is empty, and `RepositoryMutationGate` on main already retries the identical lock the identical way. The only delta here is that reaching the unavoidable error now takes ~1s instead of ~2ms. The fix belongs in `repositoryLock.ts`, where it also fixes main, and is worth its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when Git operations close unexpectedly, preventing broken-pipe errors from causing failures.
  * Improved handling of simultaneous shelf operations by waiting briefly for active changes to finish and reporting a clear error if contention persists.
  * Catalog reads now wait for in-progress shelf updates before returning results.

* **Maintenance**
  * Updated the extension version to 0.25.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->