### PR TITLE
fix(test): decide lock-record replacement by a held-open reader, not a reusable inode (v0.25.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.10] - 2026-08-18
+
+### Fixed
+
+- Published 0.25.9, which was built and then never released. A test covering how IntelliGit writes the marker that names the window currently changing a repository was checking the wrong thing: it identified the marker file by a number the operating system is free to hand out again once a file is gone, and every renewal of the marker releases the previous one. On Linux that number came straight back, so the test's verdict depended on how many renewals happened to fit in the moment it waited — it passed twice and then failed, which stopped the release. It now holds the file open and checks that the renewal leaves it untouched, which is the behaviour that actually matters. Nothing in the extension itself changed between the two versions.
+
 ## [0.25.9] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.9",
+    "version": "0.25.10",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/tests/unit/git/repositoryLock.test.ts
+++ b/tests/unit/git/repositoryLock.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -80,21 +80,41 @@ describe("RepositoryLock", () => {
         const common = await commonDir();
         const lockPath = path.join(common, "intelligit", "repo.lock");
         const release = await new RepositoryLock({ heartbeatIntervalMs: 10 }).acquire(common);
+        // Rewriting in place is what makes a live owner briefly indistinguishable from
+        // abandoned residue: `writeFile` truncates at open and writes the bytes as a separate
+        // step, so an owner whose thread stalls between the two leaves an empty file --
+        // unparseable, and with no pid left in it for the liveness probe to rescue the owner
+        // with. Publishing by rename is the difference, and a reader already holding the file
+        // open is what witnesses it: the rename leaves that reader's file untouched, while an
+        // in-place rewrite truncates the very bytes it is holding. Reading the PATH instead
+        // would pass either way, because both forms do update the record found there.
+        //
+        // The held-open handle is also the only thing that makes this decidable. Inode numbers
+        // cannot answer it: `publishLockRecord` renames one fixed temporary path per owner, so
+        // each heartbeat frees the inode the previous one published and the allocator hands it
+        // straight back. Measured on ext4, eight publishes cycled between exactly two inodes,
+        // returning to the starting one on every even heartbeat -- so an inode comparison here
+        // is a coin flip that lands on the count of heartbeats that happened to fit in the
+        // wait. Holding the file open pins its inode, which can then be neither reused nor
+        // rewritten behind this assertion.
         try {
-            // Rewriting in place is what makes a live owner briefly indistinguishable from
-            // abandoned residue: `writeFile` truncates at open and writes the bytes as a
-            // separate step, so an owner whose thread stalls between the two leaves an empty
-            // file -- unparseable, and with no pid left in it for the liveness probe to rescue
-            // the owner with. Publishing by rename is the difference, and file identity at the
-            // path is what witnesses it: comparing contents would pass either way, because both
-            // forms do update the record.
-            const claimed = await stat(lockPath, { bigint: true });
-            await new Promise<void>((resolve) => setTimeout(resolve, 40));
+            const reader = await open(lockPath, "r");
+            try {
+                const claimed = await readFile(lockPath, "utf8");
+                // Wait for a heartbeat to land rather than for a duration: until one record
+                // has been published there is nothing for the two forms to differ about, and
+                // a fixed sleep decides how many landed by how loaded the machine is.
+                await vi.waitFor(async () => {
+                    expect(await readFile(lockPath, "utf8")).not.toBe(claimed);
+                });
 
-            expect(
-                (await stat(lockPath, { bigint: true })).ino,
-                "each heartbeat must publish a new file, never rewrite the one in place",
-            ).not.toBe(claimed.ino);
+                expect(
+                    await reader.readFile({ encoding: "utf8" }),
+                    "each heartbeat must publish a new file, never rewrite the one already open",
+                ).toBe(claimed);
+            } finally {
+                await reader.close();
+            }
         } finally {
             await release();
         }


### PR DESCRIPTION
Fixes the `build` job that has been red on `main` since #207 merged, and releases 0.25.9's work as 0.25.10.

## The failure

```
AssertionError: each heartbeat must publish a new file, never rewrite the one in place:
  expected 9175525n not to be 9175525n
❯ tests/unit/git/repositoryLock.test.ts:97:19
```

The same job passed **twice** on #207 before merge. It is a coin flip, not a regression.

## Root cause

`publishLockRecord` renames one fixed temporary path per owner (`${lockPath}.${nonce}`), so every heartbeat frees the inode the previous one published and the allocator immediately hands it back. Measured with the production publish shape:

| platform | inode after each of 8 publishes | distinct | returns to start |
|---|---|---|---|
| Linux / ext4 | `1136576 → 1136577 → 1136576 → 1136577 → …` | **2** | 4× |
| macOS / APFS | `321229832 → …833 → …834 → …` | 9 | 0 |

So the lock path alternates between exactly two inodes, and the assertion's verdict was decided by whether an odd or even number of heartbeats fit inside a fixed 40ms wait. APFS never reuses, which is why it was green on every local run and on two of three CI runs.

This is a defect in the test's **oracle**, not in the production code and not in the `bigint` change from #207 — `9175525 !== 9175525` fails identically as a plain number.

## The fix

A reader that already holds the file open decides it instead. The open handle pins the inode, so it can be neither reused nor rewritten behind the assertion, and what that reader sees is the property actually worth defending: a rename leaves an already-open reader's file untouched, an in-place rewrite truncates the very bytes it holds. Reading the path would pass either way, since both forms update the record found there.

The wait is now on a heartbeat actually landing (`vi.waitFor`), not on a duration, so machine load cannot decide how many happened.

## Why the version moves

**0.25.9 was never published** — latest release is v0.25.8. The build failure skipped `release-eligibility` and everything downstream.

`version_changed` compares `package.json` at HEAD against the push's before-SHA. Merging this fix on an unchanged 0.25.9 would compare 0.25.9 against 0.25.9, report no change, and strand those fixes on `main` unreleased — the same way 0.25.2 was lost. 0.25.10 carries exactly 0.25.9's code plus this test fix.

The alternative is a manual `workflow_dispatch` with `force_publish` to ship 0.25.9 unchanged after this merges; say so and I will drop the bump instead.

## Test plan

- [x] Oracle discriminates in **both** directions on ext4 and APFS (production → green, in-place rewrite → red)
- [x] **10/10** consecutive runs on macOS
- [x] **10/10** consecutive runs on Linux, in the repo's own pinned `linux/amd64` container
- [x] Mutation: `publishLockRecord` rewriting in place reds `replaces the lock record instead of rewriting the file a reader already opened` by name on both platforms
- [x] Full 12-gate CI mirror: 290 files, 3997 tests, all rc=0
