### PR TITLE
chore(format): close the format:check gate gap over tests/unit, and restore CodeRabbit review of the test tree (1 of 2)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,27 +3,26 @@
 # CodeRabbit reviews at most 100 changed files per pull request; past that it
 # reviews nothing at all. There is no setting for the cap — the only lever is
 # `path_filters`, which CodeRabbit applies as a sparse-checkout, so excluded
-# files are never even fetched. This file therefore spends the 100 slots
-# deliberately instead of letting a large branch spill over the edge.
+# files are never even fetched.
 #
-# Priority: every source file gets reviewed. What is cut is generated or
-# mechanical content (translations, docs, release notes) plus the test suites
-# whose failures are loud and local. What survives is the shelf engine and the
-# git concurrency layer — the two places where a wrong assertion hides a real
-# defect instead of turning CI red.
+# This file used to spend those 100 slots as a budget: eight test directories
+# were excluded so that a large branch would fit under the cap. That trade does
+# not hold up. A `path_filter` is permanent and repository-wide, so buying room
+# for one branch blinds the reviewer on every file that lands in those
+# directories afterwards. It had hidden 110 test files — `tests/webview` (42),
+# `tests/unit/services` (24), `tests/unit/views` (14), and five smaller trees —
+# indefinitely, to fit branches that merged long ago.
 #
-# On the shelve-parity branch this leaves 97 of 182 changed files reviewed:
-# 81 source/config and 16 tests. Source count is fixed, so the tests are the
-# only adjustable part. If a branch ever crosses the cap again, cut
-# `tests/unit/git/**` next (5 files), then `tests/unit/shelf/**` (11).
+# The cap is a per-pull-request problem and it has a per-pull-request answer:
+# split the branch. A 200-file pull request is not reviewable by a person
+# either.
 #
-# The visual-testing branch crossed it: 129 changed files, 122 surviving the
-# filters below, so CodeRabbit reviewed none of them. Excluding the pixel
-# baselines brings it to 90. That is the cheapest 32 slots in the repo -- they
-# are binary PNGs, so there is no text for a reviewer to have an opinion about,
-# and a diff on one is either an intended rebaseline or a regression the visual
-# suite itself already failed on. Margin is only 10 files, so the next branch
-# to cross the cap cuts `tests/unit/git/**` as above.
+# So the rule here is about content rather than arithmetic. What stays excluded
+# is what a reviewer cannot form an opinion about: binary images, generated
+# translation data, and prose. Everything that is code — `src`, `scripts`, and
+# the whole test tree — gets reviewed.
+#
+# If a branch crosses 100 files, split it. Do not buy the slots from here.
 reviews:
     path_filters:
         # Translation and docs data: no logic, 12 locales of churn per string.
@@ -48,16 +47,19 @@ reviews:
         # them. Kept separate from the baselines above because these change for
         # documentation reasons rather than as visual-suite output.
         - "!media/screenshots/**"
-        # DOM and host-wiring tests: breakage shows up as a red suite, not as a
-        # silently-passing test, so an extra reviewer buys the least here.
-        - "!tests/webview/**"
-        - "!tests/integration/extension/**"
-        - "!tests/integration/webviews/**"
-        - "!tests/integration/shelf/**"
-        - "!tests/unit/views/**"
-        - "!tests/unit/activation/**"
-        - "!tests/unit/localization/**"
-        - "!tests/unit/services/**"
+        #
+        # Deliberately NOT excluded, though it looks like the same class of
+        # recorded data: `tests/visual/fixtures/**`. Its subdirectories do hold
+        # machine-recorded webview payloads, but three files sit at the top of
+        # that directory and are among the most review-worthy in the repository.
+        # `baselineEnvironment.json` pins the container image by digest, so a
+        # change to it is a supply-chain event. `knownFindings.json` and
+        # `knownLocaleFindings.json` are the known-bad baselines the visual gate
+        # ratchets against, which makes them the one place a real regression can
+        # be accepted silently. Excluding the subdirectories alone would need
+        # `tests/visual/fixtures/*/**`, whose behaviour on the top-level files
+        # depends on trailing-`/**` semantics; 12 slots are not worth guessing
+        # at a glob that might blind the ratchet.
     # Dependabot pull requests. CodeRabbit already skips them today -- zero
     # review comments across all 17 dependabot PRs this repo has opened, against
     # 1-18 on every human PR in the same window -- but that skip comes from a

--- a/tests/unit/activation/repositoryCommands.test.ts
+++ b/tests/unit/activation/repositoryCommands.test.ts
@@ -175,23 +175,20 @@ describe("registerRepositoryCommands", () => {
         ]);
     });
 
-    it.each(FENCED_BRANCH_COMMAND_IDS)(
-        "refuses %s while a rebase is active",
-        async (commandId) => {
-            const gitOps = makeGitOps();
-            gitOps.getActiveOperation = vi.fn(async () => "rebase");
-            registerRepositoryCommands(makeDeps(gitOps));
+    it.each(FENCED_BRANCH_COMMAND_IDS)("refuses %s while a rebase is active", async (commandId) => {
+        const gitOps = makeGitOps();
+        gitOps.getActiveOperation = vi.fn(async () => "rebase");
+        registerRepositoryCommands(makeDeps(gitOps));
 
-            await mocks.commands.get(commandId)?.({ branch: { name: "feature/fenced" } });
+        await mocks.commands.get(commandId)?.({ branch: { name: "feature/fenced" } });
 
-            expect(mocks.branchHandlers.get(commandId)).not.toHaveBeenCalled();
-            expect(mocks.showErrorMessage).toHaveBeenCalledTimes(1);
-            // Naming the blocking operation is the user-visible contract, not merely refusing.
-            expect(mocks.showErrorMessage).toHaveBeenCalledWith(
-                "xx:A rebase is in progress — continue or abort it first.",
-            );
-        },
-    );
+        expect(mocks.branchHandlers.get(commandId)).not.toHaveBeenCalled();
+        expect(mocks.showErrorMessage).toHaveBeenCalledTimes(1);
+        // Naming the blocking operation is the user-visible contract, not merely refusing.
+        expect(mocks.showErrorMessage).toHaveBeenCalledWith(
+            "xx:A rebase is in progress — continue or abort it first.",
+        );
+    });
 
     it.each(UNFENCED_BRANCH_COMMAND_IDS)(
         "keeps %s available while a rebase is active",

--- a/tests/unit/commands/commitCommands.test.ts
+++ b/tests/unit/commands/commitCommands.test.ts
@@ -56,7 +56,9 @@ import { handleCommitContextAction } from "../../../src/commands/commitCommands"
 const HASH = "a".repeat(40);
 // Derived from the production decision map rather than restated: a new protocol action lands in
 // whichever matrix its own declared decision puts it in, instead of quietly in neither.
-const fencedActions = COMMIT_ACTION_VALUES.filter((action) => COMMIT_ACTION_FENCE_DECISIONS[action]);
+const fencedActions = COMMIT_ACTION_VALUES.filter(
+    (action) => COMMIT_ACTION_FENCE_DECISIONS[action],
+);
 const unfencedActions = COMMIT_ACTION_VALUES.filter(
     (action) => !COMMIT_ACTION_FENCE_DECISIONS[action],
 );

--- a/tests/unit/commands/operationFence.test.ts
+++ b/tests/unit/commands/operationFence.test.ts
@@ -72,18 +72,18 @@ describe("operation fence", () => {
     ] as const)("shows the translated %s rejection", async (operation, message) => {
         mocks.getActiveOperation.mockResolvedValueOnce(operation);
 
-        await expect(rejectCommitActionWhenOperationInProgress("dropCommit", gitOps())).resolves.toBe(
-            true,
-        );
+        await expect(
+            rejectCommitActionWhenOperationInProgress("dropCommit", gitOps()),
+        ).resolves.toBe(true);
 
         expect(mocks.l10nT).toHaveBeenCalledWith(message);
         expect(mocks.showErrorMessage).toHaveBeenCalledWith(`xx:${message}`);
     });
 
     it("allows a fenced action when no whole-index operation is active", async () => {
-        await expect(rejectCommitActionWhenOperationInProgress("dropCommit", gitOps())).resolves.toBe(
-            false,
-        );
+        await expect(
+            rejectCommitActionWhenOperationInProgress("dropCommit", gitOps()),
+        ).resolves.toBe(false);
 
         expect(mocks.showErrorMessage).not.toHaveBeenCalled();
     });
@@ -121,9 +121,9 @@ describe("operation fence", () => {
     it("fails closed when the operation probe cannot be completed", async () => {
         mocks.getActiveOperation.mockRejectedValueOnce(new Error("EACCES"));
 
-        await expect(rejectCommitActionWhenOperationInProgress("dropCommit", gitOps())).resolves.toBe(
-            true,
-        );
+        await expect(
+            rejectCommitActionWhenOperationInProgress("dropCommit", gitOps()),
+        ).resolves.toBe(true);
 
         expect(mocks.showErrorMessage).toHaveBeenCalledWith(
             "xx:Unable to check whether a Git operation is in progress. Try again before changing history.",

--- a/tests/unit/core/concurrency.test.ts
+++ b/tests/unit/core/concurrency.test.ts
@@ -15,12 +15,16 @@ describe("mapWithConcurrency", () => {
     it("never exceeds the concurrency limit", async () => {
         let active = 0;
         let peak = 0;
-        await mapWithConcurrency(Array.from({ length: 20 }, (_, i) => i), 3, async () => {
-            active += 1;
-            peak = Math.max(peak, active);
-            await new Promise((resolve) => setTimeout(resolve, 5));
-            active -= 1;
-        });
+        await mapWithConcurrency(
+            Array.from({ length: 20 }, (_, i) => i),
+            3,
+            async () => {
+                active += 1;
+                peak = Math.max(peak, active);
+                await new Promise((resolve) => setTimeout(resolve, 5));
+                active -= 1;
+            },
+        );
         expect(peak).toBeLessThanOrEqual(3);
         expect(peak).toBeGreaterThan(1);
     });
@@ -28,10 +32,14 @@ describe("mapWithConcurrency", () => {
     it("processes every item exactly once", async () => {
         const seen = new Set<number>();
         let calls = 0;
-        await mapWithConcurrency(Array.from({ length: 50 }, (_, i) => i), 7, async (item) => {
-            calls += 1;
-            seen.add(item);
-        });
+        await mapWithConcurrency(
+            Array.from({ length: 50 }, (_, i) => i),
+            7,
+            async (item) => {
+                calls += 1;
+                seen.add(item);
+            },
+        );
         expect(calls).toBe(50);
         expect(seen.size).toBe(50);
     });

--- a/tests/unit/core/fileIconTheme.test.ts
+++ b/tests/unit/core/fileIconTheme.test.ts
@@ -11,14 +11,17 @@ interface VscodeState {
     extensionDisposeCount: number;
 }
 
-async function loadResolver(state: VscodeState): Promise<
-    typeof import("../../../src/utils/fileIconTheme")
-> {
+async function loadResolver(
+    state: VscodeState,
+): Promise<typeof import("../../../src/utils/fileIconTheme")> {
     class FakeUri {
         readonly path: string;
         readonly scheme: string;
 
-        constructor(public readonly fsPath: string, scheme = "file") {
+        constructor(
+            public readonly fsPath: string,
+            scheme = "file",
+        ) {
             this.scheme = scheme;
             this.path = fsPath;
         }
@@ -164,7 +167,11 @@ describe("FileIconThemeResolver", () => {
                         contributes: {
                             iconThemes: [{ id: "test-theme", path: "themes/theme.json" }],
                             languages: [
-                                { id: "typescriptreact", extensions: [".tsx"], filenames: ["Dockerfile"] },
+                                {
+                                    id: "typescriptreact",
+                                    extensions: [".tsx"],
+                                    filenames: ["Dockerfile"],
+                                },
                             ],
                         },
                     },
@@ -196,7 +203,9 @@ describe("FileIconThemeResolver", () => {
                 folderIcon: expect.objectContaining({ glyph: "" }),
                 folderExpandedIcon: expect.objectContaining({ glyph: "" }),
             });
-            await expect(resolver.getFolderIconsByName(["src", "repo", "nested / components", ""])).resolves.toEqual(
+            await expect(
+                resolver.getFolderIconsByName(["src", "repo", "nested / components", ""]),
+            ).resolves.toEqual(
                 expect.objectContaining({
                     src: {
                         collapsed: expect.objectContaining({ glyph: "" }),

--- a/tests/unit/e2e/controlChannel.test.ts
+++ b/tests/unit/e2e/controlChannel.test.ts
@@ -453,39 +453,45 @@ describe("activateE2eControlChannel: end-to-end request/response over the real t
      * a watcher can survive an uncaught listener throw and still leave the failure attributed to
      * nothing at all, and a test that only checks the next request would pass in that state.
      */
-    it("logs and skips a non-JSON request body instead of throwing inside the watcher listener", { retry: 2 }, async () => {
-        const { context } = makeContext(vscodeMock.ExtensionMode.Development);
-        const handle = activateE2eControlChannel(context);
-        const logged: string[] = [];
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-            logged.push(args.map((arg) => String(arg)).join(" "));
-        });
+    it(
+        "logs and skips a non-JSON request body instead of throwing inside the watcher listener",
+        { retry: 2 },
+        async () => {
+            const { context } = makeContext(vscodeMock.ExtensionMode.Development);
+            const handle = activateE2eControlChannel(context);
+            const logged: string[] = [];
+            const consoleSpy = vi
+                .spyOn(console, "error")
+                .mockImplementation((...args: unknown[]) => {
+                    logged.push(args.map((arg) => String(arg)).join(" "));
+                });
 
-        try {
-            writeFileSync(join(channelDir, "not-json.request.json"), "{ not json", "utf8");
+            try {
+                writeFileSync(join(channelDir, "not-json.request.json"), "{ not json", "utf8");
 
-            await waitFor(() =>
-                logged.some((line) => line.includes("not-json") && line.includes("unreadable")),
-            );
+                await waitFor(() =>
+                    logged.some((line) => line.includes("not-json") && line.includes("unreadable")),
+                );
 
-            // Skipped, not answered: with a non-atomic writer this same failure is also how a
-            // half-written file looks, and answering it would race a spurious error response
-            // against the real one.
-            expect(existsSync(join(channelDir, "not-json.response.json"))).toBe(false);
+                // Skipped, not answered: with a non-atomic writer this same failure is also how a
+                // half-written file looks, and answering it would race a spurious error response
+                // against the real one.
+                expect(existsSync(join(channelDir, "not-json.response.json"))).toBe(false);
 
-            // The watcher must still answer the next request.
-            const next = await sendAndAwait(channelDir, "after-not-json", {
-                store: "memento",
-                operation: "snapshot",
-                scope: "workspace",
-                key: ALLOWED_WORKSPACE_KEY,
-            });
-            expect(next.ok).toBe(true);
-        } finally {
-            consoleSpy.mockRestore();
-            handle.dispose();
-        }
-    });
+                // The watcher must still answer the next request.
+                const next = await sendAndAwait(channelDir, "after-not-json", {
+                    store: "memento",
+                    operation: "snapshot",
+                    scope: "workspace",
+                    key: ALLOWED_WORKSPACE_KEY,
+                });
+                expect(next.ok).toBe(true);
+            } finally {
+                consoleSpy.mockRestore();
+                handle.dispose();
+            }
+        },
+    );
 
     /**
      * The log line added for the case above must not become a way out for the thing this
@@ -506,31 +512,37 @@ describe("activateE2eControlChannel: end-to-end request/response over the real t
      * The assertion is on the leading characters V8 actually emits, so it fails when the guard
      * is removed, and it does not depend on the wording of the replacement message.
      */
-    it("never echoes the request body when reporting an unreadable request, because a body can carry a secret", { retry: 2 }, async () => {
-        const { context } = makeContext(vscodeMock.ExtensionMode.Development);
-        const handle = activateE2eControlChannel(context);
-        const logged: string[] = [];
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-            logged.push(args.map((arg) => String(arg)).join(" "));
-        });
-        const secretValue = "placeholder-not-a-credential-0000";
+    it(
+        "never echoes the request body when reporting an unreadable request, because a body can carry a secret",
+        { retry: 2 },
+        async () => {
+            const { context } = makeContext(vscodeMock.ExtensionMode.Development);
+            const handle = activateE2eControlChannel(context);
+            const logged: string[] = [];
+            const consoleSpy = vi
+                .spyOn(console, "error")
+                .mockImplementation((...args: unknown[]) => {
+                    logged.push(args.map((arg) => String(arg)).join(" "));
+                });
+            const secretValue = "placeholder-not-a-credential-0000";
 
-        try {
-            writeFileSync(join(channelDir, "leaky.request.json"), secretValue, "utf8");
+            try {
+                writeFileSync(join(channelDir, "leaky.request.json"), secretValue, "utf8");
 
-            await waitFor(() => logged.some((line) => line.includes("leaky")));
+                await waitFor(() => logged.some((line) => line.includes("leaky")));
 
-            expect(
-                logged.join("\n"),
-                "the parse failure was reported with its own message, and V8 builds that message " +
-                    "by quoting the input's leading characters -- so part of a request body, which " +
-                    "for a secret seed is the secret itself, reached a log this suite writes in CI",
-            ).not.toContain(secretValue.slice(0, 10));
-        } finally {
-            consoleSpy.mockRestore();
-            handle.dispose();
-        }
-    });
+                expect(
+                    logged.join("\n"),
+                    "the parse failure was reported with its own message, and V8 builds that message " +
+                        "by quoting the input's leading characters -- so part of a request body, which " +
+                        "for a secret seed is the secret itself, reached a log this suite writes in CI",
+                ).not.toContain(secretValue.slice(0, 10));
+            } finally {
+                consoleSpy.mockRestore();
+                handle.dispose();
+            }
+        },
+    );
 
     /**
      * The failure that happens AFTER `dispatchRequest` has already resolved. `dispatchRequest`
@@ -541,36 +553,42 @@ describe("activateE2eControlChannel: end-to-end request/response over the real t
      * that throw is an unhandled promise rejection in the extension host, attributed to no
      * request at all.
      */
-    it("reports a finalize failure against its own nonce instead of raising an unhandled rejection", { retry: 2 }, async () => {
-        const { context } = makeContext(vscodeMock.ExtensionMode.Development);
-        const handle = activateE2eControlChannel(context);
-        const logged: string[] = [];
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-            logged.push(args.map((arg) => String(arg)).join(" "));
-        });
+    it(
+        "reports a finalize failure against its own nonce instead of raising an unhandled rejection",
+        { retry: 2 },
+        async () => {
+            const { context } = makeContext(vscodeMock.ExtensionMode.Development);
+            const handle = activateE2eControlChannel(context);
+            const logged: string[] = [];
+            const consoleSpy = vi
+                .spyOn(console, "error")
+                .mockImplementation((...args: unknown[]) => {
+                    logged.push(args.map((arg) => String(arg)).join(" "));
+                });
 
-        try {
-            mkdirSync(join(channelDir, "collide.response.json"));
-            writeFileSync(
-                join(channelDir, "collide.request.json"),
-                JSON.stringify({
-                    nonce: "collide",
-                    store: "memento",
-                    operation: "snapshot",
-                    scope: "workspace",
-                    key: ALLOWED_WORKSPACE_KEY,
-                }),
-                "utf8",
-            );
+            try {
+                mkdirSync(join(channelDir, "collide.response.json"));
+                writeFileSync(
+                    join(channelDir, "collide.request.json"),
+                    JSON.stringify({
+                        nonce: "collide",
+                        store: "memento",
+                        operation: "snapshot",
+                        scope: "workspace",
+                        key: ALLOWED_WORKSPACE_KEY,
+                    }),
+                    "utf8",
+                );
 
-            await waitFor(() =>
-                logged.some((line) => line.includes("collide") && line.includes("deliver")),
-            );
-        } finally {
-            consoleSpy.mockRestore();
-            handle.dispose();
-        }
-    });
+                await waitFor(() =>
+                    logged.some((line) => line.includes("collide") && line.includes("deliver")),
+                );
+            } finally {
+                consoleSpy.mockRestore();
+                handle.dispose();
+            }
+        },
+    );
 
     /** Writes a request file and waits for the correlated response file, returning its parsed body. */
     async function sendAndAwait(

--- a/tests/unit/e2e/gitEnv.test.ts
+++ b/tests/unit/e2e/gitEnv.test.ts
@@ -63,9 +63,9 @@ describe("sanitizedGitEnv drops every inherited git pointer", () => {
     it("drops a mixed-case Git_Work_Tree", () => {
         setEnv("Git_Work_Tree", "/somewhere/else");
         const result = sanitizedGitEnv();
-        expect(
-            Object.keys(result).filter((name) => name.toUpperCase().startsWith("GIT_")),
-        ).toEqual([]);
+        expect(Object.keys(result).filter((name) => name.toUpperCase().startsWith("GIT_"))).toEqual(
+            [],
+        );
     });
 
     // The other direction: a filter widened to `includes("GIT_")` would pass every test above

--- a/tests/unit/e2e/handlers/mementoHandler.test.ts
+++ b/tests/unit/e2e/handlers/mementoHandler.test.ts
@@ -33,7 +33,9 @@ function makeMemento(
     } as unknown as vscode.Memento & { setKeysForSync(keys: readonly string[]): void };
 }
 
-function makeContext(): { context: Pick<vscode.ExtensionContext, "globalState" | "workspaceState"> } {
+function makeContext(): {
+    context: Pick<vscode.ExtensionContext, "globalState" | "workspaceState">;
+} {
     return {
         context: {
             globalState: makeMemento(),

--- a/tests/unit/e2e/handlers/secretHandler.test.ts
+++ b/tests/unit/e2e/handlers/secretHandler.test.ts
@@ -25,7 +25,9 @@ function makeSecretStorage(seed: Record<string, string> = {}): vscode.SecretStor
         delete: async (key: string) => {
             map.delete(key);
         },
-        onDidChange: (() => ({ dispose: () => undefined })) as unknown as vscode.SecretStorage["onDidChange"],
+        onDidChange: (() => ({
+            dispose: () => undefined,
+        })) as unknown as vscode.SecretStorage["onDidChange"],
     };
 }
 

--- a/tests/unit/e2e/hostFixtureStalenessComparator.test.ts
+++ b/tests/unit/e2e/hostFixtureStalenessComparator.test.ts
@@ -101,9 +101,7 @@ describe("compareHostFixtureStaleness", () => {
         // fixture becomes byte-identical to the committed one, and `toEqual([])` below passes while
         // proving nothing about the 46KB CSS payload. The anchor is asserted before it is mutated.
         expect(
-            /--vscode-editor-background: [^;]+/.test(
-                committedFixture.documentElement.styleCssText,
-            ),
+            /--vscode-editor-background: [^;]+/.test(committedFixture.documentElement.styleCssText),
             "the committed artifact must still carry the anchor token this proof mutates",
         ).toBe(true);
         const capturedFixture: HostFixture = {

--- a/tests/unit/e2e/protocol.test.ts
+++ b/tests/unit/e2e/protocol.test.ts
@@ -159,7 +159,12 @@ describe("parseE2eRequest: structural rejections", () => {
 
     it("rejects a missing nonce", () => {
         expect(() =>
-            parseE2eRequest({ store: "memento", operation: "snapshot", scope: "workspace", key: "k" }),
+            parseE2eRequest({
+                store: "memento",
+                operation: "snapshot",
+                scope: "workspace",
+                key: "k",
+            }),
         ).toThrow(/nonce/);
     });
 
@@ -177,7 +182,12 @@ describe("parseE2eRequest: structural rejections", () => {
 
     it("rejects an unknown store", () => {
         expect(() =>
-            parseE2eRequest({ nonce: "n1", store: "configuration", operation: "snapshot", key: "k" }),
+            parseE2eRequest({
+                nonce: "n1",
+                store: "configuration",
+                operation: "snapshot",
+                key: "k",
+            }),
         ).toThrow(/store/);
     });
 });

--- a/tests/unit/e2e/secretDigest.test.ts
+++ b/tests/unit/e2e/secretDigest.test.ts
@@ -27,7 +27,9 @@ describe("digestSecret", () => {
     it("differs across different salts for the same value", () => {
         // Proves the digest is not a bare hash: without the salt, an attacker who captured a
         // digest from one process run could dictionary-attack a low-entropy test token.
-        expect(digestSecret("glpat-abc123", "salt-a")).not.toBe(digestSecret("glpat-abc123", "salt-b"));
+        expect(digestSecret("glpat-abc123", "salt-a")).not.toBe(
+            digestSecret("glpat-abc123", "salt-b"),
+        );
     });
 
     it("differs across different values for the same salt", () => {
@@ -35,7 +37,9 @@ describe("digestSecret", () => {
     });
 
     it("differs for values that share a common prefix (no length-extension leakage)", () => {
-        expect(digestSecret("glpat-abc", "salt-a")).not.toBe(digestSecret("glpat-abc123", "salt-a"));
+        expect(digestSecret("glpat-abc", "salt-a")).not.toBe(
+            digestSecret("glpat-abc123", "salt-a"),
+        );
     });
 });
 

--- a/tests/unit/e2e/transportFs.test.ts
+++ b/tests/unit/e2e/transportFs.test.ts
@@ -232,24 +232,28 @@ describe("watchChannelDir", () => {
     // environmental scheduling variance without hiding a real failure: a genuine regression in
     // watchChannelDir fails all 3 attempts, since nothing about the retry changes what is
     // asserted.
-    it("invokes onRequest with the nonce and parsed payload when a request file appears", { timeout: 10_000, retry: 2 }, async () => {
-        const received = new Promise<{ nonce: string; payload: unknown }>((resolve) => {
-            const watcher = watchChannelDir(channelDir, (nonce, payload) => {
-                watcher.dispose();
-                resolve({ nonce, payload });
+    it(
+        "invokes onRequest with the nonce and parsed payload when a request file appears",
+        { timeout: 10_000, retry: 2 },
+        async () => {
+            const received = new Promise<{ nonce: string; payload: unknown }>((resolve) => {
+                const watcher = watchChannelDir(channelDir, (nonce, payload) => {
+                    watcher.dispose();
+                    resolve({ nonce, payload });
+                });
             });
-        });
 
-        writeFileSync(
-            join(channelDir, "watch-nonce.request.json"),
-            JSON.stringify({ hello: "world" }),
-            "utf8",
-        );
+            writeFileSync(
+                join(channelDir, "watch-nonce.request.json"),
+                JSON.stringify({ hello: "world" }),
+                "utf8",
+            );
 
-        const result = await received;
-        expect(result.nonce).toBe("watch-nonce");
-        expect(result.payload).toEqual({ hello: "world" });
-    });
+            const result = await received;
+            expect(result.nonce).toBe("watch-nonce");
+            expect(result.payload).toEqual({ hello: "world" });
+        },
+    );
 
     it("ignores unrelated files written to the same directory", async () => {
         const onRequest = vi.fn();

--- a/tests/unit/e2e/transportFsAtomicWrite.test.ts
+++ b/tests/unit/e2e/transportFsAtomicWrite.test.ts
@@ -50,7 +50,11 @@ describe("writeResponseFileAtomic: temp-file-plus-rename mechanism", () => {
     });
 
     it("writes the full payload to a temp file, then moves it into place with exactly one rename", () => {
-        writeResponseFileAtomic(channelDir, "abc123", { nonce: "abc123", ok: true, big: "x".repeat(500) });
+        writeResponseFileAtomic(channelDir, "abc123", {
+            nonce: "abc123",
+            ok: true,
+            big: "x".repeat(500),
+        });
 
         expect(mocks.calls).toHaveLength(2);
         expect(mocks.calls[0]).toMatch(/^write:/);

--- a/tests/unit/e2e/webviewBridge.test.ts
+++ b/tests/unit/e2e/webviewBridge.test.ts
@@ -23,12 +23,19 @@ interface FakeWebview {
  * simulate the webview-side bridge's reply by invoking the captured listener directly.
  */
 function makeFakeWebview(postMessageResult: boolean | (() => boolean) = true): FakeWebview {
-    const state: FakeWebview = { webview: undefined as unknown as vscode.Webview, posted: [], listeners: [], disposeCalls: 0 };
+    const state: FakeWebview = {
+        webview: undefined as unknown as vscode.Webview,
+        posted: [],
+        listeners: [],
+        disposeCalls: 0,
+    };
 
     state.webview = {
         postMessage: async (message: Record<string, unknown>) => {
             state.posted.push(message);
-            return typeof postMessageResult === "function" ? postMessageResult() : postMessageResult;
+            return typeof postMessageResult === "function"
+                ? postMessageResult()
+                : postMessageResult;
         },
         onDidReceiveMessage: (listener: MessageListener) => {
             state.listeners.push(listener);
@@ -44,7 +51,10 @@ function makeFakeWebview(postMessageResult: boolean | (() => boolean) = true): F
 }
 
 /** Simulates the webview-side bridge replying to the most recently posted correlated call. */
-function replyToLatest(fake: FakeWebview, reply: { ok: true; value: unknown } | { ok: false; error: string }): void {
+function replyToLatest(
+    fake: FakeWebview,
+    reply: { ok: true; value: unknown } | { ok: false; error: string },
+): void {
     const lastMessage = fake.posted[fake.posted.length - 1];
     const callId = lastMessage?.callId as string;
     fake.listeners[fake.listeners.length - 1]?.({ source: "intelligitE2E", callId, ...reply });
@@ -84,7 +94,9 @@ describe("E2eWebviewRegistry: hard failure on a missing webview", () => {
     it("fails with a descriptive error, not an empty snapshot, when no webview is registered", async () => {
         const registry = new E2eWebviewRegistry();
 
-        const response = await registry.handleRequest(snapshotRequest({ viewId: "never-registered" }));
+        const response = await registry.handleRequest(
+            snapshotRequest({ viewId: "never-registered" }),
+        );
 
         expect(response.ok).toBe(false);
         if (!response.ok) {
@@ -174,7 +186,12 @@ describe("E2eWebviewRegistry: correlated round trip", () => {
         const responsePromise = registry.handleRequest(snapshotRequest());
         await flushMicrotasks();
 
-        fake.listeners[0]?.({ source: "intelligitE2E", callId: "unrelated-call-id", ok: true, value: 1 });
+        fake.listeners[0]?.({
+            source: "intelligitE2E",
+            callId: "unrelated-call-id",
+            ok: true,
+            value: 1,
+        });
         fake.listeners[0]?.({ source: "someOtherProtocol", callId: fake.posted[0]?.callId });
 
         replyToLatest(fake, { ok: true, value: "real reply" });

--- a/tests/unit/e2e/webviewCapture.test.ts
+++ b/tests/unit/e2e/webviewCapture.test.ts
@@ -295,9 +295,7 @@ describe("WEBVIEW_CONTEXT_IDS: completeness against the real wiring sites", () =
         // only supported way to wire one: it is what returns the real provider unchanged when
         // the gate is off, so a site that wrapped a provider by any other route would lose
         // identity-equality in production and is deliberately not matched here.
-        for (const match of source.matchAll(
-            /captureWebviewViewProvider\([^,]+,\s*"([a-z-]+)"/g,
-        )) {
+        for (const match of source.matchAll(/captureWebviewViewProvider\([^,]+,\s*"([a-z-]+)"/g)) {
             ids.push(match[1]);
         }
         return ids;

--- a/tests/unit/e2e/webviewHtmlBootstrap.test.ts
+++ b/tests/unit/e2e/webviewHtmlBootstrap.test.ts
@@ -101,7 +101,10 @@ describe("buildWebviewShellHtml E2E bootstrap", () => {
         mockVsCode();
         const register = mockActivationState(true);
 
-        await buildHtml({ scriptFile: "webview-mergeeditor.js", e2eViewId: "merge-editor src/a.ts" });
+        await buildHtml({
+            scriptFile: "webview-mergeeditor.js",
+            e2eViewId: "merge-editor src/a.ts",
+        });
 
         expect(register.mock.calls[0]?.[0]).toBe("merge-editor src/a.ts");
     });

--- a/tests/unit/fixtures/copyTemplate.test.ts
+++ b/tests/unit/fixtures/copyTemplate.test.ts
@@ -12,7 +12,18 @@
  * this package.
  */
 
-import { link, mkdir, mkdtemp, readFile, readlink, realpath, rename, rm, symlink, writeFile } from "node:fs/promises";
+import {
+    link,
+    mkdir,
+    mkdtemp,
+    readFile,
+    readlink,
+    realpath,
+    rename,
+    rm,
+    symlink,
+    writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -33,7 +44,9 @@ describe("copyTemplate", () => {
     });
 
     /** A fresh `source`/`destination` pair under one throwaway work directory, tracked for cleanup. */
-    async function makeWorkspace(prefix: string): Promise<{ readonly source: string; readonly destination: string }> {
+    async function makeWorkspace(
+        prefix: string,
+    ): Promise<{ readonly source: string; readonly destination: string }> {
         const workDir = await mkdtemp(path.join(tmpdir(), `intelligit-copytemplate-${prefix}-`));
         cleanupDirs.push(workDir);
         const source = path.join(workDir, "source");
@@ -63,7 +76,10 @@ describe("copyTemplate", () => {
             expect(findEntry(inventory, "workspace/.git")).toBeDefined();
             expect(findEntry(inventory, "origin.git/HEAD")).toBeDefined();
 
-            const copiedReadme = await readFile(path.join(destination, "workspace", "README.md"), "utf8");
+            const copiedReadme = await readFile(
+                path.join(destination, "workspace", "README.md"),
+                "utf8",
+            );
             expect(copiedReadme).toBe("# IntelliGit Fixture Repo\n");
         });
     });
@@ -86,7 +102,9 @@ describe("copyTemplate", () => {
             const outsideTarget = path.join(tmpdir(), "definitely-not-the-template", "secret.txt");
             await symlink(outsideTarget, path.join(source, "abs-outside-link"));
 
-            await expect(copyTemplate(source, destination)).rejects.toThrow(/absolute target outside the template/);
+            await expect(copyTemplate(source, destination)).rejects.toThrow(
+                /absolute target outside the template/,
+            );
         });
 
         it("rebases a template-contained absolute symlink target onto the copy, resolving inside it", async () => {
@@ -158,7 +176,9 @@ describe("copyTemplate", () => {
 
             // Re-derives what `assertNoSharedInodes` already asserted internally, using evidence
             // this test generated itself rather than trusting `copyTemplate`'s internals (Gate 4).
-            await expect(assertNoSharedInodes(source, destination, inventory)).resolves.not.toThrow();
+            await expect(
+                assertNoSharedInodes(source, destination, inventory),
+            ).resolves.not.toThrow();
         });
 
         it("THROWS when a copy shares an inode with the template -- the deliberate break", async () => {
@@ -171,7 +191,14 @@ describe("copyTemplate", () => {
             await link(path.join(source, "shared.txt"), path.join(destination, "shared.txt"));
 
             const entries: readonly FsEntry[] = [
-                { relativePath: "shared.txt", type: "file", mode: 0o644, digest: null, text: null, symlinkTarget: null },
+                {
+                    relativePath: "shared.txt",
+                    type: "file",
+                    mode: 0o644,
+                    digest: null,
+                    text: null,
+                    symlinkTarget: null,
+                },
             ];
 
             await expect(assertNoSharedInodes(source, destination, entries)).rejects.toThrow(
@@ -192,7 +219,10 @@ describe("copyTemplate", () => {
 
             // Case-only rename, performed directly on the copy -- confirmed empirically on this
             // filesystem to change the recorded case without an intermediate name.
-            await rename(path.join(destination, "MixedCase.txt"), path.join(destination, "mixedcase.txt"));
+            await rename(
+                path.join(destination, "MixedCase.txt"),
+                path.join(destination, "mixedcase.txt"),
+            );
 
             const renamedInventory = await inventoryDirectory({ root: destination });
             expect(findEntry(renamedInventory, "mixedcase.txt")).toBeDefined();

--- a/tests/unit/fixtures/gitTestHelpers.ts
+++ b/tests/unit/fixtures/gitTestHelpers.ts
@@ -25,7 +25,11 @@ import { createSanitizedGitEnv, type SanitizedGitEnv } from "../../fixtures/repo
 const execFileAsync = promisify(execFile);
 
 /** Runs one git process against `cwd` with `env`, returning trimmed UTF-8 stdout. */
-export async function git(cwd: string, args: readonly string[], env: NodeJS.ProcessEnv): Promise<string> {
+export async function git(
+    cwd: string,
+    args: readonly string[],
+    env: NodeJS.ProcessEnv,
+): Promise<string> {
     const result = await execFileAsync("git", [...args], { cwd, env, encoding: "buffer" });
     return result.stdout.toString("utf8").trim();
 }
@@ -63,7 +67,11 @@ export async function createScratchRepo(namePrefix: string): Promise<ScratchRepo
 }
 
 /** Writes `content` to `relativePath` under `root`, creating parent directories as needed. */
-export async function writeRepoFile(root: string, relativePath: string, content: string): Promise<void> {
+export async function writeRepoFile(
+    root: string,
+    relativePath: string,
+    content: string,
+): Promise<void> {
     const absolutePath = path.join(root, relativePath);
     await mkdir(path.dirname(absolutePath), { recursive: true });
     await writeFile(absolutePath, content, "utf8");
@@ -72,7 +80,11 @@ export async function writeRepoFile(root: string, relativePath: string, content:
 /** Stages every pending change and commits it, returning the new commit's SHA. Every commit in
  * this test suite shares `seed.ts`'s fixed author/committer identity and date via `env`, so SHAs
  * stay stable across runs wherever a test happens to assert one directly. */
-export async function commitAll(root: string, env: NodeJS.ProcessEnv, message: string): Promise<string> {
+export async function commitAll(
+    root: string,
+    env: NodeJS.ProcessEnv,
+    message: string,
+): Promise<string> {
     await git(root, ["add", "-A"], env);
     await git(root, ["commit", "--quiet", "-m", message], env);
     return git(root, ["rev-parse", "HEAD"], env);

--- a/tests/unit/fixtures/harness.test.ts
+++ b/tests/unit/fixtures/harness.test.ts
@@ -373,7 +373,8 @@ describe("createFixtureWorkspace", () => {
         it(
             "removes its own root when construction fails, leaving nothing behind under the workspaces root",
             async () => {
-                const { workDir, manifestPath, workspacesRoot } = await seedTemplateAndManifest("failed-construction");
+                const { workDir, manifestPath, workspacesRoot } =
+                    await seedTemplateAndManifest("failed-construction");
 
                 // A manifest whose templateRoot does not exist: `readFixtureManifest` accepts it
                 // (the path is a well-formed absolute string), `mkdtemp` succeeds, and
@@ -387,7 +388,9 @@ describe("createFixtureWorkspace", () => {
                     "utf8",
                 );
 
-                await expect(createFixtureWorkspace({ manifestPath, workspacesRoot })).rejects.toThrow();
+                await expect(
+                    createFixtureWorkspace({ manifestPath, workspacesRoot }),
+                ).rejects.toThrow();
 
                 const leaked = await readdir(workspacesRoot).catch(() => [] as string[]);
                 expect(
@@ -407,20 +410,25 @@ describe("createFixtureWorkspace", () => {
         it(
             "propagates the original construction error rather than a cleanup error",
             async () => {
-                const { workDir, manifestPath, workspacesRoot } = await seedTemplateAndManifest("failed-construction-error");
+                const { workDir, manifestPath, workspacesRoot } = await seedTemplateAndManifest(
+                    "failed-construction-error",
+                );
                 const missingTemplate = path.join(workDir, "template-that-was-never-seeded");
 
                 await writeFile(
                     manifestPath,
-                    JSON.stringify({ schemaVersion: MANIFEST_SCHEMA_VERSION, templateRoot: missingTemplate }),
+                    JSON.stringify({
+                        schemaVersion: MANIFEST_SCHEMA_VERSION,
+                        templateRoot: missingTemplate,
+                    }),
                     "utf8",
                 );
 
                 // A string argument to `toThrow` is a substring check, which is what the escaped
                 // RegExp this replaced was reconstructing by hand.
-                await expect(createFixtureWorkspace({ manifestPath, workspacesRoot })).rejects.toThrow(
-                    missingTemplate,
-                );
+                await expect(
+                    createFixtureWorkspace({ manifestPath, workspacesRoot }),
+                ).rejects.toThrow(missingTemplate);
             },
             FIXTURE_TIMEOUT_MS,
         );

--- a/tests/unit/fixtures/manifest.test.ts
+++ b/tests/unit/fixtures/manifest.test.ts
@@ -133,56 +133,52 @@ describe("manifest", () => {
             expect(renameTo).toBe(manifestPath);
         });
 
-        it(
-            "a concurrent reader never observes a partially-written manifest under real write pressure",
-            async () => {
-                const workDir = await makeWorkDir("race");
-                const manifestPath = path.join(workDir, "manifest.json");
-                // A large `templateRoot`-adjacent payload (still schema-valid: extra keys are not
-                // rejected) gives the temp-file write measurable duration, so a reader polling
-                // during that window has a real chance to observe a bug if one existed -- not just
-                // a theoretical race.
-                const manifest = {
-                    schemaVersion: MANIFEST_SCHEMA_VERSION,
-                    templateRoot: path.join(workDir, "template"),
-                    padding: "x".repeat(8_000_000),
-                } as unknown as FixtureManifest;
+        it("a concurrent reader never observes a partially-written manifest under real write pressure", async () => {
+            const workDir = await makeWorkDir("race");
+            const manifestPath = path.join(workDir, "manifest.json");
+            // A large `templateRoot`-adjacent payload (still schema-valid: extra keys are not
+            // rejected) gives the temp-file write measurable duration, so a reader polling
+            // during that window has a real chance to observe a bug if one existed -- not just
+            // a theoretical race.
+            const manifest = {
+                schemaVersion: MANIFEST_SCHEMA_VERSION,
+                templateRoot: path.join(workDir, "template"),
+                padding: "x".repeat(8_000_000),
+            } as unknown as FixtureManifest;
 
-                let writeDone = false;
-                let observedValid = 0;
-                let observedMissing = 0;
-                let observedUnexpected: unknown = null;
+            let writeDone = false;
+            let observedValid = 0;
+            let observedMissing = 0;
+            let observedUnexpected: unknown = null;
 
-                const writePromise = writeFixtureManifest(manifestPath, manifest).then(() => {
-                    writeDone = true;
-                });
+            const writePromise = writeFixtureManifest(manifestPath, manifest).then(() => {
+                writeDone = true;
+            });
 
-                const pollPromise = (async () => {
-                    while (!writeDone) {
-                        try {
-                            const read = await readFixtureManifest(manifestPath);
-                            observedValid += 1;
-                            if (read.templateRoot !== manifest.templateRoot) {
-                                observedUnexpected = `templateRoot mismatch: ${read.templateRoot}`;
-                            }
-                        } catch (error) {
-                            const message = error instanceof Error ? error.message : String(error);
-                            if (message.includes("no manifest file")) {
-                                observedMissing += 1;
-                            } else {
-                                observedUnexpected = message;
-                            }
+            const pollPromise = (async () => {
+                while (!writeDone) {
+                    try {
+                        const read = await readFixtureManifest(manifestPath);
+                        observedValid += 1;
+                        if (read.templateRoot !== manifest.templateRoot) {
+                            observedUnexpected = `templateRoot mismatch: ${read.templateRoot}`;
+                        }
+                    } catch (error) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        if (message.includes("no manifest file")) {
+                            observedMissing += 1;
+                        } else {
+                            observedUnexpected = message;
                         }
                     }
-                })();
+                }
+            })();
 
-                await Promise.all([writePromise, pollPromise]);
+            await Promise.all([writePromise, pollPromise]);
 
-                expect(observedUnexpected).toBeNull();
-                expect(observedMissing + observedValid).toBeGreaterThan(0);
-            },
-            30_000,
-        );
+            expect(observedUnexpected).toBeNull();
+            expect(observedMissing + observedValid).toBeGreaterThan(0);
+        }, 30_000);
     });
 
     describe("hard failures -- distinct message per cause", () => {
@@ -223,7 +219,9 @@ describe("manifest", () => {
             const halfWritten = fullyValid.slice(0, Math.floor(fullyValid.length / 2));
             await writeFile(manifestPath, halfWritten, "utf8");
 
-            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(/truncated or contains malformed JSON/);
+            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(
+                /truncated or contains malformed JSON/,
+            );
         });
 
         it("THROWS distinguishing schema-invalid JSON (valid JSON, wrong shape) from truncated JSON", async () => {
@@ -231,23 +229,37 @@ describe("manifest", () => {
             const manifestPath = path.join(workDir, "manifest.json");
             await writeFile(manifestPath, JSON.stringify([1, 2, 3]), "utf8");
 
-            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(/fails schema validation/);
+            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(
+                /fails schema validation/,
+            );
         });
 
         it("THROWS naming the wrong schemaVersion", async () => {
             const workDir = await makeWorkDir("schema-version");
             const manifestPath = path.join(workDir, "manifest.json");
-            await writeFile(manifestPath, JSON.stringify({ schemaVersion: 999, templateRoot: workDir }), "utf8");
+            await writeFile(
+                manifestPath,
+                JSON.stringify({ schemaVersion: 999, templateRoot: workDir }),
+                "utf8",
+            );
 
-            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(/"schemaVersion" must be exactly/);
+            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(
+                /"schemaVersion" must be exactly/,
+            );
         });
 
         it("THROWS naming a missing templateRoot field", async () => {
             const workDir = await makeWorkDir("schema-missing-root");
             const manifestPath = path.join(workDir, "manifest.json");
-            await writeFile(manifestPath, JSON.stringify({ schemaVersion: MANIFEST_SCHEMA_VERSION }), "utf8");
+            await writeFile(
+                manifestPath,
+                JSON.stringify({ schemaVersion: MANIFEST_SCHEMA_VERSION }),
+                "utf8",
+            );
 
-            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(/"templateRoot" must be/);
+            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(
+                /"templateRoot" must be/,
+            );
         });
 
         it("THROWS naming a relative templateRoot as invalid", async () => {
@@ -255,17 +267,26 @@ describe("manifest", () => {
             const manifestPath = path.join(workDir, "manifest.json");
             await writeFile(
                 manifestPath,
-                JSON.stringify({ schemaVersion: MANIFEST_SCHEMA_VERSION, templateRoot: "relative/path" }),
+                JSON.stringify({
+                    schemaVersion: MANIFEST_SCHEMA_VERSION,
+                    templateRoot: "relative/path",
+                }),
                 "utf8",
             );
 
-            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(/"templateRoot" must be/);
+            await expect(readFixtureManifest(manifestPath)).rejects.toThrow(
+                /"templateRoot" must be/,
+            );
         });
 
         it("THROWS naming multiple problems together when several fields are wrong at once", async () => {
             const workDir = await makeWorkDir("schema-multi");
             const manifestPath = path.join(workDir, "manifest.json");
-            await writeFile(manifestPath, JSON.stringify({ schemaVersion: "not-a-number", templateRoot: 42 }), "utf8");
+            await writeFile(
+                manifestPath,
+                JSON.stringify({ schemaVersion: "not-a-number", templateRoot: 42 }),
+                "utf8",
+            );
 
             let thrown: unknown;
             try {
@@ -378,37 +399,33 @@ describe("manifest", () => {
             await expect(readFixtureManifest(manifestPath)).resolves.toEqual(replacement);
         });
 
-        it(
-            "concurrent claims at the same target: exactly one wins, the rest throw",
-            async () => {
-                const workDir = await makeWorkDir("claim-concurrent");
-                const manifestPath = path.join(workDir, "manifest.json");
-                const CONCURRENT_CLAIMANTS = 10;
+        it("concurrent claims at the same target: exactly one wins, the rest throw", async () => {
+            const workDir = await makeWorkDir("claim-concurrent");
+            const manifestPath = path.join(workDir, "manifest.json");
+            const CONCURRENT_CLAIMANTS = 10;
 
-                const results = await Promise.allSettled(
-                    Array.from({ length: CONCURRENT_CLAIMANTS }, (_, index) =>
-                        claimFixtureManifest(manifestPath, {
-                            schemaVersion: MANIFEST_SCHEMA_VERSION,
-                            templateRoot: path.join(workDir, `claimant-${index}-template`),
-                        }),
-                    ),
-                );
+            const results = await Promise.allSettled(
+                Array.from({ length: CONCURRENT_CLAIMANTS }, (_, index) =>
+                    claimFixtureManifest(manifestPath, {
+                        schemaVersion: MANIFEST_SCHEMA_VERSION,
+                        templateRoot: path.join(workDir, `claimant-${index}-template`),
+                    }),
+                ),
+            );
 
-                const fulfilled = results.filter((result) => result.status === "fulfilled");
-                const rejected = results.filter((result) => result.status === "rejected");
+            const fulfilled = results.filter((result) => result.status === "fulfilled");
+            const rejected = results.filter((result) => result.status === "rejected");
 
-                expect(fulfilled).toHaveLength(1);
-                expect(rejected).toHaveLength(CONCURRENT_CLAIMANTS - 1);
+            expect(fulfilled).toHaveLength(1);
+            expect(rejected).toHaveLength(CONCURRENT_CLAIMANTS - 1);
 
-                // The one winner's manifest must be the one actually on disk -- and it must be readable,
-                // proving the winning write was never partially applied.
-                await expect(readFixtureManifest(manifestPath)).resolves.not.toThrow();
+            // The one winner's manifest must be the one actually on disk -- and it must be readable,
+            // proving the winning write was never partially applied.
+            await expect(readFixtureManifest(manifestPath)).resolves.not.toThrow();
 
-                const entries = await readdir(workDir);
-                expect(entries).toEqual(["manifest.json"]);
-            },
-            30_000,
-        );
+            const entries = await readdir(workDir);
+            expect(entries).toEqual(["manifest.json"]);
+        }, 30_000);
     });
 
     describe("directory hygiene", () => {

--- a/tests/unit/fixtures/rehydrate.test.ts
+++ b/tests/unit/fixtures/rehydrate.test.ts
@@ -24,7 +24,11 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { assertWorkspaceEquivalentToTemplate } from "../../fixtures/repo/assertWorkspaceEquivalence";
 import { copyTemplate } from "../../fixtures/repo/copyTemplate";
-import { createSanitizedGitEnv, seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
+import {
+    createSanitizedGitEnv,
+    seedFixtureTemplate,
+    type FixtureTemplate,
+} from "../../fixtures/repo/seed";
 import { DECLARED_REWRITES, rehydrateCopy } from "../../fixtures/repo/rehydrate";
 import { snapshotWorkspace, type PlaceholderRoots } from "../../fixtures/repo/snapshot";
 import { git } from "./gitTestHelpers";
@@ -35,9 +39,13 @@ const FIXTURE_TIMEOUT_MS = 30_000;
 /** `grep -rIl` over `root` for the literal `needle`, tolerating grep's "no match" exit code (1)
  * as an empty result rather than a thrown error -- independent of any production code under test. */
 async function grepLiteral(needle: string, root: string): Promise<string> {
-    const { stdout } = await execFileAsync("grep", ["-rIl", "--fixed-strings", "--", needle, root]).catch(
-        (error: unknown) => ({ stdout: (error as { stdout?: string }).stdout ?? "" }),
-    );
+    const { stdout } = await execFileAsync("grep", [
+        "-rIl",
+        "--fixed-strings",
+        "--",
+        needle,
+        root,
+    ]).catch((error: unknown) => ({ stdout: (error as { stdout?: string }).stdout ?? "" }));
     return stdout.trim();
 }
 
@@ -92,7 +100,11 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
             "before rehydration the copy's origin silently resolves into the TEMPLATE -- the hazard this step closes",
             async () => {
                 const { copyRoot, template } = await seedAndCopy("before");
-                const url = await git(copyRoot, ["config", "--get", "remote.origin.url"], template.env);
+                const url = await git(
+                    copyRoot,
+                    ["config", "--get", "remote.origin.url"],
+                    template.env,
+                );
                 expect(url).toBe(pathToFileURL(template.originRoot).href);
             },
             FIXTURE_TIMEOUT_MS,
@@ -101,19 +113,31 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
         it(
             "rewrites the copy's origin remote URL to its own origin.git, and the copy becomes independently functional",
             async () => {
-                const { destination, template, copyRoot, copyOriginRoot } = await seedAndCopy("functional");
+                const { destination, template, copyRoot, copyOriginRoot } =
+                    await seedAndCopy("functional");
 
                 const result = await rehydrateCopy(destination, template.env);
                 expect(result.rewrites).toEqual([
-                    { id: "workspace-origin-remote-url", newValue: pathToFileURL(copyOriginRoot).href },
+                    {
+                        id: "workspace-origin-remote-url",
+                        newValue: pathToFileURL(copyOriginRoot).href,
+                    },
                 ]);
 
-                const urlAfter = await git(copyRoot, ["config", "--get", "remote.origin.url"], template.env);
+                const urlAfter = await git(
+                    copyRoot,
+                    ["config", "--get", "remote.origin.url"],
+                    template.env,
+                );
                 expect(urlAfter).toBe(pathToFileURL(copyOriginRoot).href);
 
                 // Real functional proof: `git ls-remote` and `git fetch` against the copy succeed
                 // and report the copy's own origin, not a stale/failed lookup.
-                const lsRemoteUrl = await git(copyRoot, ["ls-remote", "--get-url", "origin"], template.env);
+                const lsRemoteUrl = await git(
+                    copyRoot,
+                    ["ls-remote", "--get-url", "origin"],
+                    template.env,
+                );
                 expect(lsRemoteUrl).toBe(pathToFileURL(copyOriginRoot).href);
                 await git(copyRoot, ["fetch", "--quiet", "origin"], template.env);
             },
@@ -128,9 +152,17 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
 
                 // Push state to the TEMPLATE's origin only, after the copy was already rehydrated.
                 await git(template.root, ["tag", "template-only-tag"], template.env);
-                await git(template.root, ["push", "--quiet", "origin", "template-only-tag"], template.env);
+                await git(
+                    template.root,
+                    ["push", "--quiet", "origin", "template-only-tag"],
+                    template.env,
+                );
 
-                const copyRemoteTags = await git(copyRoot, ["ls-remote", "--tags", "origin"], template.env);
+                const copyRemoteTags = await git(
+                    copyRoot,
+                    ["ls-remote", "--tags", "origin"],
+                    template.env,
+                );
                 expect(copyRemoteTags).not.toContain("template-only-tag");
             },
             FIXTURE_TIMEOUT_MS,
@@ -139,7 +171,9 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
         it(
             "THROWS when the copy is not a real git repository -- fails loudly rather than leaving a broken copy",
             async () => {
-                const workDir = await mkdtemp(path.join(tmpdir(), "intelligit-rehydrate-malformed-"));
+                const workDir = await mkdtemp(
+                    path.join(tmpdir(), "intelligit-rehydrate-malformed-"),
+                );
                 cleanupDirs.push(workDir);
                 const destination = path.join(workDir, "destination");
                 await mkdir(path.join(destination, "workspace"), { recursive: true });
@@ -159,7 +193,9 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
                 const { destination, template, copyRoot } = await seedAndCopy("alternates");
                 await rehydrateCopy(destination, template.env); // succeeds the first time
 
-                const outside = await mkdtemp(path.join(tmpdir(), "intelligit-rehydrate-alternates-outside-"));
+                const outside = await mkdtemp(
+                    path.join(tmpdir(), "intelligit-rehydrate-alternates-outside-"),
+                );
                 cleanupDirs.push(outside);
                 const infoDir = path.join(copyRoot, ".git", "objects", "info");
                 await mkdir(infoDir, { recursive: true });
@@ -212,7 +248,8 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
         it(
             "passes for a correctly rehydrated copy -- the normalized diff is empty",
             async () => {
-                const { destination, template, copyRoot, copyOriginRoot } = await seedAndCopy("equivalence-pass");
+                const { destination, template, copyRoot, copyOriginRoot } =
+                    await seedAndCopy("equivalence-pass");
                 await rehydrateCopy(destination, template.env);
 
                 const templateRoots = rootsFor(destination, template.root, template.originRoot);
@@ -223,7 +260,12 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
                 ]);
 
                 expect(() =>
-                    assertWorkspaceEquivalentToTemplate(templateSnapshot, templateRoots, copySnapshot, copyRoots),
+                    assertWorkspaceEquivalentToTemplate(
+                        templateSnapshot,
+                        templateRoots,
+                        copySnapshot,
+                        copyRoots,
+                    ),
                 ).not.toThrow();
             },
             FIXTURE_TIMEOUT_MS,
@@ -232,20 +274,36 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
         it(
             "THE TEETH TEST: THROWS naming the offending file when an undeclared mutation is planted in the copy",
             async () => {
-                const { destination, template, copyRoot, copyOriginRoot } = await seedAndCopy("equivalence-fail");
+                const { destination, template, copyRoot, copyOriginRoot } =
+                    await seedAndCopy("equivalence-fail");
                 await rehydrateCopy(destination, template.env);
 
                 const templateRoots = rootsFor(destination, template.root, template.originRoot);
                 const copyRoots = rootsFor(destination, copyRoot, copyOriginRoot);
-                const templateSnapshot = await snapshotWorkspace({ ...templateRoots, env: template.env });
+                const templateSnapshot = await snapshotWorkspace({
+                    ...templateRoots,
+                    env: template.env,
+                });
 
                 // Undeclared mutation: nothing in DECLARED_REWRITES touches README.md.
-                await writeFile(path.join(copyRoot, "README.md"), "mutated by a test, not a declared rewrite\n", "utf8");
-                const mutatedCopySnapshot = await snapshotWorkspace({ ...copyRoots, env: template.env });
+                await writeFile(
+                    path.join(copyRoot, "README.md"),
+                    "mutated by a test, not a declared rewrite\n",
+                    "utf8",
+                );
+                const mutatedCopySnapshot = await snapshotWorkspace({
+                    ...copyRoots,
+                    env: template.env,
+                });
 
                 let thrown: unknown;
                 try {
-                    assertWorkspaceEquivalentToTemplate(templateSnapshot, templateRoots, mutatedCopySnapshot, copyRoots);
+                    assertWorkspaceEquivalentToTemplate(
+                        templateSnapshot,
+                        templateRoots,
+                        mutatedCopySnapshot,
+                        copyRoots,
+                    );
                 } catch (error) {
                     thrown = error;
                 }
@@ -261,7 +319,8 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
         it(
             "sanity: the exact same snapshot compared against itself never throws -- the failure above was the mutation, not a bug in the assertion",
             async () => {
-                const { destination, template, copyRoot, copyOriginRoot } = await seedAndCopy("equivalence-sanity");
+                const { destination, template, copyRoot, copyOriginRoot } =
+                    await seedAndCopy("equivalence-sanity");
                 await rehydrateCopy(destination, template.env);
 
                 const copyRoots = rootsFor(destination, copyRoot, copyOriginRoot);

--- a/tests/unit/fixtures/restoreFidelity.test.ts
+++ b/tests/unit/fixtures/restoreFidelity.test.ts
@@ -46,160 +46,176 @@ describe("Phase 6 step 33 -- restore fidelity", () => {
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);
 
-    it("restores commit, branch, staged, untracked, and config mutations to the pre-mutation canonical snapshot", async () => {
-        const workspacesRoot = await mkdtemp(
-            path.join(tmpdir(), "intelligit-phase6-restore-pass-"),
-        );
-        cleanupDirs.push(workspacesRoot);
-        const workspace = await createFixtureWorkspace({ scenario: "clean", workspacesRoot });
-        workspaces.push(workspace);
-        const initial = await captureFixtureSnapshot(workspace);
-
-        await mutateWorkspace(workspace);
-        const mutated = await captureFixtureSnapshot(workspace);
-        expect(mutated.snapshot.workspace.refs).not.toEqual(initial.snapshot.workspace.refs);
-        expect(mutated.snapshot.workspace.head).not.toEqual(initial.snapshot.workspace.head);
-        expect(mutated.snapshot.workspace.index).not.toEqual(initial.snapshot.workspace.index);
-        expect(mutated.snapshot.workspace.workingTree).not.toEqual(
-            initial.snapshot.workspace.workingTree,
-        );
-        expect(mutated.snapshot.workspace.gitDirState).not.toEqual(
-            initial.snapshot.workspace.gitDirState,
-        );
-
-        const restored = await restoreFixtureWorkspace(workspace, {
-            scenario: "clean",
-            workspacesRoot,
-        });
-        workspaces.push(restored);
-        const restoredSnapshot = await captureFixtureSnapshot(restored);
-
-        expect(normalizeFixtureSnapshot(restoredSnapshot)).toEqual(
-            normalizeFixtureSnapshot(initial),
-        );
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof #5: refs restored without the working tree or index still fail the canonical comparison", async () => {
-        const workspacesRoot = await mkdtemp(
-            path.join(tmpdir(), "intelligit-phase6-restore-partial-"),
-        );
-        cleanupDirs.push(workspacesRoot);
-        const workspace = await createFixtureWorkspace({ scenario: "clean", workspacesRoot });
-        workspaces.push(workspace);
-        const initial = await captureFixtureSnapshot(workspace);
-        const initialHead = await git(workspace.root, ["rev-parse", "HEAD"], workspace.env);
-
-        await mutateWorkspace(workspace);
-        await git(workspace.root, ["checkout", "--quiet", "main"], workspace.env);
-        await git(workspace.root, ["branch", "-D", "phase6-mutated"], workspace.env);
-        await git(workspace.root, ["reset", "--hard", initialHead], workspace.env);
-        await writeFile(
-            path.join(workspace.root, "phase6-leftover-staged.txt"),
-            "staged residue\n",
-            "utf8",
-        );
-        await git(workspace.root, ["add", "phase6-leftover-staged.txt"], workspace.env);
-        await writeFile(
-            path.join(workspace.root, "phase6-leftover-untracked.txt"),
-            "untracked residue\n",
-            "utf8",
-        );
-
-        const partial = await captureFixtureSnapshot(workspace);
-        expect(partial.snapshot.workspace.refs).toEqual(initial.snapshot.workspace.refs);
-        expect(partial.snapshot.workspace.head).toEqual(initial.snapshot.workspace.head);
-        expect(partial.snapshot.workspace.index).not.toEqual(initial.snapshot.workspace.index);
-        expect(partial.snapshot.workspace.workingTree).not.toEqual(
-            initial.snapshot.workspace.workingTree,
-        );
-
-        let thrown: unknown;
-        try {
-            assertWorkspaceEquivalentToTemplate(
-                initial.snapshot,
-                initial.roots,
-                partial.snapshot,
-                partial.roots,
+    it(
+        "restores commit, branch, staged, untracked, and config mutations to the pre-mutation canonical snapshot",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-restore-pass-"),
             );
-        } catch (error) {
-            thrown = error;
-        }
-        expect(thrown).toBeInstanceOf(Error);
-        const message = (thrown as Error).message;
-        expect(message).toContain("snapshot.workspace.index");
-        expect(message).toContain("snapshot.workspace.workingTree");
-    }, FIXTURE_TIMEOUT_MS);
+            cleanupDirs.push(workspacesRoot);
+            const workspace = await createFixtureWorkspace({ scenario: "clean", workspacesRoot });
+            workspaces.push(workspace);
+            const initial = await captureFixtureSnapshot(workspace);
 
-    it("RED-proof #6: a fresh-copy baseline can pass while the pre-mutation snapshot catches a corrupted template", async () => {
-        const fixture = await seedManifestFixture("restore-baseline-trap", cleanupDirs);
-        const workspace = await createFixtureWorkspace({
-            manifestPath: fixture.manifestPath,
-            workspacesRoot: fixture.workspacesRoot,
-        });
-        workspaces.push(workspace);
-        const initial = await captureFixtureSnapshot(workspace);
-        const originalReadme = await readFile(
-            path.join(fixture.template.root, "README.md"),
-            "utf8",
-        );
+            await mutateWorkspace(workspace);
+            const mutated = await captureFixtureSnapshot(workspace);
+            expect(mutated.snapshot.workspace.refs).not.toEqual(initial.snapshot.workspace.refs);
+            expect(mutated.snapshot.workspace.head).not.toEqual(initial.snapshot.workspace.head);
+            expect(mutated.snapshot.workspace.index).not.toEqual(initial.snapshot.workspace.index);
+            expect(mutated.snapshot.workspace.workingTree).not.toEqual(
+                initial.snapshot.workspace.workingTree,
+            );
+            expect(mutated.snapshot.workspace.gitDirState).not.toEqual(
+                initial.snapshot.workspace.gitDirState,
+            );
 
-        await writeFile(
-            path.join(workspace.root, "phase6-mutation.txt"),
-            "mutated workspace\n",
-            "utf8",
-        );
-        await git(workspace.root, ["config", "phase6.restore", "mutated"], workspace.env);
-        await writeFile(
-            path.join(fixture.template.root, "README.md"),
-            "corrupted template baseline\n",
-            "utf8",
-        );
-
-        try {
             const restored = await restoreFixtureWorkspace(workspace, {
-                manifestPath: fixture.manifestPath,
-                workspacesRoot: fixture.workspacesRoot,
+                scenario: "clean",
+                workspacesRoot,
             });
             workspaces.push(restored);
             const restoredSnapshot = await captureFixtureSnapshot(restored);
 
-            const secondFreshCopy = await createFixtureWorkspace({
-                manifestPath: fixture.manifestPath,
-                workspacesRoot: fixture.workspacesRoot,
-            });
-            workspaces.push(secondFreshCopy);
-            const freshSnapshot = await captureFixtureSnapshot(secondFreshCopy);
+            expect(normalizeFixtureSnapshot(restoredSnapshot)).toEqual(
+                normalizeFixtureSnapshot(initial),
+            );
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 
-            // The named trap: both copies inherit the corrupted template, so comparing them
-            // against one another stays green and says nothing about restore fidelity.
-            expect(() =>
-                assertWorkspaceEquivalentToTemplate(
-                    freshSnapshot.snapshot,
-                    freshSnapshot.roots,
-                    restoredSnapshot.snapshot,
-                    restoredSnapshot.roots,
-                ),
-            ).not.toThrow();
+    it(
+        "RED-proof #5: refs restored without the working tree or index still fail the canonical comparison",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-restore-partial-"),
+            );
+            cleanupDirs.push(workspacesRoot);
+            const workspace = await createFixtureWorkspace({ scenario: "clean", workspacesRoot });
+            workspaces.push(workspace);
+            const initial = await captureFixtureSnapshot(workspace);
+            const initialHead = await git(workspace.root, ["rev-parse", "HEAD"], workspace.env);
+
+            await mutateWorkspace(workspace);
+            await git(workspace.root, ["checkout", "--quiet", "main"], workspace.env);
+            await git(workspace.root, ["branch", "-D", "phase6-mutated"], workspace.env);
+            await git(workspace.root, ["reset", "--hard", initialHead], workspace.env);
+            await writeFile(
+                path.join(workspace.root, "phase6-leftover-staged.txt"),
+                "staged residue\n",
+                "utf8",
+            );
+            await git(workspace.root, ["add", "phase6-leftover-staged.txt"], workspace.env);
+            await writeFile(
+                path.join(workspace.root, "phase6-leftover-untracked.txt"),
+                "untracked residue\n",
+                "utf8",
+            );
+
+            const partial = await captureFixtureSnapshot(workspace);
+            expect(partial.snapshot.workspace.refs).toEqual(initial.snapshot.workspace.refs);
+            expect(partial.snapshot.workspace.head).toEqual(initial.snapshot.workspace.head);
+            expect(partial.snapshot.workspace.index).not.toEqual(initial.snapshot.workspace.index);
+            expect(partial.snapshot.workspace.workingTree).not.toEqual(
+                initial.snapshot.workspace.workingTree,
+            );
 
             let thrown: unknown;
             try {
                 assertWorkspaceEquivalentToTemplate(
                     initial.snapshot,
                     initial.roots,
-                    restoredSnapshot.snapshot,
-                    restoredSnapshot.roots,
+                    partial.snapshot,
+                    partial.roots,
                 );
             } catch (error) {
                 thrown = error;
             }
             expect(thrown).toBeInstanceOf(Error);
             const message = (thrown as Error).message;
+            expect(message).toContain("snapshot.workspace.index");
             expect(message).toContain("snapshot.workspace.workingTree");
-            expect(message).toContain("README.md");
-        } finally {
-            await writeFile(path.join(fixture.template.root, "README.md"), originalReadme, "utf8");
-        }
-    }, FIXTURE_TIMEOUT_MS);
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof #6: a fresh-copy baseline can pass while the pre-mutation snapshot catches a corrupted template",
+        async () => {
+            const fixture = await seedManifestFixture("restore-baseline-trap", cleanupDirs);
+            const workspace = await createFixtureWorkspace({
+                manifestPath: fixture.manifestPath,
+                workspacesRoot: fixture.workspacesRoot,
+            });
+            workspaces.push(workspace);
+            const initial = await captureFixtureSnapshot(workspace);
+            const originalReadme = await readFile(
+                path.join(fixture.template.root, "README.md"),
+                "utf8",
+            );
+
+            await writeFile(
+                path.join(workspace.root, "phase6-mutation.txt"),
+                "mutated workspace\n",
+                "utf8",
+            );
+            await git(workspace.root, ["config", "phase6.restore", "mutated"], workspace.env);
+            await writeFile(
+                path.join(fixture.template.root, "README.md"),
+                "corrupted template baseline\n",
+                "utf8",
+            );
+
+            try {
+                const restored = await restoreFixtureWorkspace(workspace, {
+                    manifestPath: fixture.manifestPath,
+                    workspacesRoot: fixture.workspacesRoot,
+                });
+                workspaces.push(restored);
+                const restoredSnapshot = await captureFixtureSnapshot(restored);
+
+                const secondFreshCopy = await createFixtureWorkspace({
+                    manifestPath: fixture.manifestPath,
+                    workspacesRoot: fixture.workspacesRoot,
+                });
+                workspaces.push(secondFreshCopy);
+                const freshSnapshot = await captureFixtureSnapshot(secondFreshCopy);
+
+                // The named trap: both copies inherit the corrupted template, so comparing them
+                // against one another stays green and says nothing about restore fidelity.
+                expect(() =>
+                    assertWorkspaceEquivalentToTemplate(
+                        freshSnapshot.snapshot,
+                        freshSnapshot.roots,
+                        restoredSnapshot.snapshot,
+                        restoredSnapshot.roots,
+                    ),
+                ).not.toThrow();
+
+                let thrown: unknown;
+                try {
+                    assertWorkspaceEquivalentToTemplate(
+                        initial.snapshot,
+                        initial.roots,
+                        restoredSnapshot.snapshot,
+                        restoredSnapshot.roots,
+                    );
+                } catch (error) {
+                    thrown = error;
+                }
+                expect(thrown).toBeInstanceOf(Error);
+                const message = (thrown as Error).message;
+                expect(message).toContain("snapshot.workspace.workingTree");
+                expect(message).toContain("README.md");
+            } finally {
+                await writeFile(
+                    path.join(fixture.template.root, "README.md"),
+                    originalReadme,
+                    "utf8",
+                );
+            }
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 });
 
 /** Applies mutations across refs, HEAD, index, working tree, and repository configuration. */

--- a/tests/unit/fixtures/runFixtureSetup.test.ts
+++ b/tests/unit/fixtures/runFixtureSetup.test.ts
@@ -15,7 +15,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createFixtureWorkspace, type FixtureWorkspace } from "../../fixtures/repo/harness";
-import { claimFixtureManifest, MANIFEST_SCHEMA_VERSION, readFixtureManifest, type FixtureManifest } from "../../fixtures/repo/manifest";
+import {
+    claimFixtureManifest,
+    MANIFEST_SCHEMA_VERSION,
+    readFixtureManifest,
+    type FixtureManifest,
+} from "../../fixtures/repo/manifest";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
 import {
     assertTemplateFsckClean,
@@ -49,7 +54,9 @@ async function corruptOneLooseObject(workspaceRoot: string): Promise<void> {
     const objectsDir = path.join(workspaceRoot, ".git", "objects");
     const shardNames = (await readdir(objectsDir)).filter((name) => name.length === 2);
     if (shardNames.length === 0) {
-        throw new Error(`corruptOneLooseObject: no loose-object shard directories found under ${objectsDir}`);
+        throw new Error(
+            `corruptOneLooseObject: no loose-object shard directories found under ${objectsDir}`,
+        );
     }
     const shardDir = path.join(objectsDir, shardNames[0] as string);
     const objectNames = await readdir(shardDir);
@@ -108,7 +115,10 @@ describe("runFixtureSetup", () => {
                 const workspace = await createFixtureWorkspace({ manifestPath, workspacesRoot });
                 workspacesToDispose.push(workspace);
 
-                const readmeContent = await readFile(path.join(workspace.root, "README.md"), "utf8");
+                const readmeContent = await readFile(
+                    path.join(workspace.root, "README.md"),
+                    "utf8",
+                );
                 expect(readmeContent).toBe("# IntelliGit Fixture Repo\n");
             },
             FIXTURE_TIMEOUT_MS,
@@ -147,7 +157,8 @@ describe("runFixtureSetup", () => {
                 // seed on top of a non-empty destination (so corruption cannot be planted before
                 // runFixtureSetup's own internal seed call).
                 vi.doMock("../../fixtures/repo/seed", async (importOriginal) => {
-                    const actual = await importOriginal<typeof import("../../fixtures/repo/seed")>();
+                    const actual =
+                        await importOriginal<typeof import("../../fixtures/repo/seed")>();
                     return {
                         ...actual,
                         seedFixtureTemplate: vi.fn(async (destination: string) => {
@@ -158,13 +169,12 @@ describe("runFixtureSetup", () => {
                     };
                 });
                 vi.resetModules();
-                const { runFixtureSetup: runFixtureSetupWithCorruption } = await import(
-                    "../../fixtures/repo/runFixtureSetup.js"
-                );
+                const { runFixtureSetup: runFixtureSetupWithCorruption } =
+                    await import("../../fixtures/repo/runFixtureSetup.js");
 
-                await expect(runFixtureSetupWithCorruption({ templateRoot, manifestPath })).rejects.toThrow(
-                    /git fsck/,
-                );
+                await expect(
+                    runFixtureSetupWithCorruption({ templateRoot, manifestPath }),
+                ).rejects.toThrow(/git fsck/);
 
                 // The teeth: the manifest must be ABSENT, not partially written, not written then
                 // removed -- readFixtureManifest's own "no manifest file" hard failure is the proof.

--- a/tests/unit/fixtures/runFixtureTeardown.test.ts
+++ b/tests/unit/fixtures/runFixtureTeardown.test.ts
@@ -12,7 +12,11 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { claimFixtureManifest, MANIFEST_SCHEMA_VERSION, readFixtureManifest } from "../../fixtures/repo/manifest";
+import {
+    claimFixtureManifest,
+    MANIFEST_SCHEMA_VERSION,
+    readFixtureManifest,
+} from "../../fixtures/repo/manifest";
 import { runFixtureSetup } from "../../fixtures/repo/runFixtureSetup";
 import { runFixtureTeardown } from "../../fixtures/repo/runFixtureTeardown";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
@@ -36,7 +40,9 @@ describe("runFixtureTeardown", () => {
     let permissionsToRestore: string[] = [];
 
     afterEach(async () => {
-        await Promise.all(permissionsToRestore.map((dir) => chmod(dir, 0o755).catch(() => undefined)));
+        await Promise.all(
+            permissionsToRestore.map((dir) => chmod(dir, 0o755).catch(() => undefined)),
+        );
         permissionsToRestore = [];
         await Promise.all([
             ...cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })),
@@ -47,7 +53,9 @@ describe("runFixtureTeardown", () => {
     });
 
     async function makeWorkDir(prefix: string): Promise<string> {
-        const workDir = await mkdtemp(path.join(tmpdir(), `intelligit-runfixtureteardown-${prefix}-`));
+        const workDir = await mkdtemp(
+            path.join(tmpdir(), `intelligit-runfixtureteardown-${prefix}-`),
+        );
         cleanupDirs.push(workDir);
         return workDir;
     }
@@ -95,7 +103,9 @@ describe("runFixtureTeardown", () => {
                 cleanupHomes.push(template.home);
                 expect(await exists(templateRoot)).toBe(true);
 
-                await expect(runFixtureTeardown({ templateRoot, manifestPath })).resolves.not.toThrow();
+                await expect(
+                    runFixtureTeardown({ templateRoot, manifestPath }),
+                ).resolves.not.toThrow();
 
                 expect(await exists(templateRoot)).toBe(false);
             },
@@ -131,7 +141,9 @@ describe("runFixtureTeardown", () => {
                 cleanupHomes.push(result.template.home);
 
                 await runFixtureTeardown({ templateRoot, manifestPath });
-                await expect(runFixtureTeardown({ templateRoot, manifestPath })).resolves.not.toThrow();
+                await expect(
+                    runFixtureTeardown({ templateRoot, manifestPath }),
+                ).resolves.not.toThrow();
             },
             FIXTURE_TIMEOUT_MS,
         );
@@ -155,7 +167,9 @@ describe("runFixtureTeardown", () => {
                 await chmod(lockedParent, 0o555);
                 permissionsToRestore.push(lockedParent);
 
-                await expect(runFixtureTeardown({ templateRoot, manifestPath })).rejects.toThrow(/EACCES|permission/i);
+                await expect(runFixtureTeardown({ templateRoot, manifestPath })).rejects.toThrow(
+                    /EACCES|permission/i,
+                );
             },
             FIXTURE_TIMEOUT_MS,
         );

--- a/tests/unit/fixtures/scenarios.test.ts
+++ b/tests/unit/fixtures/scenarios.test.ts
@@ -363,7 +363,11 @@ describe("ahead-only", () => {
         scratchHomes.push(workspace.home);
 
         await expect(
-            assertAheadOnlyPostcondition(workspace.root, workspace.template!.originRoot, workspace.env),
+            assertAheadOnlyPostcondition(
+                workspace.root,
+                workspace.template!.originRoot,
+                workspace.env,
+            ),
         ).rejects.toThrow(/ahead-only scenario postcondition violated/);
     });
 });
@@ -374,18 +378,23 @@ describe("pushed-tip", () => {
         const workspace = await scenarioFor("pushed-tip").prepare(destination);
         scratchHomes.push(workspace.home);
 
-        const [counts, status, subject, parents, localRemoteTracking, originHead] = await Promise.all([
-            git(
-                workspace.root,
-                ["rev-list", "--left-right", "--count", "main...@{upstream}"],
-                workspace.env,
-            ),
-            git(workspace.root, ["status", "--porcelain"], workspace.env),
-            git(workspace.root, ["show", "-s", "--format=%s", "HEAD"], workspace.env),
-            git(workspace.root, ["show", "-s", "--format=%P", "HEAD"], workspace.env),
-            git(workspace.root, ["rev-parse", "refs/remotes/origin/main"], workspace.env),
-            git(workspace.template!.originRoot, ["rev-parse", "refs/heads/main"], workspace.env),
-        ]);
+        const [counts, status, subject, parents, localRemoteTracking, originHead] =
+            await Promise.all([
+                git(
+                    workspace.root,
+                    ["rev-list", "--left-right", "--count", "main...@{upstream}"],
+                    workspace.env,
+                ),
+                git(workspace.root, ["status", "--porcelain"], workspace.env),
+                git(workspace.root, ["show", "-s", "--format=%s", "HEAD"], workspace.env),
+                git(workspace.root, ["show", "-s", "--format=%P", "HEAD"], workspace.env),
+                git(workspace.root, ["rev-parse", "refs/remotes/origin/main"], workspace.env),
+                git(
+                    workspace.template!.originRoot,
+                    ["rev-parse", "refs/heads/main"],
+                    workspace.env,
+                ),
+            ]);
 
         expect(counts.split(/\s+/).map(Number)).toEqual([0, 0]);
         expect(status).toBe("");
@@ -393,7 +402,11 @@ describe("pushed-tip", () => {
         expect(parents.split(/\s+/)).toHaveLength(1);
         expect(localRemoteTracking).toBe(originHead);
         await expect(
-            assertPushedTipPostcondition(workspace.root, workspace.template!.originRoot, workspace.env),
+            assertPushedTipPostcondition(
+                workspace.root,
+                workspace.template!.originRoot,
+                workspace.env,
+            ),
         ).resolves.toBeUndefined();
     });
 
@@ -403,7 +416,11 @@ describe("pushed-tip", () => {
         scratchHomes.push(workspace.home);
 
         await expect(
-            assertPushedTipPostcondition(workspace.root, workspace.template!.originRoot, workspace.env),
+            assertPushedTipPostcondition(
+                workspace.root,
+                workspace.template!.originRoot,
+                workspace.env,
+            ),
         ).rejects.toThrow(/pushed-tip scenario postcondition violated/);
     });
 });

--- a/tests/unit/fixtures/seedDeterminism.test.ts
+++ b/tests/unit/fixtures/seedDeterminism.test.ts
@@ -81,22 +81,28 @@ describe("Phase 6 step 32 -- canonical snapshot seed determinism", () => {
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);
 
-    it("compares two fully initialized workspaces by their normalized canonical snapshots", async () => {
-        const workspacesRoot = await mkdtemp(path.join(tmpdir(), "intelligit-phase6-seed-pair-"));
-        cleanupDirs.push(workspacesRoot);
-        const result = await capturePairSnapshots(workspacesRoot);
-        workspaces.push(...result.workspaces);
+    it(
+        "compares two fully initialized workspaces by their normalized canonical snapshots",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-seed-pair-"),
+            );
+            cleanupDirs.push(workspacesRoot);
+            const result = await capturePairSnapshots(workspacesRoot);
+            workspaces.push(...result.workspaces);
 
-        await Promise.all(
-            result.workspaces.map((workspace, index) =>
-                assertFullyInitialized(workspace, result.snapshots[index]!),
-            ),
-        );
+            await Promise.all(
+                result.workspaces.map((workspace, index) =>
+                    assertFullyInitialized(workspace, result.snapshots[index]!),
+                ),
+            );
 
-        expect(normalizeFixtureSnapshot(result.snapshots[0]!)).toEqual(
-            normalizeFixtureSnapshot(result.snapshots[1]!),
-        );
-    }, FIXTURE_TIMEOUT_MS);
+            expect(normalizeFixtureSnapshot(result.snapshots[0]!)).toEqual(
+                normalizeFixtureSnapshot(result.snapshots[1]!),
+            );
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 
     it(
         "seeds identically under two different ambient timezones, because the pinned dates carry an explicit offset",
@@ -139,186 +145,216 @@ describe("Phase 6 step 32 -- canonical snapshot seed determinism", () => {
         FIXTURE_TIMEOUT_MS,
     );
 
-    it("RED-proof #1: a substantive index flag survives canonical normalization", async () => {
-        const workspacesRoot = await mkdtemp(
-            path.join(tmpdir(), "intelligit-phase6-normalization-red-"),
-        );
-        cleanupDirs.push(workspacesRoot);
-        const result = await capturePairSnapshots(workspacesRoot);
-        workspaces.push(...result.workspaces);
-
-        const original = result.snapshots[0]!;
-        const index = original.snapshot.workspace.index;
-        expect(index.status).toBe("captured");
-        if (index.status !== "captured" || index.data.length === 0) return;
-
-        const first = index.data[0]!;
-        const badSnapshot: FixtureSnapshot = {
-            ...original,
-            snapshot: {
-                ...original.snapshot,
-                workspace: {
-                    ...original.snapshot.workspace,
-                    index: captured([
-                        { ...first, flag: first.flag === "H" ? "h" : "H" },
-                        ...index.data.slice(1),
-                    ]),
-                },
-            },
-        };
-
-        expect(normalizeFixtureSnapshot(original)).not.toEqual(
-            normalizeFixtureSnapshot(badSnapshot),
-        );
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof #2: changed untracked and ignored bytes survive canonical normalization", async () => {
-        const workspacesRoot = await mkdtemp(
-            path.join(tmpdir(), "intelligit-phase6-working-tree-red-"),
-        );
-        cleanupDirs.push(workspacesRoot);
-        const result = await capturePairSnapshots(workspacesRoot);
-        workspaces.push(...result.workspaces);
-
-        const [workspaceA, workspaceB] = result.workspaces;
-        await writeFile(path.join(workspaceA.root, "phase6-untracked.txt"), "same bytes\n", "utf8");
-        await writeFile(path.join(workspaceB.root, "phase6-untracked.txt"), "same bytes\n", "utf8");
-        await writeFile(
-            path.join(workspaceA.root, "ignored", "phase6-build.log"),
-            "same ignored bytes\n",
-            "utf8",
-        );
-        await writeFile(
-            path.join(workspaceB.root, "ignored", "phase6-build.log"),
-            "same ignored bytes\n",
-            "utf8",
-        );
-
-        const beforeA = await captureFixtureSnapshot(workspaceA);
-        const beforeB = await captureFixtureSnapshot(workspaceB);
-        await writeFile(
-            path.join(workspaceB.root, "phase6-untracked.txt"),
-            "different bytes\n",
-            "utf8",
-        );
-        await writeFile(
-            path.join(workspaceB.root, "ignored", "phase6-build.log"),
-            "different ignored bytes\n",
-            "utf8",
-        );
-        const afterB = await captureFixtureSnapshot(workspaceB);
-
-        expect(normalizeFixtureSnapshot(beforeA)).not.toEqual(normalizeFixtureSnapshot(afterB));
-        expect(normalizeFixtureSnapshot(beforeA)).toEqual(normalizeFixtureSnapshot(beforeB));
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof #3: a changed repository config value survives canonical normalization", async () => {
-        const workspacesRoot = await mkdtemp(path.join(tmpdir(), "intelligit-phase6-config-red-"));
-        cleanupDirs.push(workspacesRoot);
-        const result = await capturePairSnapshots(workspacesRoot);
-        workspaces.push(...result.workspaces);
-        const beforeA = await captureFixtureSnapshot(result.workspaces[0]!);
-        const beforeB = await captureFixtureSnapshot(result.workspaces[1]!);
-
-        await run(
-            "git",
-            ["config", "phase6.oracle", "changed-value"],
-            result.workspaces[1]!.root,
-            result.workspaces[1]!.env,
-        );
-        const after = await captureFixtureSnapshot(result.workspaces[1]!);
-
-        expect(normalizeFixtureSnapshot(beforeA)).toEqual(normalizeFixtureSnapshot(beforeB));
-        expect(normalizeFixtureSnapshot(beforeA)).not.toEqual(normalizeFixtureSnapshot(after));
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof #4: hostile global config and timezone reach an unsanitized control, then stay out of the pair", async () => {
-        const workspacesRoot = await mkdtemp(path.join(tmpdir(), "intelligit-phase6-hostile-env-"));
-        const ambientRoot = await mkdtemp(path.join(tmpdir(), "intelligit-phase6-hostile-global-"));
-        cleanupDirs.push(workspacesRoot, ambientRoot);
-        const globalConfig = path.join(ambientRoot, ".gitconfig");
-        await writeFile(
-            globalConfig,
-            "[user]\n\tname = Ambient Hostile User\n\temail = hostile@example.invalid\n[core]\n\tautocrlf = true\n",
-            "utf8",
-        );
-
-        const savedEnvironment = {
-            GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
-            GIT_CONFIG_SYSTEM: process.env.GIT_CONFIG_SYSTEM,
-            HOME: process.env.HOME,
-            TZ: process.env.TZ,
-        };
-        const hostileEnvironment: NodeJS.ProcessEnv = {
-            ...process.env,
-            GIT_CONFIG_GLOBAL: globalConfig,
-            GIT_CONFIG_SYSTEM: "/dev/null",
-            HOME: ambientRoot,
-            TZ: "Pacific/Auckland",
-        };
-        delete hostileEnvironment.GIT_AUTHOR_NAME;
-        delete hostileEnvironment.GIT_AUTHOR_EMAIL;
-        delete hostileEnvironment.GIT_COMMITTER_NAME;
-        delete hostileEnvironment.GIT_COMMITTER_EMAIL;
-        delete hostileEnvironment.GIT_AUTHOR_DATE;
-        delete hostileEnvironment.GIT_COMMITTER_DATE;
-        Object.assign(process.env, {
-            GIT_CONFIG_GLOBAL: globalConfig,
-            GIT_CONFIG_SYSTEM: "/dev/null",
-            HOME: ambientRoot,
-            TZ: "Pacific/Auckland",
-        });
-
-        try {
-            const controlRoot = await mkdtemp(path.join(ambientRoot, "control-"));
-            cleanupDirs.push(controlRoot);
-            const controlName = await run(
-                "git",
-                ["config", "--global", "--get", "user.name"],
-                controlRoot,
-                hostileEnvironment,
+    it(
+        "RED-proof #1: a substantive index flag survives canonical normalization",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-normalization-red-"),
             );
-            const controlAutocrlf = await run(
-                "git",
-                ["config", "--global", "--get", "core.autocrlf"],
-                controlRoot,
-                hostileEnvironment,
-            );
-            const controlTimezone = await run("date", ["+%z"], controlRoot, hostileEnvironment);
-            expect(controlName).toBe("Ambient Hostile User");
-            expect(controlAutocrlf).toBe("true");
-            expect(controlTimezone).not.toBe("+0000");
-
+            cleanupDirs.push(workspacesRoot);
             const result = await capturePairSnapshots(workspacesRoot);
             workspaces.push(...result.workspaces);
-            for (const workspace of result.workspaces) {
-                expect(workspace.env.GIT_CONFIG_GLOBAL).toBe("/dev/null");
-                expect(workspace.env.TZ).toBe("Pacific/Auckland");
-                await expect(
-                    run(
-                        "git",
-                        ["config", "--global", "--get", "user.name"],
-                        workspace.root,
-                        workspace.env,
-                    ),
-                ).rejects.toBeDefined();
-                expect(
-                    await run(
-                        "git",
-                        ["config", "--get", "core.autocrlf"],
-                        workspace.root,
-                        workspace.env,
-                    ),
-                ).toBe("false");
-            }
-            expect(normalizeFixtureSnapshot(result.snapshots[0]!)).toEqual(
-                normalizeFixtureSnapshot(result.snapshots[1]!),
+
+            const original = result.snapshots[0]!;
+            const index = original.snapshot.workspace.index;
+            expect(index.status).toBe("captured");
+            if (index.status !== "captured" || index.data.length === 0) return;
+
+            const first = index.data[0]!;
+            const badSnapshot: FixtureSnapshot = {
+                ...original,
+                snapshot: {
+                    ...original.snapshot,
+                    workspace: {
+                        ...original.snapshot.workspace,
+                        index: captured([
+                            { ...first, flag: first.flag === "H" ? "h" : "H" },
+                            ...index.data.slice(1),
+                        ]),
+                    },
+                },
+            };
+
+            expect(normalizeFixtureSnapshot(original)).not.toEqual(
+                normalizeFixtureSnapshot(badSnapshot),
             );
-        } finally {
-            for (const [key, value] of Object.entries(savedEnvironment)) {
-                if (value === undefined) delete process.env[key];
-                else process.env[key] = value;
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof #2: changed untracked and ignored bytes survive canonical normalization",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-working-tree-red-"),
+            );
+            cleanupDirs.push(workspacesRoot);
+            const result = await capturePairSnapshots(workspacesRoot);
+            workspaces.push(...result.workspaces);
+
+            const [workspaceA, workspaceB] = result.workspaces;
+            await writeFile(
+                path.join(workspaceA.root, "phase6-untracked.txt"),
+                "same bytes\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(workspaceB.root, "phase6-untracked.txt"),
+                "same bytes\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(workspaceA.root, "ignored", "phase6-build.log"),
+                "same ignored bytes\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(workspaceB.root, "ignored", "phase6-build.log"),
+                "same ignored bytes\n",
+                "utf8",
+            );
+
+            const beforeA = await captureFixtureSnapshot(workspaceA);
+            const beforeB = await captureFixtureSnapshot(workspaceB);
+            await writeFile(
+                path.join(workspaceB.root, "phase6-untracked.txt"),
+                "different bytes\n",
+                "utf8",
+            );
+            await writeFile(
+                path.join(workspaceB.root, "ignored", "phase6-build.log"),
+                "different ignored bytes\n",
+                "utf8",
+            );
+            const afterB = await captureFixtureSnapshot(workspaceB);
+
+            expect(normalizeFixtureSnapshot(beforeA)).not.toEqual(normalizeFixtureSnapshot(afterB));
+            expect(normalizeFixtureSnapshot(beforeA)).toEqual(normalizeFixtureSnapshot(beforeB));
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof #3: a changed repository config value survives canonical normalization",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-config-red-"),
+            );
+            cleanupDirs.push(workspacesRoot);
+            const result = await capturePairSnapshots(workspacesRoot);
+            workspaces.push(...result.workspaces);
+            const beforeA = await captureFixtureSnapshot(result.workspaces[0]!);
+            const beforeB = await captureFixtureSnapshot(result.workspaces[1]!);
+
+            await run(
+                "git",
+                ["config", "phase6.oracle", "changed-value"],
+                result.workspaces[1]!.root,
+                result.workspaces[1]!.env,
+            );
+            const after = await captureFixtureSnapshot(result.workspaces[1]!);
+
+            expect(normalizeFixtureSnapshot(beforeA)).toEqual(normalizeFixtureSnapshot(beforeB));
+            expect(normalizeFixtureSnapshot(beforeA)).not.toEqual(normalizeFixtureSnapshot(after));
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof #4: hostile global config and timezone reach an unsanitized control, then stay out of the pair",
+        async () => {
+            const workspacesRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-hostile-env-"),
+            );
+            const ambientRoot = await mkdtemp(
+                path.join(tmpdir(), "intelligit-phase6-hostile-global-"),
+            );
+            cleanupDirs.push(workspacesRoot, ambientRoot);
+            const globalConfig = path.join(ambientRoot, ".gitconfig");
+            await writeFile(
+                globalConfig,
+                "[user]\n\tname = Ambient Hostile User\n\temail = hostile@example.invalid\n[core]\n\tautocrlf = true\n",
+                "utf8",
+            );
+
+            const savedEnvironment = {
+                GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
+                GIT_CONFIG_SYSTEM: process.env.GIT_CONFIG_SYSTEM,
+                HOME: process.env.HOME,
+                TZ: process.env.TZ,
+            };
+            const hostileEnvironment: NodeJS.ProcessEnv = {
+                ...process.env,
+                GIT_CONFIG_GLOBAL: globalConfig,
+                GIT_CONFIG_SYSTEM: "/dev/null",
+                HOME: ambientRoot,
+                TZ: "Pacific/Auckland",
+            };
+            delete hostileEnvironment.GIT_AUTHOR_NAME;
+            delete hostileEnvironment.GIT_AUTHOR_EMAIL;
+            delete hostileEnvironment.GIT_COMMITTER_NAME;
+            delete hostileEnvironment.GIT_COMMITTER_EMAIL;
+            delete hostileEnvironment.GIT_AUTHOR_DATE;
+            delete hostileEnvironment.GIT_COMMITTER_DATE;
+            Object.assign(process.env, {
+                GIT_CONFIG_GLOBAL: globalConfig,
+                GIT_CONFIG_SYSTEM: "/dev/null",
+                HOME: ambientRoot,
+                TZ: "Pacific/Auckland",
+            });
+
+            try {
+                const controlRoot = await mkdtemp(path.join(ambientRoot, "control-"));
+                cleanupDirs.push(controlRoot);
+                const controlName = await run(
+                    "git",
+                    ["config", "--global", "--get", "user.name"],
+                    controlRoot,
+                    hostileEnvironment,
+                );
+                const controlAutocrlf = await run(
+                    "git",
+                    ["config", "--global", "--get", "core.autocrlf"],
+                    controlRoot,
+                    hostileEnvironment,
+                );
+                const controlTimezone = await run("date", ["+%z"], controlRoot, hostileEnvironment);
+                expect(controlName).toBe("Ambient Hostile User");
+                expect(controlAutocrlf).toBe("true");
+                expect(controlTimezone).not.toBe("+0000");
+
+                const result = await capturePairSnapshots(workspacesRoot);
+                workspaces.push(...result.workspaces);
+                for (const workspace of result.workspaces) {
+                    expect(workspace.env.GIT_CONFIG_GLOBAL).toBe("/dev/null");
+                    expect(workspace.env.TZ).toBe("Pacific/Auckland");
+                    await expect(
+                        run(
+                            "git",
+                            ["config", "--global", "--get", "user.name"],
+                            workspace.root,
+                            workspace.env,
+                        ),
+                    ).rejects.toBeDefined();
+                    expect(
+                        await run(
+                            "git",
+                            ["config", "--get", "core.autocrlf"],
+                            workspace.root,
+                            workspace.env,
+                        ),
+                    ).toBe("false");
+                }
+                expect(normalizeFixtureSnapshot(result.snapshots[0]!)).toEqual(
+                    normalizeFixtureSnapshot(result.snapshots[1]!),
+                );
+            } finally {
+                for (const [key, value] of Object.entries(savedEnvironment)) {
+                    if (value === undefined) delete process.env[key];
+                    else process.env[key] = value;
+                }
             }
-        }
-    }, FIXTURE_TIMEOUT_MS);
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 });

--- a/tests/unit/fixtures/snapshot.test.ts
+++ b/tests/unit/fixtures/snapshot.test.ts
@@ -21,8 +21,15 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_TEXT_CAPTURE_LIMIT_BYTES, inventoryDirectory } from "../../fixtures/repo/fsInventory";
-import { createSanitizedGitEnv, seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
+import {
+    DEFAULT_TEXT_CAPTURE_LIMIT_BYTES,
+    inventoryDirectory,
+} from "../../fixtures/repo/fsInventory";
+import {
+    createSanitizedGitEnv,
+    seedFixtureTemplate,
+    type FixtureTemplate,
+} from "../../fixtures/repo/seed";
 // Imported through the public barrel (`snapshot.ts`), not the internal `snapshotTypes.ts`/
 // `snapshotDurableState.ts` modules: this file exercises `snapshotWorkspace()`'s own public
 // contract -- the same surface step 8's `harness.ts` will consume -- rather than one internal
@@ -37,7 +44,9 @@ import {
 const FIXTURE_TIMEOUT_MS = 30_000;
 const UNUSED_PROFILE_DIR = "/nonexistent/profile";
 
-function buildDurableStateSnapshot(overrides: Partial<DurableStateSnapshot> = {}): DurableStateSnapshot {
+function buildDurableStateSnapshot(
+    overrides: Partial<DurableStateSnapshot> = {},
+): DurableStateSnapshot {
     return {
         shelfFiles: [],
         memento: { global: {}, workspace: {} },
@@ -63,73 +72,87 @@ describe("snapshotWorkspace -- captures the full restorable domain for both repo
         scratchDest = undefined;
     }, FIXTURE_TIMEOUT_MS);
 
-    it("captures real seeded state for the workspace and reports the origin as bare with no working tree", async () => {
-        scratchDest = await mkdtemp(path.join(tmpdir(), "intelligit-snapshotworkspace-"));
-        template = await seedFixtureTemplate(scratchDest);
+    it(
+        "captures real seeded state for the workspace and reports the origin as bare with no working tree",
+        async () => {
+            scratchDest = await mkdtemp(path.join(tmpdir(), "intelligit-snapshotworkspace-"));
+            template = await seedFixtureTemplate(scratchDest);
 
-        const snapshot = await snapshotWorkspace({
-            root: template.root,
-            originRoot: template.originRoot,
-            profileDir: UNUSED_PROFILE_DIR,
-            env: template.env,
-        });
-
-        expect(snapshot.workspace.isBare).toBe(false);
-        expect(snapshot.workspace.workingTree.status).toBe("captured");
-        if (snapshot.workspace.workingTree.status === "captured") {
-            const paths = snapshot.workspace.workingTree.data.map((entry) => entry.relativePath);
-            expect(paths).toContain("README.md"); // committed history
-            expect(paths).toContain("untracked.txt"); // dirty layer: untracked
-            expect(paths).toContain("ignored/build.log"); // dirty layer: ignored
-        }
-
-        expect(snapshot.workspace.index.status).toBe("captured");
-        if (snapshot.workspace.index.status === "captured") {
-            const mutableEntries = snapshot.workspace.index.data.filter((entry) => entry.path === "mutable.txt");
-            expect(mutableEntries.length).toBeGreaterThan(0); // dirty layer: staged-and-unstaged
-        }
-
-        expect(snapshot.workspace.refs.status).toBe("captured");
-        if (snapshot.workspace.refs.status === "captured") {
-            const names = snapshot.workspace.refs.data.map((entry) => entry.name);
-            expect(names).toContain("refs/stash"); // pre-seeded stash entries
-            expect(names).toContain("refs/heads/feature/awesome");
-        }
-
-        // The bare origin has no working tree at all -- `not-captured` here is a correct,
-        // reasoned absence (PLAN.md's binary Section contract), never a bug to paper over.
-        expect(snapshot.origin.isBare).toBe(true);
-        expect(snapshot.origin.workingTree.status).toBe("not-captured");
-        expect(snapshot.origin.refs.status).toBe("captured");
-        if (snapshot.origin.refs.status === "captured") {
-            const names = snapshot.origin.refs.data.map((entry) => entry.name);
-            expect(names).toContain("refs/heads/main");
-            expect(names).toContain("refs/tags/v1.0.0");
-        }
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("REJECTS rather than returning an empty captured section when a root is not a git repository at all", async () => {
-        // The governing principle's sharpest edge, verified directly: a total read failure must
-        // propagate as a rejection, never collapse into a silently empty (but structurally
-        // "captured") section -- confirmed empirically that a bare `git rev-parse` against a
-        // non-repository directory exits 128 and rejects the promisified subprocess call, which
-        // every snapshot* module lets propagate rather than swallowing in a `catch {}`.
-        const sanitized = await createSanitizedGitEnv();
-        scratchDest = await mkdtemp(path.join(tmpdir(), "intelligit-snapshotworkspace-notrepo-"));
-        const notARepo = path.join(scratchDest, "not-a-repo");
-        await mkdir(notARepo, { recursive: true });
-
-        await expect(
-            snapshotWorkspace({
-                root: notARepo,
-                originRoot: notARepo,
+            const snapshot = await snapshotWorkspace({
+                root: template.root,
+                originRoot: template.originRoot,
                 profileDir: UNUSED_PROFILE_DIR,
-                env: sanitized.env,
-            }),
-        ).rejects.toThrow();
+                env: template.env,
+            });
 
-        await rm(sanitized.home, { recursive: true, force: true });
-    }, FIXTURE_TIMEOUT_MS);
+            expect(snapshot.workspace.isBare).toBe(false);
+            expect(snapshot.workspace.workingTree.status).toBe("captured");
+            if (snapshot.workspace.workingTree.status === "captured") {
+                const paths = snapshot.workspace.workingTree.data.map(
+                    (entry) => entry.relativePath,
+                );
+                expect(paths).toContain("README.md"); // committed history
+                expect(paths).toContain("untracked.txt"); // dirty layer: untracked
+                expect(paths).toContain("ignored/build.log"); // dirty layer: ignored
+            }
+
+            expect(snapshot.workspace.index.status).toBe("captured");
+            if (snapshot.workspace.index.status === "captured") {
+                const mutableEntries = snapshot.workspace.index.data.filter(
+                    (entry) => entry.path === "mutable.txt",
+                );
+                expect(mutableEntries.length).toBeGreaterThan(0); // dirty layer: staged-and-unstaged
+            }
+
+            expect(snapshot.workspace.refs.status).toBe("captured");
+            if (snapshot.workspace.refs.status === "captured") {
+                const names = snapshot.workspace.refs.data.map((entry) => entry.name);
+                expect(names).toContain("refs/stash"); // pre-seeded stash entries
+                expect(names).toContain("refs/heads/feature/awesome");
+            }
+
+            // The bare origin has no working tree at all -- `not-captured` here is a correct,
+            // reasoned absence (PLAN.md's binary Section contract), never a bug to paper over.
+            expect(snapshot.origin.isBare).toBe(true);
+            expect(snapshot.origin.workingTree.status).toBe("not-captured");
+            expect(snapshot.origin.refs.status).toBe("captured");
+            if (snapshot.origin.refs.status === "captured") {
+                const names = snapshot.origin.refs.data.map((entry) => entry.name);
+                expect(names).toContain("refs/heads/main");
+                expect(names).toContain("refs/tags/v1.0.0");
+            }
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "REJECTS rather than returning an empty captured section when a root is not a git repository at all",
+        async () => {
+            // The governing principle's sharpest edge, verified directly: a total read failure must
+            // propagate as a rejection, never collapse into a silently empty (but structurally
+            // "captured") section -- confirmed empirically that a bare `git rev-parse` against a
+            // non-repository directory exits 128 and rejects the promisified subprocess call, which
+            // every snapshot* module lets propagate rather than swallowing in a `catch {}`.
+            const sanitized = await createSanitizedGitEnv();
+            scratchDest = await mkdtemp(
+                path.join(tmpdir(), "intelligit-snapshotworkspace-notrepo-"),
+            );
+            const notARepo = path.join(scratchDest, "not-a-repo");
+            await mkdir(notARepo, { recursive: true });
+
+            await expect(
+                snapshotWorkspace({
+                    root: notARepo,
+                    originRoot: notARepo,
+                    profileDir: UNUSED_PROFILE_DIR,
+                    env: sanitized.env,
+                }),
+            ).rejects.toThrow();
+
+            await rm(sanitized.home, { recursive: true, force: true });
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 });
 
 describe("snapshotWorkspace -- durable VS Code state seam (PLAN.md step 10)", () => {
@@ -149,91 +172,111 @@ describe("snapshotWorkspace -- durable VS Code state seam (PLAN.md step 10)", ()
         return template;
     }
 
-    it("is not-captured, with a non-empty reason, when no provider is supplied", async () => {
-        const tpl = await seedMinimalTemplate("intelligit-durable-noprovider-");
-        const snapshot = await snapshotWorkspace({
-            root: tpl.root,
-            originRoot: tpl.originRoot,
-            profileDir: UNUSED_PROFILE_DIR,
-            env: tpl.env,
-        });
-        expect(snapshot.durableState.status).toBe("not-captured");
-        if (snapshot.durableState.status !== "not-captured") return;
-        expect(snapshot.durableState.reason.length).toBeGreaterThan(0);
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("is captured, wired through to the provider's real data, when a provider IS supplied", async () => {
-        const tpl = await seedMinimalTemplate("intelligit-durable-withprovider-");
-        const providerData = buildDurableStateSnapshot({
-            secrets: { commitChecks: { present: true, digest: "abc123" } },
-        });
-        const provider = buildProvider(providerData);
-
-        const snapshot = await snapshotWorkspace({
-            root: tpl.root,
-            originRoot: tpl.originRoot,
-            profileDir: UNUSED_PROFILE_DIR,
-            env: tpl.env,
-            durableState: provider,
-        });
-
-        expect(provider.snapshotDurableState).toHaveBeenCalledTimes(1);
-        expect(snapshot.durableState).toEqual(captured(providerData));
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof: the not-captured seam and the captured seam never compare equal -- Phase 6's actual defence", async () => {
-        const tpl = await seedMinimalTemplate("intelligit-durable-redproof-");
-
-        const withoutProvider = await snapshotWorkspace({
-            root: tpl.root,
-            originRoot: tpl.originRoot,
-            profileDir: UNUSED_PROFILE_DIR,
-            env: tpl.env,
-        });
-        const withProvider = await snapshotWorkspace({
-            root: tpl.root,
-            originRoot: tpl.originRoot,
-            profileDir: UNUSED_PROFILE_DIR,
-            env: tpl.env,
-            durableState: buildProvider(buildDurableStateSnapshot()),
-        });
-
-        // The literal claim PLAN.md's work order asks to be proven: a `not-captured` durable
-        // section must not compare equal to a `captured` one, even when the captured payload is
-        // itself empty -- otherwise a Phase 6 comparison against a template snapshot taken WITH a
-        // live host (captured) could pass against a later copy snapshotted WITHOUT one
-        // (not-captured), and a real regression in durable state would never be caught.
-        expect(withoutProvider.durableState).not.toEqual(withProvider.durableState);
-        expect(withoutProvider).not.toEqual(withProvider);
-    }, FIXTURE_TIMEOUT_MS);
-
-    it("RED-proof: the provider's actual data flows through unmangled, not a hardcoded constant", async () => {
-        const tpl = await seedMinimalTemplate("intelligit-durable-datadiffers-");
-
-        const [snapA, snapB] = await Promise.all([
-            snapshotWorkspace({
+    it(
+        "is not-captured, with a non-empty reason, when no provider is supplied",
+        async () => {
+            const tpl = await seedMinimalTemplate("intelligit-durable-noprovider-");
+            const snapshot = await snapshotWorkspace({
                 root: tpl.root,
                 originRoot: tpl.originRoot,
                 profileDir: UNUSED_PROFILE_DIR,
                 env: tpl.env,
-                durableState: buildProvider(buildDurableStateSnapshot({ configuration: { undockableWindow: true } })),
-            }),
-            snapshotWorkspace({
+            });
+            expect(snapshot.durableState.status).toBe("not-captured");
+            if (snapshot.durableState.status !== "not-captured") return;
+            expect(snapshot.durableState.reason.length).toBeGreaterThan(0);
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "is captured, wired through to the provider's real data, when a provider IS supplied",
+        async () => {
+            const tpl = await seedMinimalTemplate("intelligit-durable-withprovider-");
+            const providerData = buildDurableStateSnapshot({
+                secrets: { commitChecks: { present: true, digest: "abc123" } },
+            });
+            const provider = buildProvider(providerData);
+
+            const snapshot = await snapshotWorkspace({
                 root: tpl.root,
                 originRoot: tpl.originRoot,
                 profileDir: UNUSED_PROFILE_DIR,
                 env: tpl.env,
-                durableState: buildProvider(buildDurableStateSnapshot({ configuration: { undockableWindow: false } })),
-            }),
-        ]);
+                durableState: provider,
+            });
 
-        expect(snapA.durableState.status).toBe("captured");
-        expect(snapB.durableState.status).toBe("captured");
-        // Same comparison shape as the RED-proof above; it distinguishes two DIFFERENT captured
-        // payloads too, not just captured-vs-not-captured -- proving this seam is not short-
-        // circuited to a single constant result regardless of what the provider returns.
-        expect(snapA.durableState).not.toEqual(snapB.durableState);
-    }, FIXTURE_TIMEOUT_MS);
+            expect(provider.snapshotDurableState).toHaveBeenCalledTimes(1);
+            expect(snapshot.durableState).toEqual(captured(providerData));
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof: the not-captured seam and the captured seam never compare equal -- Phase 6's actual defence",
+        async () => {
+            const tpl = await seedMinimalTemplate("intelligit-durable-redproof-");
+
+            const withoutProvider = await snapshotWorkspace({
+                root: tpl.root,
+                originRoot: tpl.originRoot,
+                profileDir: UNUSED_PROFILE_DIR,
+                env: tpl.env,
+            });
+            const withProvider = await snapshotWorkspace({
+                root: tpl.root,
+                originRoot: tpl.originRoot,
+                profileDir: UNUSED_PROFILE_DIR,
+                env: tpl.env,
+                durableState: buildProvider(buildDurableStateSnapshot()),
+            });
+
+            // The literal claim PLAN.md's work order asks to be proven: a `not-captured` durable
+            // section must not compare equal to a `captured` one, even when the captured payload is
+            // itself empty -- otherwise a Phase 6 comparison against a template snapshot taken WITH a
+            // live host (captured) could pass against a later copy snapshotted WITHOUT one
+            // (not-captured), and a real regression in durable state would never be caught.
+            expect(withoutProvider.durableState).not.toEqual(withProvider.durableState);
+            expect(withoutProvider).not.toEqual(withProvider);
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
+
+    it(
+        "RED-proof: the provider's actual data flows through unmangled, not a hardcoded constant",
+        async () => {
+            const tpl = await seedMinimalTemplate("intelligit-durable-datadiffers-");
+
+            const [snapA, snapB] = await Promise.all([
+                snapshotWorkspace({
+                    root: tpl.root,
+                    originRoot: tpl.originRoot,
+                    profileDir: UNUSED_PROFILE_DIR,
+                    env: tpl.env,
+                    durableState: buildProvider(
+                        buildDurableStateSnapshot({ configuration: { undockableWindow: true } }),
+                    ),
+                }),
+                snapshotWorkspace({
+                    root: tpl.root,
+                    originRoot: tpl.originRoot,
+                    profileDir: UNUSED_PROFILE_DIR,
+                    env: tpl.env,
+                    durableState: buildProvider(
+                        buildDurableStateSnapshot({ configuration: { undockableWindow: false } }),
+                    ),
+                }),
+            ]);
+
+            expect(snapA.durableState.status).toBe("captured");
+            expect(snapB.durableState.status).toBe("captured");
+            // Same comparison shape as the RED-proof above; it distinguishes two DIFFERENT captured
+            // payloads too, not just captured-vs-not-captured -- proving this seam is not short-
+            // circuited to a single constant result regardless of what the provider returns.
+            expect(snapA.durableState).not.toEqual(snapB.durableState);
+        },
+        FIXTURE_TIMEOUT_MS,
+    );
 });
 
 describe("inventoryDirectory -- text capture limit boundary (fsInventory.ts)", () => {
@@ -246,8 +289,14 @@ describe("inventoryDirectory -- text capture limit boundary (fsInventory.ts)", (
 
     it("captures decoded text for a file at the default limit, and withholds it for one byte over -- digest is captured either way", async () => {
         scratch = await mkdtemp(path.join(tmpdir(), "intelligit-textcapture-"));
-        await writeFile(path.join(scratch, "at-limit.txt"), "a".repeat(DEFAULT_TEXT_CAPTURE_LIMIT_BYTES));
-        await writeFile(path.join(scratch, "over-limit.txt"), "a".repeat(DEFAULT_TEXT_CAPTURE_LIMIT_BYTES + 1));
+        await writeFile(
+            path.join(scratch, "at-limit.txt"),
+            "a".repeat(DEFAULT_TEXT_CAPTURE_LIMIT_BYTES),
+        );
+        await writeFile(
+            path.join(scratch, "over-limit.txt"),
+            "a".repeat(DEFAULT_TEXT_CAPTURE_LIMIT_BYTES + 1),
+        );
 
         const entries = await inventoryDirectory({ root: scratch });
         const byPath = new Map(entries.map((entry) => [entry.relativePath, entry]));

--- a/tests/unit/fixtures/snapshotIndex.test.ts
+++ b/tests/unit/fixtures/snapshotIndex.test.ts
@@ -68,7 +68,9 @@ describe("snapshotIndex", () => {
             await writeRepoFile(conflictRepo.root, "shared.txt", "one\nMAIN\nthree\n");
             await commitAll(conflictRepo.root, conflictRepo.env, "main edit");
 
-            await git(conflictRepo.root, ["merge", "other"], conflictRepo.env).catch(() => undefined);
+            await git(conflictRepo.root, ["merge", "other"], conflictRepo.env).catch(
+                () => undefined,
+            );
             return conflictRepo;
         }
 
@@ -95,7 +97,9 @@ describe("snapshotIndex", () => {
             expect(cleanSection.status).toBe("captured");
             const cleanStages =
                 cleanSection.status === "captured"
-                    ? cleanSection.data.filter((entry) => entry.path === "shared.txt").map((entry) => entry.stage)
+                    ? cleanSection.data
+                          .filter((entry) => entry.path === "shared.txt")
+                          .map((entry) => entry.stage)
                     : [];
             expect(cleanStages).toEqual([0]);
             await clean.dispose();

--- a/tests/unit/fixtures/snapshotNormalize.test.ts
+++ b/tests/unit/fixtures/snapshotNormalize.test.ts
@@ -55,8 +55,16 @@ describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8'
         await rm(copy1Dest, { recursive: true, force: true });
         await rm(copy2Dest, { recursive: true, force: true });
         scratchDirs.push(copy1Dest, copy2Dest);
-        await cp(seedDest, copy1Dest, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true });
-        await cp(seedDest, copy2Dest, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true });
+        await cp(seedDest, copy1Dest, {
+            recursive: true,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+        });
+        await cp(seedDest, copy2Dest, {
+            recursive: true,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+        });
 
         const roots1 = {
             root: path.join(copy1Dest, "workspace"),
@@ -93,11 +101,23 @@ describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8'
         await rm(copy1Dest, { recursive: true, force: true });
         await rm(copy2Dest, { recursive: true, force: true });
         scratchDirs.push(copy1Dest, copy2Dest);
-        await cp(seedDest, copy1Dest, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true });
-        await cp(seedDest, copy2Dest, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true });
+        await cp(seedDest, copy1Dest, {
+            recursive: true,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+        });
+        await cp(seedDest, copy2Dest, {
+            recursive: true,
+            preserveTimestamps: true,
+            verbatimSymlinks: true,
+        });
 
         // Deliberately break copy2: add an extra untracked file that copy1 never gets.
-        await writeFile(path.join(copy2Dest, "workspace", "only-in-copy2.txt"), "divergence\n", "utf8");
+        await writeFile(
+            path.join(copy2Dest, "workspace", "only-in-copy2.txt"),
+            "divergence\n",
+            "utf8",
+        );
 
         const roots1 = {
             root: path.join(copy1Dest, "workspace"),
@@ -125,7 +145,11 @@ describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8'
 
 describe("normalizeSnapshot -- placeholder rewriting", () => {
     it("rewrites repoRoot, commonDir, and nested fs-entry text to <ROOT>/<ORIGIN>/<PROFILE>", () => {
-        const roots = { root: "/tmp/fakeworkspace", originRoot: "/tmp/fakeorigin.git", profileDir: "/tmp/fakeprofile" };
+        const roots = {
+            root: "/tmp/fakeworkspace",
+            originRoot: "/tmp/fakeorigin.git",
+            profileDir: "/tmp/fakeprofile",
+        };
         const fakeEntry: FsEntry = {
             relativePath: ".git/config",
             type: "file",
@@ -146,7 +170,10 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             origin: {
                 repoRoot: roots.originRoot,
@@ -159,7 +186,10 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             durableState: notCaptured<never>("no provider"),
         };
@@ -169,7 +199,9 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
         expect(normalized.workspace.repoRoot).toBe("<ROOT>");
         expect(normalized.workspace.commonDir).toBe("<ROOT>/.git");
         expect(normalized.origin.repoRoot).toBe("<ORIGIN>");
-        const rewrittenEntry = (normalized.workspace.workingTree as { status: "captured"; data: readonly FsEntry[] }).data[0];
+        const rewrittenEntry = (
+            normalized.workspace.workingTree as { status: "captured"; data: readonly FsEntry[] }
+        ).data[0];
         expect(rewrittenEntry?.text).toBe('[remote "origin"]\n\turl = file://<ORIGIN>\n');
         // Digest must be recomputed from the NEW text, not left pointing at stale bytes.
         expect(rewrittenEntry?.digest).not.toBe("original-digest-before-rewrite");
@@ -180,7 +212,11 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
     });
 
     it("never touches the filesystem: normalizing a snapshot for a profileDir that does not exist does not throw", () => {
-        const roots = { root: "/tmp/whatever", originRoot: "/tmp/whatever-origin", profileDir: "/definitely/not/a/real/path" };
+        const roots = {
+            root: "/tmp/whatever",
+            originRoot: "/tmp/whatever-origin",
+            profileDir: "/definitely/not/a/real/path",
+        };
         const snapshot = {
             workspace: {
                 repoRoot: roots.root,
@@ -193,7 +229,10 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             origin: {
                 repoRoot: roots.originRoot,
@@ -206,7 +245,10 @@ describe("normalizeSnapshot -- placeholder rewriting", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             durableState: notCaptured<never>("no provider"),
         };
@@ -256,7 +298,10 @@ describe("normalizeSnapshot -- realpath duality", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({ common: [entryWithRealpathSpelling] }),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             origin: {
                 repoRoot: "/tmp/unused-origin",
@@ -269,7 +314,10 @@ describe("normalizeSnapshot -- realpath duality", () => {
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             durableState: notCaptured<never>("no provider"),
         };
@@ -281,8 +329,12 @@ describe("normalizeSnapshot -- realpath duality", () => {
         });
 
         expect(normalized.workspace.repoRoot).toBe("<ROOT>");
-        const rewritten = (normalized.workspace.gitDirState as { status: "captured"; data: Record<string, readonly FsEntry[]> })
-            .data.common?.[0];
+        const rewritten = (
+            normalized.workspace.gitDirState as {
+                status: "captured";
+                data: Record<string, readonly FsEntry[]>;
+            }
+        ).data.common?.[0];
         // The entry's `text` used the REALPATH'd spelling, which is not the literal root string,
         // yet still collapses to the placeholder.
         expect(rewritten?.text).toBe("<ROOT>/.git\n");
@@ -291,9 +343,27 @@ describe("normalizeSnapshot -- realpath duality", () => {
 
 describe("normalizeSnapshot -- comparison stays case-sensitive on recorded names", () => {
     it("does not fold the case of a relativePath, so two entries differing only in case remain distinct", () => {
-        const roots = { root: "/tmp/case-test", originRoot: "/tmp/case-test-origin", profileDir: "/tmp/case-test-profile" };
-        const lower: FsEntry = { relativePath: "file.txt", type: "file", mode: 0o644, digest: "d1", text: null, symlinkTarget: null };
-        const upper: FsEntry = { relativePath: "FILE.txt", type: "file", mode: 0o644, digest: "d2", text: null, symlinkTarget: null };
+        const roots = {
+            root: "/tmp/case-test",
+            originRoot: "/tmp/case-test-origin",
+            profileDir: "/tmp/case-test-profile",
+        };
+        const lower: FsEntry = {
+            relativePath: "file.txt",
+            type: "file",
+            mode: 0o644,
+            digest: "d1",
+            text: null,
+            symlinkTarget: null,
+        };
+        const upper: FsEntry = {
+            relativePath: "FILE.txt",
+            type: "file",
+            mode: 0o644,
+            digest: "d2",
+            text: null,
+            symlinkTarget: null,
+        };
 
         const buildSnapshot = (entries: readonly FsEntry[]) => ({
             workspace: {
@@ -307,7 +377,10 @@ describe("normalizeSnapshot -- comparison stays case-sensitive on recorded names
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             origin: {
                 repoRoot: roots.originRoot,
@@ -320,7 +393,10 @@ describe("normalizeSnapshot -- comparison stays case-sensitive on recorded names
                 reflogs: captured([]),
                 worktrees: captured([]),
                 gitDirState: captured({}),
-                objectStore: captured({ objects: [], alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] } }),
+                objectStore: captured({
+                    objects: [],
+                    alternates: { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                }),
             },
             durableState: notCaptured<never>("no provider"),
         });

--- a/tests/unit/fixtures/snapshotObjectStore.test.ts
+++ b/tests/unit/fixtures/snapshotObjectStore.test.ts
@@ -15,7 +15,10 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { assertAlternatesContained, snapshotObjectStore } from "../../fixtures/repo/snapshotObjectStore";
+import {
+    assertAlternatesContained,
+    snapshotObjectStore,
+} from "../../fixtures/repo/snapshotObjectStore";
 import type { ScratchRepo } from "./gitTestHelpers";
 import { commitAll, createScratchRepo, writeRepoFile } from "./gitTestHelpers";
 
@@ -55,18 +58,28 @@ describe("snapshotObjectStore", () => {
             const small = await createScratchRepo("objectstore-small");
             await writeRepoFile(small.root, "a.txt", "hello\n");
             await commitAll(small.root, small.env, "one commit");
-            const smallSection = await snapshotObjectStore(small.root, path.join(small.root, ".git"), small.env);
+            const smallSection = await snapshotObjectStore(
+                small.root,
+                path.join(small.root, ".git"),
+                small.env,
+            );
             expect(smallSection.status).toBe("captured");
-            const smallCount = smallSection.status === "captured" ? smallSection.data.objects.length : -1;
+            const smallCount =
+                smallSection.status === "captured" ? smallSection.data.objects.length : -1;
 
             const large = await createScratchRepo("objectstore-large");
             await writeRepoFile(large.root, "a.txt", "hello\n");
             await commitAll(large.root, large.env, "one commit");
             await writeRepoFile(large.root, "b.txt", "world\n");
             await commitAll(large.root, large.env, "two commits");
-            const largeSection = await snapshotObjectStore(large.root, path.join(large.root, ".git"), large.env);
+            const largeSection = await snapshotObjectStore(
+                large.root,
+                path.join(large.root, ".git"),
+                large.env,
+            );
             expect(largeSection.status).toBe("captured");
-            const largeCount = largeSection.status === "captured" ? largeSection.data.objects.length : -1;
+            const largeCount =
+                largeSection.status === "captured" ? largeSection.data.objects.length : -1;
 
             expect(largeCount).toBeGreaterThan(smallCount);
 
@@ -80,10 +93,18 @@ describe("snapshotObjectStore", () => {
             await writeRepoFile(repo.root, "a.txt", "hello\n");
             await commitAll(repo.root, repo.env, "c1");
 
-            const section = await snapshotObjectStore(repo.root, path.join(repo.root, ".git"), repo.env);
+            const section = await snapshotObjectStore(
+                repo.root,
+                path.join(repo.root, ".git"),
+                repo.env,
+            );
             expect(section.status).toBe("captured");
             if (section.status !== "captured") return;
-            expect(section.data.alternates).toEqual({ present: false, rawLines: [], resolvedAbsolutePaths: [] });
+            expect(section.data.alternates).toEqual({
+                present: false,
+                rawLines: [],
+                resolvedAbsolutePaths: [],
+            });
         });
 
         it("reports present with resolved absolute paths when an alternates file exists", async () => {
@@ -96,7 +117,11 @@ describe("snapshotObjectStore", () => {
             const insideObjectsDir = path.join(repo.root, ".git", "objects");
             await writeFile(path.join(infoDir, "alternates"), `${insideObjectsDir}\n`);
 
-            const section = await snapshotObjectStore(repo.root, path.join(repo.root, ".git"), repo.env);
+            const section = await snapshotObjectStore(
+                repo.root,
+                path.join(repo.root, ".git"),
+                repo.env,
+            );
             expect(section.status).toBe("captured");
             if (section.status !== "captured") return;
             expect(section.data.alternates.present).toBe(true);
@@ -108,14 +133,21 @@ describe("snapshotObjectStore", () => {
     describe("assertAlternatesContained -- the RED-proof this bullet exists for", () => {
         it("does not throw when alternates is absent", () => {
             expect(() =>
-                assertAlternatesContained({ present: false, rawLines: [], resolvedAbsolutePaths: [] }, ["/allowed"]),
+                assertAlternatesContained(
+                    { present: false, rawLines: [], resolvedAbsolutePaths: [] },
+                    ["/allowed"],
+                ),
             ).not.toThrow();
         });
 
         it("does not throw when every alternates path resolves inside an allowed root", () => {
             expect(() =>
                 assertAlternatesContained(
-                    { present: true, rawLines: ["x"], resolvedAbsolutePaths: ["/allowed/root/objects"] },
+                    {
+                        present: true,
+                        rawLines: ["x"],
+                        resolvedAbsolutePaths: ["/allowed/root/objects"],
+                    },
                     ["/allowed/root"],
                 ),
             ).not.toThrow();
@@ -135,7 +167,11 @@ describe("snapshotObjectStore", () => {
             await mkdir(infoDir, { recursive: true });
             await writeFile(path.join(infoDir, "alternates"), `${outside.root}\n`);
 
-            const section = await snapshotObjectStore(repo.root, path.join(repo.root, ".git"), repo.env);
+            const section = await snapshotObjectStore(
+                repo.root,
+                path.join(repo.root, ".git"),
+                repo.env,
+            );
             expect(section.status).toBe("captured");
             if (section.status !== "captured") return;
 

--- a/tests/unit/fixtures/snapshotRefsAndWorktrees.test.ts
+++ b/tests/unit/fixtures/snapshotRefsAndWorktrees.test.ts
@@ -55,13 +55,16 @@ describe("snapshotRefs / snapshotHead / snapshotReflogs", () => {
         await git(repo.root, ["stash", "push", "--quiet", "-m", "will be dropped"], repo.env);
 
         const before = await snapshotRefs(repo.root, repo.env);
-        const hasStashBefore = before.status === "captured" && before.data.some((entry) => entry.name === "refs/stash");
+        const hasStashBefore =
+            before.status === "captured" &&
+            before.data.some((entry) => entry.name === "refs/stash");
         expect(hasStashBefore).toBe(true);
 
         await git(repo.root, ["stash", "drop"], repo.env);
 
         const after = await snapshotRefs(repo.root, repo.env);
-        const hasStashAfter = after.status === "captured" && after.data.some((entry) => entry.name === "refs/stash");
+        const hasStashAfter =
+            after.status === "captured" && after.data.some((entry) => entry.name === "refs/stash");
         // Same assertion shape as `hasStashBefore`; the deliberate break (dropping the stash)
         // flips it to `false`, proving the section is not tautologically "always has refs/stash".
         expect(hasStashAfter).toBe(false);
@@ -74,7 +77,10 @@ describe("snapshotRefs / snapshotHead / snapshotReflogs", () => {
 
         const gitDir = path.join(repo.root, ".git");
         const symbolic = await snapshotHead(gitDir);
-        expect(symbolic).toEqual({ status: "captured", data: { kind: "symbolic", target: "refs/heads/main" } });
+        expect(symbolic).toEqual({
+            status: "captured",
+            data: { kind: "symbolic", target: "refs/heads/main" },
+        });
 
         await git(repo.root, ["checkout", "--quiet", "--detach", sha], repo.env);
         const detached = await snapshotHead(gitDir);
@@ -130,7 +136,11 @@ describe("snapshotWorktrees", () => {
         await commitAll(repo.root, repo.env, "c1");
 
         const linkedPath = path.join(path.dirname(repo.root), `${path.basename(repo.root)}-linked`);
-        await git(repo.root, ["worktree", "add", "--quiet", "-b", "linked-branch", linkedPath, "main"], repo.env);
+        await git(
+            repo.root,
+            ["worktree", "add", "--quiet", "-b", "linked-branch", linkedPath, "main"],
+            repo.env,
+        );
 
         const commonDir = path.join(repo.root, ".git");
         const result = await snapshotWorktrees(repo.root, commonDir, repo.env);
@@ -148,11 +158,16 @@ describe("snapshotWorktrees", () => {
         // `commonDir` here is built from the literal, non-realpath'd `repo.root`.
         const { realpath } = await import("node:fs/promises");
         const [[, linkedGitDir]] = [...result.linkedGitDirs.entries()];
-        const [realLinkedGitDir, realCommonDir] = await Promise.all([realpath(linkedGitDir), realpath(commonDir)]);
+        const [realLinkedGitDir, realCommonDir] = await Promise.all([
+            realpath(linkedGitDir),
+            realpath(commonDir),
+        ]);
         expect(realLinkedGitDir).not.toBe(realCommonDir);
         expect(realLinkedGitDir.startsWith(path.join(realCommonDir, "worktrees"))).toBe(true);
 
-        await git(repo.root, ["worktree", "remove", "--force", linkedPath], repo.env).catch(() => undefined);
+        await git(repo.root, ["worktree", "remove", "--force", linkedPath], repo.env).catch(
+            () => undefined,
+        );
     });
 });
 
@@ -205,7 +220,9 @@ describe("snapshotGitDirState -- per-worktree and common-directory private state
             const before = await snapshotGitDirState(commonDir, new Map());
             const bisectFilesBefore =
                 before.status === "captured"
-                    ? (before.data.common ?? []).filter((entry) => entry.relativePath.startsWith("BISECT"))
+                    ? (before.data.common ?? []).filter((entry) =>
+                          entry.relativePath.startsWith("BISECT"),
+                      )
                     : [];
             expect(bisectFilesBefore).toEqual([]);
 
@@ -217,9 +234,13 @@ describe("snapshotGitDirState -- per-worktree and common-directory private state
             expect(during.status).toBe("captured");
             const bisectFilesDuring =
                 during.status === "captured"
-                    ? (during.data.common ?? []).filter((entry) => entry.relativePath.startsWith("BISECT"))
+                    ? (during.data.common ?? []).filter((entry) =>
+                          entry.relativePath.startsWith("BISECT"),
+                      )
                     : [];
-            expect(bisectFilesDuring.map((entry) => entry.relativePath).sort()).toContain("BISECT_LOG");
+            expect(bisectFilesDuring.map((entry) => entry.relativePath).sort()).toContain(
+                "BISECT_LOG",
+            );
             expect(bisectFilesDuring.length).toBeGreaterThan(0);
 
             // RED-proof completes the loop: `git bisect reset` removes them again, and the same
@@ -229,7 +250,9 @@ describe("snapshotGitDirState -- per-worktree and common-directory private state
             const after = await snapshotGitDirState(commonDir, new Map());
             const bisectFilesAfter =
                 after.status === "captured"
-                    ? (after.data.common ?? []).filter((entry) => entry.relativePath.startsWith("BISECT"))
+                    ? (after.data.common ?? []).filter((entry) =>
+                          entry.relativePath.startsWith("BISECT"),
+                      )
                     : [];
             expect(bisectFilesAfter).toEqual([]);
         });
@@ -241,8 +264,15 @@ describe("snapshotGitDirState -- per-worktree and common-directory private state
             await writeRepoFile(repo.root, "a.txt", "one\n");
             await commitAll(repo.root, repo.env, "primary commit");
 
-            const linkedPath = path.join(path.dirname(repo.root), `${path.basename(repo.root)}-linked`);
-            await git(repo.root, ["worktree", "add", "--quiet", "-b", "linked-branch", linkedPath, "main"], repo.env);
+            const linkedPath = path.join(
+                path.dirname(repo.root),
+                `${path.basename(repo.root)}-linked`,
+            );
+            await git(
+                repo.root,
+                ["worktree", "add", "--quiet", "-b", "linked-branch", linkedPath, "main"],
+                repo.env,
+            );
             await writeRepoFile(linkedPath, "b.txt", "from linked worktree\n");
             await commitAll(linkedPath, repo.env, "linked commit");
 
@@ -254,7 +284,9 @@ describe("snapshotGitDirState -- per-worktree and common-directory private state
             // temp root (e.g. macOS `/var` -> `/private/var`), and the snapshot's own gitDirState
             // key must match that exactly for the lookup below to mean anything.
             const linkedWorktreeInfo =
-                worktreesResult.section.status === "captured" ? worktreesResult.section.data[1] : undefined;
+                worktreesResult.section.status === "captured"
+                    ? worktreesResult.section.data[1]
+                    : undefined;
             expect(linkedWorktreeInfo).toBeDefined();
 
             const gitDirState = await snapshotGitDirState(commonDir, worktreesResult.linkedGitDirs);

--- a/tests/unit/git/executor.test.ts
+++ b/tests/unit/git/executor.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { GitExecutor, isExpectedStdinFailure, setGitSuccessListener } from "../../../src/git/executor";
+import {
+    GitExecutor,
+    isExpectedStdinFailure,
+    setGitSuccessListener,
+} from "../../../src/git/executor";
 import { RepositoryMutationCoordinator } from "../../../src/git/mutationCoordinator";
 import { RepositoryLock } from "../../../src/git/repositoryLock";
 import { RepositoryMutationGate } from "../../../src/git/repositoryMutationGate";

--- a/tests/unit/git/gitAskpass.test.ts
+++ b/tests/unit/git/gitAskpass.test.ts
@@ -48,11 +48,10 @@ describe("git askpass helper", () => {
         mocks.fsWriteFile.mockRejectedValueOnce(failure);
 
         await expect(
-            runGitCommandWithAskpass(
-                "/repo",
-                ["push"],
-                { username: "oauth2", token: "secret-token" },
-            ),
+            runGitCommandWithAskpass("/repo", ["push"], {
+                username: "oauth2",
+                token: "secret-token",
+            }),
         ).rejects.toThrow("disk full");
 
         expect(mocks.execFile).not.toHaveBeenCalled();

--- a/tests/unit/git/gitops/branch.test.ts
+++ b/tests/unit/git/gitops/branch.test.ts
@@ -137,7 +137,9 @@ describe("GitOps", () => {
 
             await ops.push();
 
-            const calls = (executor.run as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]);
+            const calls = (executor.run as ReturnType<typeof vi.fn>).mock.calls.map(
+                (call) => call[0],
+            );
             expect(calls).toEqual([
                 ["rev-parse", "--abbrev-ref", "HEAD"],
                 ["rev-parse", "--abbrev-ref", "@{upstream}"],

--- a/tests/unit/git/gitops/remotes.test.ts
+++ b/tests/unit/git/gitops/remotes.test.ts
@@ -742,13 +742,19 @@ describe("GitOps", () => {
                         throw new Error("fatal: path 'deleted.txt' does not exist in 'stash@{0}'");
                     }
                     if (key === "show stash@{0}^3:deleted.txt") {
-                        throw new Error("fatal: path 'deleted.txt' does not exist in 'stash@{0}^3'");
+                        throw new Error(
+                            "fatal: path 'deleted.txt' does not exist in 'stash@{0}^3'",
+                        );
                     }
                     if (key === "show stash@{0}^1:untracked.txt") {
-                        throw new Error("fatal: path 'untracked.txt' does not exist in 'stash@{0}^1'");
+                        throw new Error(
+                            "fatal: path 'untracked.txt' does not exist in 'stash@{0}^1'",
+                        );
                     }
                     if (key === "show stash@{0}:untracked.txt") {
-                        throw new Error("fatal: path 'untracked.txt' does not exist in 'stash@{0}'");
+                        throw new Error(
+                            "fatal: path 'untracked.txt' does not exist in 'stash@{0}'",
+                        );
                     }
                     if (key === "show stash@{0}^3:untracked.txt") return "untracked";
                     throw new Error(`Unexpected Git command: ${key}`);
@@ -804,10 +810,7 @@ describe("GitOps", () => {
 
             const contents = ops.getStashFileContents(0, "src/a.ts");
 
-            expect(started).toEqual([
-                "show stash@{0}^1:src/a.ts",
-                "show stash@{0}:src/a.ts",
-            ]);
+            expect(started).toEqual(["show stash@{0}^1:src/a.ts", "show stash@{0}:src/a.ts"]);
             resolvers.get("show stash@{0}^1:src/a.ts")?.("base");
             resolvers.get("show stash@{0}:src/a.ts")?.("stash");
             await expect(contents).resolves.toEqual({ before: "base", after: "stash" });

--- a/tests/unit/git/gitops/status.test.ts
+++ b/tests/unit/git/gitops/status.test.ts
@@ -264,7 +264,9 @@ describe("GitOps", () => {
             const ops = new GitOps(executor);
             const branches = await ops.getBranches();
 
-            expect(branches.find((branch) => branch.name === "upstream/trunk")?.isDefault).toBeUndefined();
+            expect(
+                branches.find((branch) => branch.name === "upstream/trunk")?.isDefault,
+            ).toBeUndefined();
         });
     });
 

--- a/tests/unit/git/interactiveRebase/control.test.ts
+++ b/tests/unit/git/interactiveRebase/control.test.ts
@@ -19,7 +19,8 @@ import {
 const terminalManifestWriteFault = vi.hoisted(() => ({ enabled: false }));
 
 vi.mock("../../../../src/git/interactiveRebase/storage", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("../../../../src/git/interactiveRebase/storage")>();
+    const actual =
+        await importOriginal<typeof import("../../../../src/git/interactiveRebase/storage")>();
     return {
         ...actual,
         writeRebaseManifest: async (...args: Parameters<typeof actual.writeRebaseManifest>) => {

--- a/tests/unit/git/interactiveRebase/push.test.ts
+++ b/tests/unit/git/interactiveRebase/push.test.ts
@@ -83,12 +83,7 @@ describe("readRebasePushTarget", () => {
             expect.anything(),
         );
         expect(executor.runBinary).toHaveBeenCalledWith(
-            [
-                "rev-parse",
-                "--verify",
-                "--end-of-options",
-                "refs/remotes/origin/main^{commit}",
-            ],
+            ["rev-parse", "--verify", "--end-of-options", "refs/remotes/origin/main^{commit}"],
             expect.anything(),
         );
     });
@@ -136,7 +131,9 @@ describe("readRebasePushTarget", () => {
             new Error("missing tracking ref"),
         );
 
-        await expect(readRebasePushTarget(executor as never, "refs/heads/main")).resolves.toBeUndefined();
+        await expect(
+            readRebasePushTarget(executor as never, "refs/heads/main"),
+        ).resolves.toBeUndefined();
         expect(executor.runBinary).toHaveBeenCalledTimes(2);
     });
 
@@ -146,7 +143,9 @@ describe("readRebasePushTarget", () => {
             "not-an-object-id",
         );
 
-        await expect(readRebasePushTarget(executor as never, "refs/heads/main")).resolves.toBeUndefined();
+        await expect(
+            readRebasePushTarget(executor as never, "refs/heads/main"),
+        ).resolves.toBeUndefined();
         expect(executor.runBinary).toHaveBeenCalledTimes(2);
     });
 });

--- a/tests/unit/git/interactiveRebase/run.test.ts
+++ b/tests/unit/git/interactiveRebase/run.test.ts
@@ -7,7 +7,8 @@ const cleanupFault = vi.hoisted(() => ({ manifestRemoval: false }));
 const terminalManifestWriteFault = vi.hoisted(() => ({ enabled: false }));
 
 vi.mock("../../../../src/git/interactiveRebase/storage", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("../../../../src/git/interactiveRebase/storage")>();
+    const actual =
+        await importOriginal<typeof import("../../../../src/git/interactiveRebase/storage")>();
     return {
         ...actual,
         writeRebaseManifest: async (...args: Parameters<typeof actual.writeRebaseManifest>) => {

--- a/tests/unit/git/interactiveRebase/storage.test.ts
+++ b/tests/unit/git/interactiveRebase/storage.test.ts
@@ -377,4 +377,3 @@ describe("pushTarget schema validation", () => {
         });
     });
 });
-

--- a/tests/unit/git/mutationCoordinator.test.ts
+++ b/tests/unit/git/mutationCoordinator.test.ts
@@ -27,7 +27,13 @@ describe("RepositoryMutationCoordinator", () => {
     it("allows different repositories to run concurrently", async () => {
         const coordinator = new RepositoryMutationCoordinator();
         let release: (() => void) | undefined;
-        const first = coordinator.run("/one", () => new Promise<void>((resolve) => { release = resolve; }));
+        const first = coordinator.run(
+            "/one",
+            () =>
+                new Promise<void>((resolve) => {
+                    release = resolve;
+                }),
+        );
         const second = coordinator.run("/two", async () => "parallel");
 
         await expect(second).resolves.toBe("parallel");
@@ -39,7 +45,13 @@ describe("RepositoryMutationCoordinator", () => {
         const coordinator = new RepositoryMutationCoordinator();
         const tails = (coordinator as unknown as { tails: Map<string, Promise<void>> }).tails;
         let releaseFirst: (() => void) | undefined;
-        const first = coordinator.run("/repo", () => new Promise<void>((resolve) => { releaseFirst = resolve; }));
+        const first = coordinator.run(
+            "/repo",
+            () =>
+                new Promise<void>((resolve) => {
+                    releaseFirst = resolve;
+                }),
+        );
         const literalKey = coordinator.run("/repo/.", async () => "completed");
 
         await expect(literalKey).resolves.toBe("completed");

--- a/tests/unit/git/nested-repo-root.test.ts
+++ b/tests/unit/git/nested-repo-root.test.ts
@@ -39,7 +39,10 @@ vi.mock("vscode", () => ({
 
 import { GitOps } from "../../../src/git/operations";
 import type { GitExecutor } from "../../../src/git/executor";
-import { getRepoRelativeFilePathFromUri, normalizeGitPath } from "../../../src/services/diffService";
+import {
+    getRepoRelativeFilePathFromUri,
+    normalizeGitPath,
+} from "../../../src/services/diffService";
 import { assertRepoRelativePath } from "../../../src/utils/fileOps";
 import * as path from "path";
 

--- a/tests/unit/git/operations.test.ts
+++ b/tests/unit/git/operations.test.ts
@@ -182,7 +182,7 @@ describe("GitOps.getActiveOperation", () => {
         ["REVERT_HEAD", "revert"],
         ["rebase-merge", "rebase"],
         ["rebase-apply", "rebase"],
-    ] as const satisfies readonly [string, ActiveOperationKind][]) (
+    ] as const satisfies readonly [string, ActiveOperationKind][])(
         "derives %s as %s",
         async (marker, expected) => {
             const root = await createGitRepository();
@@ -204,7 +204,7 @@ describe("GitOps.getActiveOperation", () => {
             ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply"],
             "rebase",
         ],
-    ] as const satisfies readonly [readonly string[], ActiveOperationKind][]) (
+    ] as const satisfies readonly [readonly string[], ActiveOperationKind][])(
         "uses documented precedence for %j",
         async (markers, expected) => {
             const root = await createGitRepository();
@@ -658,7 +658,13 @@ describe("GitOps.getDiffForPaths", () => {
 
     it("does not charge discarded truncated bytes against later patch budget", async () => {
         const root = await createGitRepository();
-        const paths = ["truncated.txt", "middle-one.txt", "middle-two.txt", "middle-three.txt", "later.txt"];
+        const paths = [
+            "truncated.txt",
+            "middle-one.txt",
+            "middle-two.txt",
+            "middle-three.txt",
+            "later.txt",
+        ];
         for (const filePath of paths) {
             await commitFile(root, filePath, "before\\n");
             await writeFile(path.join(root, filePath), "after\\n");
@@ -666,7 +672,9 @@ describe("GitOps.getDiffForPaths", () => {
         const gitOps = gitOpsFor(root);
         const executor = (gitOps as unknown as { executor: GitExecutor }).executor;
         const runBinary = executor.runBinary.bind(executor);
-        const laterPatch = Buffer.from(`diff --git a/later.txt b/later.txt\\n${"x".repeat(60_000)}`);
+        const laterPatch = Buffer.from(
+            `diff --git a/later.txt b/later.txt\\n${"x".repeat(60_000)}`,
+        );
         executor.runBinary = async (args, options) => {
             if (
                 args[0] === "--literal-pathspecs" &&

--- a/tests/unit/git/repositoryDiscovery.test.ts
+++ b/tests/unit/git/repositoryDiscovery.test.ts
@@ -84,7 +84,11 @@ describe("discoverGitRepositories", () => {
         const resolveGitRepository = vi.fn(async (candidateRoot: string) => {
             const root = path.resolve(candidateRoot);
             if (root === submodule) {
-                return { root, gitDir: path.join(root, ".git"), commonDir: path.join(root, ".git") };
+                return {
+                    root,
+                    gitDir: path.join(root, ".git"),
+                    commonDir: path.join(root, ".git"),
+                };
             }
             if (root === linkedWorktree) {
                 return {

--- a/tests/unit/git/repositoryLock.test.ts
+++ b/tests/unit/git/repositoryLock.test.ts
@@ -233,14 +233,17 @@ describe("RepositoryLock", () => {
 
         const outcomes = await Promise.allSettled([contender(), contender()]);
         const winners = outcomes.filter(
-            (outcome): outcome is PromiseFulfilledResult<() => Promise<void>> => outcome.status === "fulfilled",
+            (outcome): outcome is PromiseFulfilledResult<() => Promise<void>> =>
+                outcome.status === "fulfilled",
         );
         const losers = outcomes.filter((outcome) => outcome.status === "rejected");
 
         expect(winners).toHaveLength(1);
         expect(losers).toHaveLength(1);
         expect(losers[0].reason).toBeInstanceOf(RepositoryLockBusyError);
-        expect(JSON.parse(await readFile(path.join(lockDir, "repo.lock"), "utf8"))).not.toMatchObject({
+        expect(
+            JSON.parse(await readFile(path.join(lockDir, "repo.lock"), "utf8")),
+        ).not.toMatchObject({
             nonce: "dead-owner",
         });
         await winners[0].value();

--- a/tests/unit/git/repositoryMutationGate.test.ts
+++ b/tests/unit/git/repositoryMutationGate.test.ts
@@ -18,8 +18,15 @@ async function tempDir(prefix: string): Promise<string> {
     return directory;
 }
 
-function gate(options?: { acquireTimeoutMs?: number; acquireRetryDelayMs?: number }): RepositoryMutationGate {
-    return new RepositoryMutationGate(new RepositoryMutationCoordinator(), new RepositoryLock(), options);
+function gate(options?: {
+    acquireTimeoutMs?: number;
+    acquireRetryDelayMs?: number;
+}): RepositoryMutationGate {
+    return new RepositoryMutationGate(
+        new RepositoryMutationCoordinator(),
+        new RepositoryLock(),
+        options,
+    );
 }
 
 describe("RepositoryMutationGate", () => {
@@ -46,7 +53,11 @@ describe("RepositoryMutationGate", () => {
         const release = await holder.acquire(common);
 
         await expect(
-            gate({ acquireTimeoutMs: 200, acquireRetryDelayMs: 25 }).run(repoRoot, common, async () => "ran"),
+            gate({ acquireTimeoutMs: 200, acquireRetryDelayMs: 25 }).run(
+                repoRoot,
+                common,
+                async () => "ran",
+            ),
         ).rejects.toBeInstanceOf(RepositoryLockBusyError);
         await release();
     });

--- a/tests/unit/git/worktrees.test.ts
+++ b/tests/unit/git/worktrees.test.ts
@@ -114,7 +114,9 @@ describe("parseWorktreeList", () => {
      * the first assertion on its own.
      */
     it("matches a symlinked current root against Git's resolved worktree path", async () => {
-        const root = await realpath(await mkdtemp(path.join(tmpdir(), "intelligit-worktrees-sym-")));
+        const root = await realpath(
+            await mkdtemp(path.join(tmpdir(), "intelligit-worktrees-sym-")),
+        );
         tempRoots.push(root);
         const repo = path.join(root, "repo");
         const other = path.join(root, "other");
@@ -269,11 +271,9 @@ describe("listWorktrees", () => {
         const worktrees = await listWorktrees(new RealGitExecutor(repo) as GitExecutor, repo);
 
         expect(worktrees).toHaveLength(3);
-        expect(worktrees.map((worktree) => worktree.branch).sort()).toEqual([
-            defaultBranch,
-            "feature/x",
-            "feature/y",
-        ].sort());
+        expect(worktrees.map((worktree) => worktree.branch).sort()).toEqual(
+            [defaultBranch, "feature/x", "feature/y"].sort(),
+        );
         expect(worktrees.find((worktree) => worktree.path === repo)).toMatchObject({
             isMain: true,
             isCurrent: true,
@@ -295,9 +295,9 @@ describe("assertWorktreePathSafe", () => {
         await mkdir(path.join(repo, "src"), { recursive: true });
         await mkdir(linked);
 
-        expect(() =>
-            assertWorktreePathSafe(path.join(repo, "src", "nested"), repo, []),
-        ).toThrow("inside the current repository");
+        expect(() => assertWorktreePathSafe(path.join(repo, "src", "nested"), repo, [])).toThrow(
+            "inside the current repository",
+        );
         expect(() =>
             assertWorktreePathSafe(path.join(linked, "child"), repo, [
                 {

--- a/tests/unit/localization/localization.test.ts
+++ b/tests/unit/localization/localization.test.ts
@@ -95,7 +95,9 @@ describe("localization catalogs", () => {
     });
 
     it("escapes spreadsheet formula-leading cells in the translation review CSV", () => {
-        const rows = parseCsvRows(readText("docs/localization/localization_translation_review.csv"));
+        const rows = parseCsvRows(
+            readText("docs/localization/localization_translation_review.csv"),
+        );
         const unsafeCells: string[] = [];
 
         rows.forEach((row, rowIndex) => {

--- a/tests/unit/merge/autoMerge.test.ts
+++ b/tests/unit/merge/autoMerge.test.ts
@@ -38,11 +38,7 @@ describe("tryAutoMergeLines", () => {
     });
 
     it("returns the shared rewrite when both sides made the same change", () => {
-        const merged = tryAutoMergeLines(
-            ["let x = 1;"],
-            ["const x = 1;"],
-            ["const x = 1;"],
-        );
+        const merged = tryAutoMergeLines(["let x = 1;"], ["const x = 1;"], ["const x = 1;"]);
         expect(merged).toEqual(["const x = 1;"]);
     });
 
@@ -67,11 +63,7 @@ describe("tryAutoMergeLines", () => {
 
     it("returns null when the sides change the number of lines", () => {
         expect(
-            tryAutoMergeLines(
-                ["original();"],
-                ["replaced();"],
-                ["expanded();", "second_line();"],
-            ),
+            tryAutoMergeLines(["original();"], ["replaced();"], ["expanded();", "second_line();"]),
         ).toBeNull();
         expect(tryAutoMergeLines([], ["added_by_ours();"], ["added_by_theirs();"])).toBeNull();
     });
@@ -79,18 +71,18 @@ describe("tryAutoMergeLines", () => {
     it("returns null when both sides insert at the same position", () => {
         // Ordering of two insertions at one point is ambiguous; never guess.
         expect(
-            tryAutoMergeLines(
-                ["call(a);"],
-                ["call(a, extraOurs);"],
-                ["call(a, extraTheirs);"],
-            ),
+            tryAutoMergeLines(["call(a);"], ["call(a, extraOurs);"], ["call(a, extraTheirs);"]),
         ).toBeNull();
     });
 
     it("merges adjacent but non-overlapping token replacements", () => {
         // ours rewrites the identifier, theirs rewrites the operator right
         // after it; ranges share a boundary but no tokens.
-        const merged = tryAutoMergeLines(["count += step;"], ["total += step;"], ["count -= step;"]);
+        const merged = tryAutoMergeLines(
+            ["count += step;"],
+            ["total += step;"],
+            ["count -= step;"],
+        );
         expect(merged).toEqual(["total -= step;"]);
     });
 
@@ -104,6 +96,8 @@ describe("tryAutoMergeLines", () => {
     });
 
     it("returns null rather than merging when one side empties the line", () => {
-        expect(tryAutoMergeLines(["keep_or_drop();"], [""], ["keep_or_drop(); // note"])).toBeNull();
+        expect(
+            tryAutoMergeLines(["keep_or_drop();"], [""], ["keep_or_drop(); // note"]),
+        ).toBeNull();
     });
 });

--- a/tests/unit/merge/lineDiff.test.ts
+++ b/tests/unit/merge/lineDiff.test.ts
@@ -76,9 +76,7 @@ describe("diffLinesFair — important-line anchoring", () => {
             "  return 2;",
             "}",
         ];
-        expect(diffLinesFair(lines1, lines2)).toEqual([
-            { start1: 2, end1: 6, start2: 2, end2: 6 },
-        ]);
+        expect(diffLinesFair(lines1, lines2)).toEqual([{ start1: 2, end1: 6, start2: 2, end2: 6 }]);
     });
 
     it("prefers the high-information line when two anchor candidates cross", () => {
@@ -86,18 +84,14 @@ describe("diffLinesFair — important-line anchoring", () => {
         // The information-rich statement must win over structural noise.
         const lines1 = ["database: {", "middle aaa bbb", "return this.config;"];
         const lines2 = ["return this.config;", "middle ccc ddd", "database: {"];
-        expect(diffLinesFair(lines1, lines2)).toEqual([
-            { start1: 2, end1: 3, start2: 0, end2: 1 },
-        ]);
+        expect(diffLinesFair(lines1, lines2)).toEqual([{ start1: 2, end1: 3, start2: 0, end2: 1 }]);
     });
 
     it("still matches unimportant lines when no important anchors exist", () => {
         // Inside a single gap, standalone unimportant runs may match.
         const lines1 = ["first aaa", "}", "second bbb"];
         const lines2 = ["third ccc", "}", "fourth ddd"];
-        expect(diffLinesFair(lines1, lines2)).toEqual([
-            { start1: 1, end1: 2, start2: 1, end2: 2 },
-        ]);
+        expect(diffLinesFair(lines1, lines2)).toEqual([{ start1: 1, end1: 2, start2: 1, end2: 2 }]);
     });
 
     it("matches all-blank files by position", () => {
@@ -139,9 +133,7 @@ describe("diffLinesFair — gap correction", () => {
         assertValidRanges(result, lines1, lines2);
         // "const kept" must be matched (1 -> 2) despite surrounding edits.
         expect(
-            result.some(
-                (r) => r.start1 <= 1 && r.end1 > 1 && r.start2 + (1 - r.start1) === 2,
-            ),
+            result.some((r) => r.start1 <= 1 && r.end1 > 1 && r.start2 + (1 - r.start1) === 2),
         ).toBe(true);
         // "return kept;" and "}" stay matched positionally.
         expect(result[result.length - 1]).toEqual({ start1: 3, end1: 5, start2: 3, end2: 5 });

--- a/tests/unit/merge/merge-parser-performance.test.ts
+++ b/tests/unit/merge/merge-parser-performance.test.ts
@@ -77,7 +77,8 @@ describe("conflict parser performance", () => {
         // Both sides collide on every 120th line (lcm of 40 and 60), so the
         // parser must emit exactly that many true conflicts.
         const trueConflicts = segments.filter(
-            (seg): seg is ConflictSegment => seg.type === "conflict" && seg.changeKind === "conflict",
+            (seg): seg is ConflictSegment =>
+                seg.type === "conflict" && seg.changeKind === "conflict",
         );
         expect(trueConflicts).toHaveLength(TOTAL_LINES / 120);
 

--- a/tests/unit/merge/pycharm-parity.test.ts
+++ b/tests/unit/merge/pycharm-parity.test.ts
@@ -147,8 +147,12 @@ describe("PyCharm parity — config loader scenario", () => {
 
     it("keeps the parse-line conflict to a single line per side", () => {
         const second = conflicts[1];
-        expect(second.baseLines).toEqual(["  const parsed = JSON.parse(raw) as Partial<AppConfig>;"]);
-        expect(second.oursLines).toEqual(["  const parsed = yaml.parse(raw) as Partial<AppConfig>;"]);
+        expect(second.baseLines).toEqual([
+            "  const parsed = JSON.parse(raw) as Partial<AppConfig>;",
+        ]);
+        expect(second.oursLines).toEqual([
+            "  const parsed = yaml.parse(raw) as Partial<AppConfig>;",
+        ]);
         expect(second.theirsLines).toEqual([
             "  const parsed = toml.parse(raw) as Partial<AppConfig>;",
         ]);
@@ -160,9 +164,7 @@ describe("PyCharm parity — config loader scenario", () => {
         expect(third.baseLines[0]).toBe("  this.config = {");
         expect(third.baseLines).toContain("    database: {");
         expect(third.baseLines).toContain("  };");
-        expect(third.oursLines).toEqual([
-            "  this.config = this.mergeConfig(this.config, parsed);",
-        ]);
+        expect(third.oursLines).toEqual(["  this.config = this.mergeConfig(this.config, parsed);"]);
         expect(third.theirsLines[0]).toBe("  // Deep merge with validation");
         expect(third.theirsLines[third.theirsLines.length - 1]).toBe("  this.config = merged;");
     });

--- a/tests/unit/merge/syntaxHighlight.test.ts
+++ b/tests/unit/merge/syntaxHighlight.test.ts
@@ -17,7 +17,7 @@ describe("tokenizeSyntaxLine", () => {
 
     it("concatenates tokens back to the exact input line", () => {
         const lines = [
-            "const url = \"https://example.com\"; // trailing note",
+            'const url = "https://example.com"; // trailing note',
             "\tif (x <= 10) { return 'a\\'b'; }",
             "let n = 3.14 + arr[0];",
             "// whole line comment",

--- a/tests/unit/oracleRegistry.test.ts
+++ b/tests/unit/oracleRegistry.test.ts
@@ -63,14 +63,19 @@ async function findValueOracleImporters(): Promise<Set<string>> {
         }
     }
 
-    expect(valueImportCount, "oracle value-import scanner must find a known-present import").toBeGreaterThan(0);
+    expect(
+        valueImportCount,
+        "oracle value-import scanner must find a known-present import",
+    ).toBeGreaterThan(0);
     return importers;
 }
 
 describe("oracle registry", () => {
     it("matches every TypeScript oracle module exactly once", async () => {
         const modulePaths = (
-            await Promise.all(oracleDirectories.map((directory) => discoverTypeScriptModules(directory)))
+            await Promise.all(
+                oracleDirectories.map((directory) => discoverTypeScriptModules(directory)),
+            )
         ).flat();
         const discoveredIds = modulePaths.map((modulePath) => path.basename(modulePath, ".ts"));
         const duplicateIds = discoveredIds.filter(
@@ -99,7 +104,14 @@ describe("oracle registry", () => {
         // alternative, adding this file to the pinned exemption set, would hand it a permanent
         // licence to import an oracle for real.
         const oracleSpecifier = ["..", "..", "oracles", "geometry"].join("/");
-        const probePath = path.join(repositoryRoot, "tests", "visual", "playwright", "deep", "probe.ts");
+        const probePath = path.join(
+            repositoryRoot,
+            "tests",
+            "visual",
+            "playwright",
+            "deep",
+            "probe.ts",
+        );
         const lintOracleImport = async (source: string): Promise<readonly string[]> => {
             const results = await new ESLint({ cwd: repositoryRoot }).lintText(source, {
                 filePath: probePath,

--- a/tests/unit/publishing/check-extension-publish-status.test.ts
+++ b/tests/unit/publishing/check-extension-publish-status.test.ts
@@ -47,8 +47,7 @@ describe("isOvsxVersionPublished", () => {
                     version: "0.6.0",
                     allVersions: {
                         latest: "https://open-vsx.org/api/MaheshKok/intelligit/universal/latest",
-                        "0.6.0":
-                            "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.6.0",
+                        "0.6.0": "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.6.0",
                     },
                 },
                 "0.6.0",
@@ -63,8 +62,7 @@ describe("isOvsxVersionPublished", () => {
                     version: "0.5.5",
                     allVersions: {
                         latest: "https://open-vsx.org/api/MaheshKok/intelligit/universal/latest",
-                        "0.5.5":
-                            "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.5.5",
+                        "0.5.5": "https://open-vsx.org/api/MaheshKok/intelligit/universal/0.5.5",
                     },
                 },
                 "0.6.0",

--- a/tests/unit/publishing/verifyReleaseVersion.test.ts
+++ b/tests/unit/publishing/verifyReleaseVersion.test.ts
@@ -29,9 +29,7 @@ describe("verifyReleaseVersion", () => {
     it.each(["1", "1.2", "v1.2.3", "1.2.3-beta.1", "1.2.3.4", "01.2.3"])(
         "fails closed for unsupported version %s",
         (version) => {
-            expect(() => compareStableVersions(version, "2.0.0")).toThrow(
-                /stable SemVer/,
-            );
+            expect(() => compareStableVersions(version, "2.0.0")).toThrow(/stable SemVer/);
         },
     );
 
@@ -39,9 +37,7 @@ describe("verifyReleaseVersion", () => {
         expect(() => assertSameStableRelease("0.25.3", "0.25.3")).not.toThrow();
         expect(() => assertSameStableRelease("0.25.3", "0.25.4")).toThrow(/must equal/);
         expect(() => assertSameStableRelease("0.25.3", "0.25.2")).toThrow(/must equal/);
-        expect(() => assertSameStableRelease("0.25.3", "0.25.3-beta.1")).toThrow(
-            /stable SemVer/,
-        );
+        expect(() => assertSameStableRelease("0.25.3", "0.25.3-beta.1")).toThrow(/stable SemVer/);
         expect(() =>
             assertSameStableRelease("9007199254740992.0.0", "9007199254740993.0.0"),
         ).toThrow(/must equal/);

--- a/tests/unit/publishing/workflowActionPinning.test.ts
+++ b/tests/unit/publishing/workflowActionPinning.test.ts
@@ -153,9 +153,7 @@ describe("workflow action pinning", () => {
         expect(checkouts.length).toBeGreaterThan(0);
         expect(references.every(({ job }) => job !== "")).toBe(true);
         expect(
-            checkouts.every(({ body }) =>
-                /^\s+persist-credentials:\s*false\s*$/m.test(body),
-            ),
+            checkouts.every(({ body }) => /^\s+persist-credentials:\s*false\s*$/m.test(body)),
         ).toBe(true);
     });
 });

--- a/tests/unit/scripts/build.test.ts
+++ b/tests/unit/scripts/build.test.ts
@@ -168,7 +168,9 @@ describe("runBuild", () => {
         for (const file of manifest.files as { path: string; hash: string }[]) {
             const outputPath = join(distDir, file.path);
             expect(existsSync(outputPath)).toBe(true);
-            const actualSha256 = createHash("sha256").update(readFileSync(outputPath)).digest("hex");
+            const actualSha256 = createHash("sha256")
+                .update(readFileSync(outputPath))
+                .digest("hex");
             expect(file.hash, `manifest hash for ${file.path}`).toBe(actualSha256);
         }
     });

--- a/tests/unit/scripts/verifyNoE2eManifestCommand.test.ts
+++ b/tests/unit/scripts/verifyNoE2eManifestCommand.test.ts
@@ -46,11 +46,9 @@ describe("verifyNoE2eManifestCommand: synthetic fixtures", () => {
         const forbiddenPackageJsonPath = seedPackageJson({
             commands: [{ command: "intelligit.e2eControlChannel.seed", title: "Seed" }],
         });
-        const forbiddenRun = spawnSync(
-            process.execPath,
-            [SCRIPT_PATH, forbiddenPackageJsonPath],
-            { encoding: "utf8" },
-        );
+        const forbiddenRun = spawnSync(process.execPath, [SCRIPT_PATH, forbiddenPackageJsonPath], {
+            encoding: "utf8",
+        });
 
         expect(forbiddenRun.status).not.toBe(0);
         expect(forbiddenRun.stderr).toContain("packaging check failed");
@@ -117,7 +115,9 @@ describe("verifyNoE2eManifestCommand: synthetic fixtures", () => {
         // A command author could pick an innocuous-looking id while the palette label still
         // gives the control surface away -- both must be checked.
         const packageJsonPath = seedPackageJson({
-            commands: [{ command: "intelligit.internalDebug", title: "IntelliGit: E2E Seed State" }],
+            commands: [
+                { command: "intelligit.internalDebug", title: "IntelliGit: E2E Seed State" },
+            ],
         });
         const result = verifyNoE2eManifestCommand({
             packageJsonPath,

--- a/tests/unit/services/commitChecks/requestGate.test.ts
+++ b/tests/unit/services/commitChecks/requestGate.test.ts
@@ -94,22 +94,25 @@ describe("GitHubRequestGate", () => {
     it.each([
         { limit: "5000", remaining: "500" },
         { limit: "1000", remaining: "100" },
-    ])("blocks a request when observed remaining quota reaches its reserve", async ({ limit, remaining }) => {
-        const gate = new GitHubRequestGate(4, () => 1_000);
-        gate.observeResponse({
-            url: GITHUB_API_URL,
-            statusCode: 200,
-            headers: {
-                "x-ratelimit-limit": limit,
-                "x-ratelimit-remaining": remaining,
-                "x-ratelimit-reset": "3600",
-            },
-        });
-        const task = vi.fn(async () => "ok");
+    ])(
+        "blocks a request when observed remaining quota reaches its reserve",
+        async ({ limit, remaining }) => {
+            const gate = new GitHubRequestGate(4, () => 1_000);
+            gate.observeResponse({
+                url: GITHUB_API_URL,
+                statusCode: 200,
+                headers: {
+                    "x-ratelimit-limit": limit,
+                    "x-ratelimit-remaining": remaining,
+                    "x-ratelimit-reset": "3600",
+                },
+            });
+            const task = vi.fn(async () => "ok");
 
-        await expect(gate.run(task)).rejects.toThrow("GitHub rate limit cooldown is active.");
-        expect(task).not.toHaveBeenCalled();
-    });
+            await expect(gate.run(task)).rejects.toThrow("GitHub rate limit cooldown is active.");
+            expect(task).not.toHaveBeenCalled();
+        },
+    );
 
     it("blocks request 301 in a rolling hour and allows the next request after the oldest expires", async () => {
         let clock = 1_000;
@@ -141,7 +144,9 @@ describe("GitHubRequestGate", () => {
         });
         const blockedTask = vi.fn(async () => "blocked");
 
-        await expect(gate.run(blockedTask)).rejects.toThrow("GitHub rate limit cooldown is active.");
+        await expect(gate.run(blockedTask)).rejects.toThrow(
+            "GitHub rate limit cooldown is active.",
+        );
         expect(blockedTask).not.toHaveBeenCalled();
 
         clock = 3_600_001;
@@ -359,7 +364,9 @@ describe("CommitChecksRequestGateRegistry", () => {
                 throw new HttpError(429, "HTTP 429: slow down", { "retry-after": "60" });
             }),
         ).rejects.toThrow("HTTP 429: slow down");
-        await expect(registry.run("gitlab", cooledUrl, async () => "blocked")).rejects.toMatchObject({
+        await expect(
+            registry.run("gitlab", cooledUrl, async () => "blocked"),
+        ).rejects.toMatchObject({
             statusCode: 429,
         });
         await expect(registry.run("gitlab", isolatedUrl, async () => "isolated")).resolves.toBe(

--- a/tests/unit/services/commitChecks/service.test.ts
+++ b/tests/unit/services/commitChecks/service.test.ts
@@ -212,10 +212,15 @@ describe("CommitChecksService", () => {
         const service = new CommitChecksService({
             persistentCache: new CommitChecksPersistentCache(store),
         });
-        await service.getOrFetch(key, vi.fn(async () => snapshot("success")));
+        await service.getOrFetch(
+            key,
+            vi.fn(async () => snapshot("success")),
+        );
 
         const l1ForcedFetch = vi.fn(async () => snapshot("failure"));
-        await expect(service.getOrFetch(key, l1ForcedFetch, { force: true })).resolves.toMatchObject({
+        await expect(
+            service.getOrFetch(key, l1ForcedFetch, { force: true }),
+        ).resolves.toMatchObject({
             state: "failure",
         });
         expect(l1ForcedFetch).toHaveBeenCalledTimes(1);
@@ -224,7 +229,9 @@ describe("CommitChecksService", () => {
             persistentCache: new CommitChecksPersistentCache(store),
         });
         const l2ForcedFetch = vi.fn(async () => snapshot("unknown"));
-        await expect(coldService.getOrFetch(key, l2ForcedFetch, { force: true })).resolves.toMatchObject({
+        await expect(
+            coldService.getOrFetch(key, l2ForcedFetch, { force: true }),
+        ).resolves.toMatchObject({
             state: "unknown",
         });
         expect(l2ForcedFetch).toHaveBeenCalledTimes(1);
@@ -233,7 +240,10 @@ describe("CommitChecksService", () => {
     it("shares one in-flight fetch between forced requests", async () => {
         const service = new CommitChecksService();
         const key = "github:repo@abc1234:-";
-        await service.getOrFetch(key, vi.fn(async () => snapshot("success")));
+        await service.getOrFetch(
+            key,
+            vi.fn(async () => snapshot("success")),
+        );
         let resolveFetch!: (value: CommitChecksSnapshot) => void;
         const forcedFetch = vi.fn(
             () =>

--- a/tests/unit/services/diffService.test.ts
+++ b/tests/unit/services/diffService.test.ts
@@ -122,8 +122,22 @@ function makeGitOps(): GitOps {
     return {
         getFileContentAtRef: vi.fn(async (filePath: string, ref: string) => `${ref}:${filePath}`),
         getBranches: vi.fn(async () => [
-            { name: "main", hash: "aaa1111", isRemote: false, isCurrent: true, ahead: 0, behind: 0 },
-            { name: "feature", hash: "bbb2222", isRemote: false, isCurrent: false, ahead: 0, behind: 0 },
+            {
+                name: "main",
+                hash: "aaa1111",
+                isRemote: false,
+                isCurrent: true,
+                ahead: 0,
+                behind: 0,
+            },
+            {
+                name: "feature",
+                hash: "bbb2222",
+                isRemote: false,
+                isCurrent: false,
+                ahead: 0,
+                behind: 0,
+            },
         ]),
         getFileHistoryEntries: vi.fn(async () => []),
     } as unknown as GitOps;
@@ -244,7 +258,11 @@ describe("diffService", () => {
             executor,
             ["11111111", "22222222"],
         );
-        expect(gitOps.getFileContentAtRef).toHaveBeenNthCalledWith(1, "src/a.ts", `${commitHash}^2`);
+        expect(gitOps.getFileContentAtRef).toHaveBeenNthCalledWith(
+            1,
+            "src/a.ts",
+            `${commitHash}^2`,
+        );
         expect(gitOps.getFileContentAtRef).toHaveBeenNthCalledWith(2, "src/a.ts", commitHash);
     });
 
@@ -270,8 +288,8 @@ describe("diffService", () => {
 
     it("compares an editor file with a manually entered revision", async () => {
         const gitOps = makeGitOps();
-        mocks.showQuickPick.mockImplementationOnce(async (items: Array<{ refName: string }>) =>
-            items[items.length - 1],
+        mocks.showQuickPick.mockImplementationOnce(
+            async (items: Array<{ refName: string }>) => items[items.length - 1],
         );
         mocks.showInputBox.mockResolvedValueOnce("HEAD~1");
 
@@ -374,7 +392,9 @@ describe("diffService", () => {
 
     it("cleans readonly diff documents when matching virtual documents close", () => {
         const context = { subscriptions: [] as Array<{ dispose(): void }> };
-        let closeListener: ((document: { uri: { scheme: string; toString(): string } }) => void) | undefined;
+        let closeListener:
+            | ((document: { uri: { scheme: string; toString(): string } }) => void)
+            | undefined;
         mocks.onDidCloseTextDocument.mockImplementationOnce((listener) => {
             closeListener = listener as typeof closeListener;
             return { dispose: vi.fn() };
@@ -391,7 +411,10 @@ describe("diffService", () => {
             "/repo",
             gitOps,
         ).then(() => {
-            const leftUri = mocks.executeCommand.mock.calls[0][1] as { scheme: string; toString(): string };
+            const leftUri = mocks.executeCommand.mock.calls[0][1] as {
+                scheme: string;
+                toString(): string;
+            };
             expect(provider.provideTextDocumentContent(leftUri)).toBe("abcdef1234567890:src/a.ts");
 
             closeListener?.({ uri: { scheme: "file", toString: () => leftUri.toString() } });
@@ -444,7 +467,11 @@ describe("diffService", () => {
             "Compare with Branch is only available for local files.",
         );
 
-        await compareEditorFileWithBranch(mocks.FakeUri.file("/elsewhere/src/a.ts"), "/repo", gitOps);
+        await compareEditorFileWithBranch(
+            mocks.FakeUri.file("/elsewhere/src/a.ts"),
+            "/repo",
+            gitOps,
+        );
         expect(mocks.showErrorMessage).toHaveBeenCalledWith(
             "Selected file is outside the current IntelliGit repository workspace.",
         );
@@ -453,7 +480,9 @@ describe("diffService", () => {
         await compareEditorFileWithBranch(mocks.FakeUri.file("/repo/src/a.ts"), "/repo", gitOps);
         expect(gitOps.getFileContentAtRef).not.toHaveBeenCalled();
 
-        (gitOps.getBranches as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("branches failed"));
+        (gitOps.getBranches as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+            new Error("branches failed"),
+        );
         await compareEditorFileWithBranch(mocks.FakeUri.file("/repo/src/a.ts"), "/repo", gitOps);
         expect(mocks.showErrorMessage).toHaveBeenCalledWith(
             "Compare with branch failed: branches failed",
@@ -468,7 +497,11 @@ describe("diffService", () => {
             "Compare with Revision is only available for local files.",
         );
 
-        await compareEditorFileWithRevision(mocks.FakeUri.file("/elsewhere/src/a.ts"), "/repo", gitOps);
+        await compareEditorFileWithRevision(
+            mocks.FakeUri.file("/elsewhere/src/a.ts"),
+            "/repo",
+            gitOps,
+        );
         expect(mocks.showErrorMessage).toHaveBeenCalledWith(
             "Selected file is outside the current IntelliGit repository workspace.",
         );
@@ -482,12 +515,14 @@ describe("diffService", () => {
                 date: "2026-06-04",
             },
         ]);
-        mocks.showQuickPick.mockImplementationOnce(async (items: Array<{ refName: string }>) => items[0]);
+        mocks.showQuickPick.mockImplementationOnce(
+            async (items: Array<{ refName: string }>) => items[0],
+        );
         await compareEditorFileWithRevision(mocks.FakeUri.file("/repo/src/a.ts"), "/repo", gitOps);
         expect(gitOps.getFileContentAtRef).toHaveBeenCalledWith("src/a.ts", "abcdef1234567890");
 
-        mocks.showQuickPick.mockImplementationOnce(async (items: Array<{ refName: string }>) =>
-            items[items.length - 1],
+        mocks.showQuickPick.mockImplementationOnce(
+            async (items: Array<{ refName: string }>) => items[items.length - 1],
         );
         mocks.showInputBox.mockResolvedValueOnce("   ");
         await compareEditorFileWithRevision(mocks.FakeUri.file("/repo/src/a.ts"), "/repo", gitOps);

--- a/tests/unit/services/worktreeService.test.ts
+++ b/tests/unit/services/worktreeService.test.ts
@@ -56,7 +56,9 @@ function porcelainRecords(records: Array<{ path: string; branch: string }>): str
     return records
         .flatMap((record, index) => [
             `worktree ${record.path}`,
-            `HEAD ${String(index + 1).repeat(40).slice(0, 40)}`,
+            `HEAD ${String(index + 1)
+                .repeat(40)
+                .slice(0, 40)}`,
             `branch refs/heads/${record.branch}`,
             "",
         ])
@@ -194,12 +196,7 @@ describe("WorktreeService", () => {
             },
         });
 
-        expect(executor.run).toHaveBeenNthCalledWith(1, [
-            "worktree",
-            "list",
-            "--porcelain",
-            "-z",
-        ]);
+        expect(executor.run).toHaveBeenNthCalledWith(1, ["worktree", "list", "--porcelain", "-z"]);
         expect(executor.run).toHaveBeenNthCalledWith(2, [
             "worktree",
             "add",
@@ -213,12 +210,7 @@ describe("WorktreeService", () => {
             "--set-upstream-to=origin/feature/x",
             "feature/x",
         ]);
-        expect(executor.run).toHaveBeenNthCalledWith(4, [
-            "worktree",
-            "list",
-            "--porcelain",
-            "-z",
-        ]);
+        expect(executor.run).toHaveBeenNthCalledWith(4, ["worktree", "list", "--porcelain", "-z"]);
     });
 
     it("copies configured include files into a new worktree and skips missing entries", async () => {
@@ -228,20 +220,27 @@ describe("WorktreeService", () => {
         const worktreeRoot = path.join(root, "feature");
         await mkdir(path.join(sourceRoot, ".vscode"), { recursive: true });
         await writeFile(path.join(sourceRoot, ".env"), "TOKEN=1\n", "utf8");
-        await writeFile(path.join(sourceRoot, ".vscode", "settings.json"), "{\"x\":true}\n", "utf8");
+        await writeFile(path.join(sourceRoot, ".vscode", "settings.json"), '{"x":true}\n', "utf8");
         includeFiles.value = [".env", ".vscode/settings.json", "missing.local"];
         const executor = createExecutor([porcelain("main"), porcelain("feature/x")]);
         const service = new WorktreeService(executor, () => sourceRoot);
 
         await service.createWorktree({
             path: worktreeRoot,
-            branch: { name: "feature/x", hash: "b2", isRemote: false, isCurrent: false, ahead: 0, behind: 0 },
+            branch: {
+                name: "feature/x",
+                hash: "b2",
+                isRemote: false,
+                isCurrent: false,
+                ahead: 0,
+                behind: 0,
+            },
         });
 
         await expect(readFile(path.join(worktreeRoot, ".env"), "utf8")).resolves.toBe("TOKEN=1\n");
         await expect(
             readFile(path.join(worktreeRoot, ".vscode", "settings.json"), "utf8"),
-        ).resolves.toBe("{\"x\":true}\n");
+        ).resolves.toBe('{"x":true}\n');
     });
 
     it("rejects unsafe include-file paths before adding a worktree", async () => {
@@ -276,9 +275,12 @@ describe("WorktreeService", () => {
                 { path: "/repo", branch: "main" },
                 { path: "/worktrees/feature", branch: "feature/x" },
             ]),
-            ["worktree /repo", "HEAD 1111111111111111111111111111111111111111", "detached", ""].join(
-                "\0",
-            ),
+            [
+                "worktree /repo",
+                "HEAD 1111111111111111111111111111111111111111",
+                "detached",
+                "",
+            ].join("\0"),
             porcelainRecords([
                 { path: "/repo", branch: "main" },
                 { path: "/worktrees/current", branch: "feature/current" },
@@ -313,11 +315,7 @@ describe("WorktreeService", () => {
         expect(scoped.runs).toHaveLength(1);
         expect(scoped.runs[0]).toMatchObject({ repoRoot: "/worktrees/feature" });
         expect(scoped.runs[0]?.run).toHaveBeenCalledWith(["status", "--porcelain"]);
-        expect(executor.run).toHaveBeenCalledWith([
-            "worktree",
-            "remove",
-            "/worktrees/feature",
-        ]);
+        expect(executor.run).toHaveBeenCalledWith(["worktree", "remove", "/worktrees/feature"]);
         expect(executor.run).not.toHaveBeenCalledWith(expect.arrayContaining(["branch"]));
     });
 

--- a/tests/unit/shelf/importValidation.test.ts
+++ b/tests/unit/shelf/importValidation.test.ts
@@ -15,7 +15,9 @@ const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        temporaryDirectories
+            .splice(0)
+            .map((directory) => rm(directory, { recursive: true, force: true })),
     );
 });
 
@@ -65,7 +67,9 @@ describe("shelf import validation", () => {
         const patch = textPatch("src/file.txt");
 
         await expect(
-            validateImportedPatchStream([patch.subarray(0, 13), patch.subarray(13)], { stripLevel: 1 }),
+            validateImportedPatchStream([patch.subarray(0, 13), patch.subarray(13)], {
+                stripLevel: 1,
+            }),
         ).resolves.toMatchObject({
             files: [
                 {
@@ -117,15 +121,30 @@ describe("shelf import validation", () => {
             "a/\\\\server/share.txt",
             "/absolute.txt",
         ]) {
-            expect(() => normalizeImportedPatchPath(value, 0)).toThrow(
-                ShelfImportValidationError,
-            );
+            expect(() => normalizeImportedPatchPath(value, 0)).toThrow(ShelfImportValidationError);
         }
-        for (const value of ["../outside.txt", ".GIT/config", "x:stream", "COM1.txt", "C:/drive.txt", "\\\\host\\share\\x"]) {
+        for (const value of [
+            "../outside.txt",
+            ".GIT/config",
+            "x:stream",
+            "COM1.txt",
+            "C:/drive.txt",
+            "\\\\host\\share\\x",
+        ]) {
             expect(() => validateShelfManifestPath(value)).toThrow(ShelfImportValidationError);
         }
-        for (const file of ["../outside.txt", ".git/hooks/pre-commit", ".GiT/config", "x:stream", "CON", "C:/drive.txt", "\\\\host\\share.txt"]) {
-            expect(() => validateImportedPatch(textPatch(file))).toThrow(ShelfImportValidationError);
+        for (const file of [
+            "../outside.txt",
+            ".git/hooks/pre-commit",
+            ".GiT/config",
+            "x:stream",
+            "CON",
+            "C:/drive.txt",
+            "\\\\host\\share.txt",
+        ]) {
+            expect(() => validateImportedPatch(textPatch(file))).toThrow(
+                ShelfImportValidationError,
+            );
         }
         expect(() =>
             validateImportedPatch(
@@ -169,7 +188,7 @@ describe("shelf import validation", () => {
                         "",
                     ].join("\n"),
                 ),
-        ).files[0]?.declaredResultBytes,
+            ).files[0]?.declaredResultBytes,
         ).toBe(1);
         expect(
             validateImportedPatch(
@@ -241,21 +260,24 @@ describe("shelf import validation", () => {
                 { limits: { maxDeclaredResultBytes: 8 } },
             ),
         ).toThrow(ShelfImportValidationError);
-        expect(() => validateImportedPatch(twoHunkPatch(), { limits: { maxHunksPerFile: 1 } })).toThrow(
-            ShelfImportValidationError,
-        );
-        expect(() => validateImportedPatch(textPatch(), { limits: { maxLinesPerFile: 1 } })).toThrow(
-            ShelfImportValidationError,
-        );
+        expect(() =>
+            validateImportedPatch(twoHunkPatch(), { limits: { maxHunksPerFile: 1 } }),
+        ).toThrow(ShelfImportValidationError);
+        expect(() =>
+            validateImportedPatch(textPatch(), { limits: { maxLinesPerFile: 1 } }),
+        ).toThrow(ShelfImportValidationError);
         expect(() =>
             validateImportedPatch(textPatch("file.txt", "long decoded output"), {
                 limits: { maxDecodedBytesPerFile: 4 },
             }),
         ).toThrow(ShelfImportValidationError);
         expect(() =>
-            validateImportedPatch(Buffer.concat([textPatch("one.txt", "a"), textPatch("two.txt", "b")]), {
-                limits: { maxDecodedBytesTotal: 3 },
-            }),
+            validateImportedPatch(
+                Buffer.concat([textPatch("one.txt", "a"), textPatch("two.txt", "b")]),
+                {
+                    limits: { maxDecodedBytesTotal: 3 },
+                },
+            ),
         ).toThrow(ShelfImportValidationError);
     });
 

--- a/tests/unit/shelf/patchRoundTrip.test.ts
+++ b/tests/unit/shelf/patchRoundTrip.test.ts
@@ -16,7 +16,9 @@ const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+    );
 });
 
 async function git(directory: string, args: string[]): Promise<void> {
@@ -74,12 +76,14 @@ async function assertRoundTrip(
         worktreePatchPath: repository.worktreePatch,
     });
 
-    await expect(gitBuffer(repository.verify, ["diff", "--cached", ...PATCH_GENERATION_FLAGS])).resolves.toEqual(
+    await expect(
+        gitBuffer(repository.verify, ["diff", "--cached", ...PATCH_GENERATION_FLAGS]),
+    ).resolves.toEqual(
         await gitBuffer(repository.source, ["diff", "--cached", ...PATCH_GENERATION_FLAGS]),
     );
-    await expect(gitBuffer(repository.verify, ["diff", ...PATCH_GENERATION_FLAGS])).resolves.toEqual(
-        await gitBuffer(repository.source, ["diff", ...PATCH_GENERATION_FLAGS]),
-    );
+    await expect(
+        gitBuffer(repository.verify, ["diff", ...PATCH_GENERATION_FLAGS]),
+    ).resolves.toEqual(await gitBuffer(repository.source, ["diff", ...PATCH_GENERATION_FLAGS]));
 }
 
 describe("layer patch materialization", () => {
@@ -126,25 +130,22 @@ describe("layer patch materialization", () => {
         await assertRoundTrip(repository);
     });
 
-    it.each(["add-delete", "delete-recreate"])(
-        "round-trips %s cancellation",
-        async (kind) => {
-            const repository = await createRepository(
-                kind === "add-delete" ? { ".gitkeep": "" } : { "tracked.txt": "base\n" },
-            );
-            if (kind === "add-delete") {
-                await writeFile(path.join(repository.source, "new.txt"), "index\n");
-                await git(repository.source, ["add", "new.txt"]);
-                await unlink(path.join(repository.source, "new.txt"));
-            } else {
-                await unlink(path.join(repository.source, "tracked.txt"));
-                await git(repository.source, ["add", "tracked.txt"]);
-                await writeFile(path.join(repository.source, "tracked.txt"), "recreated\n");
-            }
+    it.each(["add-delete", "delete-recreate"])("round-trips %s cancellation", async (kind) => {
+        const repository = await createRepository(
+            kind === "add-delete" ? { ".gitkeep": "" } : { "tracked.txt": "base\n" },
+        );
+        if (kind === "add-delete") {
+            await writeFile(path.join(repository.source, "new.txt"), "index\n");
+            await git(repository.source, ["add", "new.txt"]);
+            await unlink(path.join(repository.source, "new.txt"));
+        } else {
+            await unlink(path.join(repository.source, "tracked.txt"));
+            await git(repository.source, ["add", "tracked.txt"]);
+            await writeFile(path.join(repository.source, "tracked.txt"), "recreated\n");
+        }
 
-            await assertRoundTrip(repository);
-        },
-    );
+        await assertRoundTrip(repository);
+    });
 
     it("round-trips binary and empty-file layers byte-for-byte", async () => {
         const repository = await createRepository({
@@ -162,7 +163,6 @@ describe("layer patch materialization", () => {
             await readFile(path.join(repository.source, "binary.bin")),
         );
     });
-
 
     it("captures and applies an untracked binary file through a no-index patch", async () => {
         const repository = await createRepository({ ".gitkeep": "" });

--- a/tests/unit/shelf/recovery.test.ts
+++ b/tests/unit/shelf/recovery.test.ts
@@ -189,16 +189,19 @@ describe("ShelfReverter", () => {
         await expect(
             reverter.revert({
                 transactionId: "symlink-parent",
-                files: [{ relativePath: "escape/new/nested.txt", baseBytes: Buffer.from("base\n") }],
+                files: [
+                    { relativePath: "escape/new/nested.txt", baseBytes: Buffer.from("base\n") },
+                ],
             }),
         ).rejects.toThrow("escaped");
 
         expect(moved).toBe(false);
-        await expect(readFile(path.join(outside, "new", "nested.txt"), "utf8")).rejects.toMatchObject({
+        await expect(
+            readFile(path.join(outside, "new", "nested.txt"), "utf8"),
+        ).rejects.toMatchObject({
             code: "ENOENT",
         });
     });
-
 
     it("continues rollback after one per-path restoration failure and retains that path", async () => {
         let root = "";
@@ -318,7 +321,6 @@ describe("ShelfReverter", () => {
         expect(error).toBeInstanceOf(ShelfRollbackRetainedError);
         expect(await readFile(path.join(repositoryRoot, "tracked.txt"), "utf8")).toBe("base\n");
     });
-
 
     it("pins a normal base OID and uses the empty tree for an unborn repository", async () => {
         const normal = await createReverter();

--- a/tests/unit/shelf/recoveryRollback.test.ts
+++ b/tests/unit/shelf/recoveryRollback.test.ts
@@ -1,6 +1,15 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
+import {
+    mkdir,
+    mkdtemp,
+    readFile,
+    readdir,
+    rename,
+    rm,
+    symlink,
+    writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -78,7 +87,11 @@ describe("ShelfReverter per-path rollback index guards", () => {
         const { repositoryRoot, gitOps, reverter } = await createReverter();
         const outside = await mkdtemp(path.join(tmpdir(), "intelligit-shelf-recovery-outside-"));
         directories.push(outside);
-        const recoveryRoot = path.join((await gitOps.getGitDirectories()).gitDir, "intelligit", "recovery");
+        const recoveryRoot = path.join(
+            (await gitOps.getGitDirectories()).gitDir,
+            "intelligit",
+            "recovery",
+        );
         await mkdir(path.dirname(recoveryRoot), { recursive: true });
         await symlink(outside, recoveryRoot);
 
@@ -119,10 +132,16 @@ describe("ShelfReverter per-path rollback index guards", () => {
             },
         });
 
-        expect(await reverter.resumePending()).toEqual({ rolledBackIds: [], retainedIds: [transactionId] });
+        expect(await reverter.resumePending()).toEqual({
+            rolledBackIds: [],
+            retainedIds: [transactionId],
+        });
         expect(await readFile(target, "utf8")).toBe("change\n");
         expect(await readdir(outside)).toEqual([]);
-        expect((await store.readJournals())[0]).toMatchObject({ id: transactionId, state: "ghost" });
+        expect((await store.readJournals())[0]).toMatchObject({
+            id: transactionId,
+            state: "ghost",
+        });
     });
 
     it("resumes a planned-only pending path as an idempotent no-op", async () => {
@@ -151,7 +170,10 @@ describe("ShelfReverter per-path rollback index guards", () => {
             },
         });
 
-        expect(await reverter.resumePending()).toEqual({ rolledBackIds: [transactionId], retainedIds: [] });
+        expect(await reverter.resumePending()).toEqual({
+            rolledBackIds: [transactionId],
+            retainedIds: [],
+        });
         expect(await reverter.resumePending()).toEqual({ rolledBackIds: [], retainedIds: [] });
         expect(await readFile(target, "utf8")).toBe("change\n");
         expect(await store.readJournals()).toEqual([]);
@@ -193,7 +215,10 @@ describe("ShelfReverter per-path rollback index guards", () => {
         await mkdir(path.dirname(recoveryPath), { recursive: true });
         await rename(target, recoveryPath);
 
-        expect(await reverter.resumePending()).toEqual({ rolledBackIds: [transactionId], retainedIds: [] });
+        expect(await reverter.resumePending()).toEqual({
+            rolledBackIds: [transactionId],
+            retainedIds: [],
+        });
         expect(await readFile(target, "utf8")).toBe("change\n");
         await expect(readFile(recoveryPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
         expect(await reverter.resumePending()).toEqual({ rolledBackIds: [], retainedIds: [] });
@@ -236,10 +261,16 @@ describe("ShelfReverter per-path rollback index guards", () => {
         await rename(target, recoveryPath);
         await writeFile(target, "third party\n");
 
-        expect(await reverter.resumePending()).toEqual({ rolledBackIds: [], retainedIds: [transactionId] });
+        expect(await reverter.resumePending()).toEqual({
+            rolledBackIds: [],
+            retainedIds: [transactionId],
+        });
         expect(await readFile(target, "utf8")).toBe("third party\n");
         expect(await readFile(recoveryPath, "utf8")).toBe("change\n");
-        expect((await store.readJournals())[0]).toMatchObject({ id: transactionId, state: "ghost" });
+        expect((await store.readJournals())[0]).toMatchObject({
+            id: transactionId,
+            state: "ghost",
+        });
     });
 
     it("retains an impossible planned no-original recovery copy", async () => {
@@ -272,9 +303,15 @@ describe("ShelfReverter per-path rollback index guards", () => {
         await mkdir(path.dirname(recoveryPath), { recursive: true });
         await writeFile(recoveryPath, "unexpected recovery copy\n");
 
-        expect(await reverter.resumePending()).toEqual({ rolledBackIds: [], retainedIds: [transactionId] });
+        expect(await reverter.resumePending()).toEqual({
+            rolledBackIds: [],
+            retainedIds: [transactionId],
+        });
         expect(await readFile(recoveryPath, "utf8")).toBe("unexpected recovery copy\n");
-        expect((await store.readJournals())[0]).toMatchObject({ id: transactionId, state: "ghost" });
+        expect((await store.readJournals())[0]).toMatchObject({
+            id: transactionId,
+            state: "ghost",
+        });
     });
 
     it("restores transaction paths without overwriting an unrelated third-party index entry", async () => {

--- a/tests/unit/shelf/store.test.ts
+++ b/tests/unit/shelf/store.test.ts
@@ -120,7 +120,11 @@ describe("ShelfStore", () => {
         await mkdir(path.dirname(shelf), { recursive: true });
         await symlink(generationOutside, shelf);
         await expect(
-            generation.store.writeGeneration("shelf-one", { schemaVersion: 1, objectHashes: [], files: [] }),
+            generation.store.writeGeneration("shelf-one", {
+                schemaVersion: 1,
+                objectHashes: [],
+                files: [],
+            }),
         ).rejects.toBeInstanceOf(ShelfPathError);
 
         const journal = await makeStore();
@@ -128,13 +132,20 @@ describe("ShelfStore", () => {
         directories.push(journalOutside);
         await symlink(journalOutside, path.join(journal.paths.root, "journals"));
         await expect(
-            journal.store.writeJournal({ id: "tx", state: "shelvePendingRevert", pathProgress: {} }),
+            journal.store.writeJournal({
+                id: "tx",
+                state: "shelvePendingRevert",
+                pathProgress: {},
+            }),
         ).rejects.toBeInstanceOf(ShelfPathError);
 
         const catalog = await makeStore();
         const catalogOutside = await mkdtemp(path.join(tmpdir(), "intelligit-shelf-outside-"));
         directories.push(catalogOutside);
-        await symlink(path.join(catalogOutside, "catalog.json"), path.join(catalog.paths.root, "catalog.json"));
+        await symlink(
+            path.join(catalogOutside, "catalog.json"),
+            path.join(catalog.paths.root, "catalog.json"),
+        );
         await expect(
             catalog.store.runIdempotent(
                 { token: "catalog", operation: "create", payload: Buffer.from("payload") },
@@ -154,13 +165,17 @@ describe("ShelfStore", () => {
         const objects = path.join(garbage.paths.root, "shelves", "shelf-one", "objects");
         await rm(objects, { recursive: true, force: true });
         await symlink(garbageOutside, objects);
-        await expect(garbage.store.collectGarbage("shelf-one")).rejects.toBeInstanceOf(ShelfPathError);
+        await expect(garbage.store.collectGarbage("shelf-one")).rejects.toBeInstanceOf(
+            ShelfPathError,
+        );
 
-        await expect(Promise.all([readdir(generationOutside), readdir(journalOutside), readdir(garbageOutside)])).resolves.toEqual([
-            [],
-            [],
-            [],
-        ]);
+        await expect(
+            Promise.all([
+                readdir(generationOutside),
+                readdir(journalOutside),
+                readdir(garbageOutside),
+            ]),
+        ).resolves.toEqual([[], [], []]);
     });
 
     it("keeps the previous current pointer if a later pointer replacement faults", async () => {
@@ -190,7 +205,11 @@ describe("ShelfStore", () => {
 
     it("never overwrites an orphaned immutable generation after a pointer crash", async () => {
         const { paths, store } = await makeStore();
-        await store.writeGeneration("shelf-one", { schemaVersion: 1, objectHashes: [], files: ["first"] });
+        await store.writeGeneration("shelf-one", {
+            schemaVersion: 1,
+            objectHashes: [],
+            files: ["first"],
+        });
         const failing = new ShelfStore(paths, {
             beforeCurrentPointerRename: async () => {
                 throw new Error("simulated pointer crash");
@@ -215,9 +234,9 @@ describe("ShelfStore", () => {
         });
 
         expect(retry.generation).toBe(3);
-        expect(await readFile(path.join(paths.root, "shelves", "shelf-one", "gen-2", "manifest.json"))).toEqual(
-            orphaned,
-        );
+        expect(
+            await readFile(path.join(paths.root, "shelves", "shelf-one", "gen-2", "manifest.json")),
+        ).toEqual(orphaned);
         expect((await store.readCurrentManifest("shelf-one")).files).toEqual(["retry"]);
     });
 
@@ -242,7 +261,9 @@ describe("ShelfStore", () => {
         await expect(
             store.writeGeneration("shelf-one", { schemaVersion: 1, objectHashes: [], files: [] }),
         ).rejects.toMatchObject({ code: "ENOENT" });
-        await expect(readFile(path.join(shelfDirectory, "gen-2", "manifest.json"))).rejects.toMatchObject({
+        await expect(
+            readFile(path.join(shelfDirectory, "gen-2", "manifest.json")),
+        ).rejects.toMatchObject({
             code: "ENOENT",
         });
     });
@@ -320,10 +341,12 @@ describe("ShelfStore", () => {
             // surface only as the runner's own timeout, which names nothing and takes 30s to
             // say it. This resolves the failing case to a value the assertion can quote.
             const outcome = await Promise.race([
-                second.withLock(async () => undefined).then(
-                    () => "acquired",
-                    (error: Error) => error.message,
-                ),
+                second
+                    .withLock(async () => undefined)
+                    .then(
+                        () => "acquired",
+                        (error: Error) => error.message,
+                    ),
                 new Promise<string>((resolve) => setTimeout(() => resolve("still-waiting"), 1_000)),
             ]);
             expect(
@@ -446,7 +469,13 @@ describe("ShelfStore", () => {
         const { paths, store } = await makeStore();
         const input = persistedShelfInput();
         await store.writeShelfGeneration("shelf-one", input);
-        const manifestPath = path.join(paths.root, "shelves", "shelf-one", "gen-1", "manifest.json");
+        const manifestPath = path.join(
+            paths.root,
+            "shelves",
+            "shelf-one",
+            "gen-1",
+            "manifest.json",
+        );
         const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
             metadata: { name: string; baseCommit: string; lifecycle: string };
             files: Array<{ indexBlock: { path: string } }>;
@@ -460,7 +489,11 @@ describe("ShelfStore", () => {
             ShelfStoreCorruptionError,
         );
 
-        for (const [shelfId, unsafePath] of [["shelf-two", "../escape"], ["shelf-three", "tracked.txt:stream"], ["shelf-four", "aux.txt"]]) {
+        for (const [shelfId, unsafePath] of [
+            ["shelf-two", "../escape"],
+            ["shelf-three", "tracked.txt:stream"],
+            ["shelf-four", "aux.txt"],
+        ]) {
             await store.writeShelfGeneration(shelfId, input);
             const shelfPath = path.join(paths.root, "shelves", shelfId, "gen-1", "manifest.json");
             const shelfManifest = JSON.parse(await readFile(shelfPath, "utf8")) as {
@@ -470,7 +503,9 @@ describe("ShelfStore", () => {
             shelfManifest.files[0].indexBlock.path = unsafePath;
             resealManifest(shelfManifest);
             await writeFile(shelfPath, JSON.stringify(shelfManifest));
-            await expect(store.readCurrentShelfManifest(shelfId)).rejects.toBeInstanceOf(ShelfStoreCorruptionError);
+            await expect(store.readCurrentShelfManifest(shelfId)).rejects.toBeInstanceOf(
+                ShelfStoreCorruptionError,
+            );
         }
     });
 
@@ -490,12 +525,9 @@ describe("ShelfStore", () => {
             ),
         ).rejects.toBeInstanceOf(ShelfStaleShelfError);
         await expect(
-            store.withGenerationCas(
-                { expectedCatalogGeneration: 0 },
-                async () => {
-                    mutations += 1;
-                },
-            ),
+            store.withGenerationCas({ expectedCatalogGeneration: 0 }, async () => {
+                mutations += 1;
+            }),
         ).rejects.toBeInstanceOf(ShelfStaleCatalogError);
 
         expect(mutations).toBe(0);
@@ -576,8 +608,14 @@ describe("ShelfStore", () => {
 
         await store.deleteShelf("shelf-one");
 
-        await expect(store.listShelves()).resolves.toEqual({ shelfIds: [], corruptShelfIds: [], catalogGeneration: 2 });
-        await expect(store.readCurrentShelfManifest("shelf-one")).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(store.listShelves()).resolves.toEqual({
+            shelfIds: [],
+            corruptShelfIds: [],
+            catalogGeneration: 2,
+        });
+        await expect(store.readCurrentShelfManifest("shelf-one")).rejects.toMatchObject({
+            code: "ENOENT",
+        });
         await expect(store.readJournals()).resolves.toEqual([
             {
                 id: "recovery-one",

--- a/tests/unit/views/CommitInfoViewProvider.test.ts
+++ b/tests/unit/views/CommitInfoViewProvider.test.ts
@@ -239,45 +239,42 @@ describe("CommitInfoViewProvider redundant setCommitDetail post", () => {
      * ordering. Selecting a different commit mid-window separates them: the correct ordering
      * sends `X` then `Y`; the broken one sends `X`, `Y`, `Y`.
      */
-    it(
-        "does not re-post a detail that arrived while the ready handler was still awaiting",
-        async () => {
-            const provider = new CommitInfoViewProvider(createFakeExtensionUri());
-            const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
+    it("does not re-post a detail that arrived while the ready handler was still awaiting", async () => {
+        const provider = new CommitInfoViewProvider(createFakeExtensionUri());
+        const { webviewView, posted, receiveMessage } = createInspectableFakeWebviewView();
 
-            provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
-            await receiveMessage({ type: "ready" });
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        await receiveMessage({ type: "ready" });
 
-            provider.setCommitDetail(sampleDetail());
+        provider.setCommitDetail(sampleDetail());
+        await flushMicrotasks();
+        expect(setDetailMessages(posted)).toHaveLength(1);
+
+        // The reload's `ready`. `initIconThemeData` is where that handler yields, so driving
+        // the selection from inside it puts the post exactly in the window under test.
+        //
+        // The guard is load-bearing, not defensive: `setCommitDetail` starts
+        // `decorateAndStoreDetail`, which awaits this very method again. Without it the
+        // stand-in re-enters itself and the test dies of heap exhaustion rather than
+        // reporting on the ordering.
+        const iconTheme = (provider as unknown as { iconTheme: IconThemeService }).iconTheme;
+        let selectedMidWindow = false;
+        vi.spyOn(iconTheme, "initIconThemeData").mockImplementation(async () => {
+            if (selectedMidWindow) return;
+            selectedMidWindow = true;
+            provider.setCommitDetail(otherDetail());
             await flushMicrotasks();
-            expect(setDetailMessages(posted)).toHaveLength(1);
+        });
 
-            // The reload's `ready`. `initIconThemeData` is where that handler yields, so driving
-            // the selection from inside it puts the post exactly in the window under test.
-            //
-            // The guard is load-bearing, not defensive: `setCommitDetail` starts
-            // `decorateAndStoreDetail`, which awaits this very method again. Without it the
-            // stand-in re-enters itself and the test dies of heap exhaustion rather than
-            // reporting on the ordering.
-            const iconTheme = (provider as unknown as { iconTheme: IconThemeService }).iconTheme;
-            let selectedMidWindow = false;
-            vi.spyOn(iconTheme, "initIconThemeData").mockImplementation(async () => {
-                if (selectedMidWindow) return;
-                selectedMidWindow = true;
-                provider.setCommitDetail(otherDetail());
-                await flushMicrotasks();
-            });
+        await receiveMessage({ type: "ready" });
+        await flushMicrotasks();
 
-            await receiveMessage({ type: "ready" });
-            await flushMicrotasks();
-
-            const messages = setDetailMessages(posted);
-            expect(
-                messages.map((message) => (message.detail as CommitDetail).shortHash),
-                "the second commit must reach the webview exactly once: the reset belongs before " +
-                    "the await, so the mid-window post is the one recorded and the handler's " +
-                    "closing post is suppressed as the duplicate it is",
-            ).toEqual(["b08ddf03", "70fa5286"]);
-        },
-    );
+        const messages = setDetailMessages(posted);
+        expect(
+            messages.map((message) => (message.detail as CommitDetail).shortHash),
+            "the second commit must reach the webview exactly once: the reset belongs before " +
+                "the await, so the mid-window post is the one recorded and the handler's " +
+                "closing post is suppressed as the duplicate it is",
+        ).toEqual(["b08ddf03", "70fa5286"]);
+    });
 });

--- a/tests/unit/views/commitPanelActions.commitAccuracy.test.ts
+++ b/tests/unit/views/commitPanelActions.commitAccuracy.test.ts
@@ -366,7 +366,9 @@ describe("commitSelectedFromPanel commit accuracy", () => {
 
         await commitSelected(repo, { message: "merge", paths: ["feature.txt"] });
 
-        expect(await git(repo, ["ls-tree", "-r", "--name-only", "HEAD"])).toContain("feature.txt\n");
+        expect(await git(repo, ["ls-tree", "-r", "--name-only", "HEAD"])).toContain(
+            "feature.txt\n",
+        );
     });
 
     it("keeps a revert-conflict commit as a bare whole-index commit", async () => {

--- a/tests/unit/views/shelfDiffActions.test.ts
+++ b/tests/unit/views/shelfDiffActions.test.ts
@@ -74,7 +74,11 @@ describe("showShelfDiffFromPanel", () => {
             "base contents",
             "Base (HEAD at shelve)",
         );
-        expect(createReadonlyDiffUri).toHaveBeenCalledWith("src/a.ts", "shelved contents", "Shelved");
+        expect(createReadonlyDiffUri).toHaveBeenCalledWith(
+            "src/a.ts",
+            "shelved contents",
+            "Shelved",
+        );
         expect(vscodeMock.workspace.openTextDocument).not.toHaveBeenCalled();
         expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith(
             "vscode.diff",
@@ -126,49 +130,52 @@ describe("showShelfDiffFromPanel", () => {
     it.each([
         ["baseToShelved", "Base (HEAD at shelve)", "Shelved"],
         ["shelvedToLocal", "Shelved", "Local"],
-    ] as const)("shows a placeholder on both sides for binary shelf entries without decoding bytes", async (
-        mode,
-        leftLabel,
-        rightLabel,
-    ) => {
-        const base = Buffer.from([0, 255]);
-        const shelved = Buffer.from([255, 0]);
-        const source = reader({
-            getShelfDiffContents: vi.fn(async () => ({
-                path: "images/logo.png",
-                binary: true,
-                base,
-                shelved,
-            })),
-        });
-        const baseToString = vi.spyOn(base, "toString");
-        const shelvedToString = vi.spyOn(shelved, "toString");
+    ] as const)(
+        "shows a placeholder on both sides for binary shelf entries without decoding bytes",
+        async (mode, leftLabel, rightLabel) => {
+            const base = Buffer.from([0, 255]);
+            const shelved = Buffer.from([255, 0]);
+            const source = reader({
+                getShelfDiffContents: vi.fn(async () => ({
+                    path: "images/logo.png",
+                    binary: true,
+                    base,
+                    shelved,
+                })),
+            });
+            const baseToString = vi.spyOn(base, "toString");
+            const shelvedToString = vi.spyOn(shelved, "toString");
 
-        await showShelfDiffFromPanel(deps(source), "shelf-1", "change-1", mode);
+            await showShelfDiffFromPanel(deps(source), "shelf-1", "change-1", mode);
 
-        expect(createReadonlyDiffUri).toHaveBeenNthCalledWith(
-            1,
-            "images/logo.png",
-            "Binary file — text diff is unavailable.",
-            leftLabel,
-        );
-        expect(createReadonlyDiffUri).toHaveBeenNthCalledWith(
-            2,
-            "images/logo.png",
-            "Binary file — text diff is unavailable.",
-            rightLabel,
-        );
-        expect(baseToString).not.toHaveBeenCalled();
-        expect(shelvedToString).not.toHaveBeenCalled();
-        expect(vscodeMock.workspace.openTextDocument).not.toHaveBeenCalled();
-    });
+            expect(createReadonlyDiffUri).toHaveBeenNthCalledWith(
+                1,
+                "images/logo.png",
+                "Binary file — text diff is unavailable.",
+                leftLabel,
+            );
+            expect(createReadonlyDiffUri).toHaveBeenNthCalledWith(
+                2,
+                "images/logo.png",
+                "Binary file — text diff is unavailable.",
+                rightLabel,
+            );
+            expect(baseToString).not.toHaveBeenCalled();
+            expect(shelvedToString).not.toHaveBeenCalled();
+            expect(vscodeMock.workspace.openTextDocument).not.toHaveBeenCalled();
+        },
+    );
 
     it("compares shelved content with the current local file using read-only documents", async () => {
         const source = reader();
 
         await showShelfDiffFromPanel(deps(source), "shelf-1", "change-1", "shelvedToLocal");
 
-        expect(createReadonlyDiffUri).toHaveBeenCalledWith("src/a.ts", "shelved contents", "Shelved");
+        expect(createReadonlyDiffUri).toHaveBeenCalledWith(
+            "src/a.ts",
+            "shelved contents",
+            "Shelved",
+        );
         expect(createReadonlyDiffUri).toHaveBeenCalledWith(
             "src/a.ts",
             "local file contents",
@@ -230,7 +237,11 @@ describe("showShelfDiffFromPanel", () => {
         const source = reader({
             getShelfFiles: vi.fn(async () => [
                 ...shelfFiles,
-                { ...shelfFiles[0], changeId: "change-2", worktreeBlock: { path: "src/b.ts", status: "M" } },
+                {
+                    ...shelfFiles[0],
+                    changeId: "change-2",
+                    worktreeBlock: { path: "src/b.ts", status: "M" },
+                },
             ]),
             getShelfDiffContents: vi.fn(async (_id, changeId) => ({
                 path: changeId === "change-1" ? "src/a.ts" : "src/b.ts",

--- a/tests/unit/visual/diffStatusChroma.test.ts
+++ b/tests/unit/visual/diffStatusChroma.test.ts
@@ -35,9 +35,21 @@ const MIN_CHROMA_RETENTION = 0.9;
 const MAX_HUE_SHIFT_DEGREES = 5;
 
 const DIFF_STATUS_TOKENS = [
-    { name: "added", expression: JETBRAINS_UI.color.added, hostVar: "--vscode-gitDecoration-addedResourceForeground" },
-    { name: "modified", expression: JETBRAINS_UI.color.modified, hostVar: "--vscode-gitDecoration-modifiedResourceForeground" },
-    { name: "deleted", expression: JETBRAINS_UI.color.deleted, hostVar: "--vscode-gitDecoration-deletedResourceForeground" },
+    {
+        name: "added",
+        expression: JETBRAINS_UI.color.added,
+        hostVar: "--vscode-gitDecoration-addedResourceForeground",
+    },
+    {
+        name: "modified",
+        expression: JETBRAINS_UI.color.modified,
+        hostVar: "--vscode-gitDecoration-modifiedResourceForeground",
+    },
+    {
+        name: "deleted",
+        expression: JETBRAINS_UI.color.deleted,
+        hostVar: "--vscode-gitDecoration-deletedResourceForeground",
+    },
 ] as const;
 
 const fixtureFiles = readdirSync(FIXTURE_DIR).filter((name) => name.endsWith(".json"));
@@ -45,7 +57,9 @@ const fixtureFiles = readdirSync(FIXTURE_DIR).filter((name) => name.endsWith(".j
 describe("diff-status colours keep the host's chroma", () => {
     it("finds the host fixtures to measure against", () => {
         // Without this the suite below would silently iterate an empty list and pass.
-        expect(fixtureFiles.length, `no *.json fixtures in ${FIXTURE_DIR}`).toBeGreaterThanOrEqual(4);
+        expect(fixtureFiles.length, `no *.json fixtures in ${FIXTURE_DIR}`).toBeGreaterThanOrEqual(
+            4,
+        );
     });
 
     for (const fixtureName of fixtureFiles) {

--- a/tests/unit/visual/hostFixtureContract.test.ts
+++ b/tests/unit/visual/hostFixtureContract.test.ts
@@ -83,9 +83,9 @@ describe("host fixture contract", () => {
         const fixtures = readHostFixtures();
         expect(fixtures.length, `no host fixtures found in ${HOST_FIXTURE_DIR}`).toBeGreaterThan(0);
 
-        expect(fixtures.map((fixture) => `${fixture.name}: ${fixture.provenance.platform}`)).toEqual(
-            fixtures.map((fixture) => `${fixture.name}: ${expectedPlatform}`),
-        );
+        expect(
+            fixtures.map((fixture) => `${fixture.name}: ${fixture.provenance.platform}`),
+        ).toEqual(fixtures.map((fixture) => `${fixture.name}: ${expectedPlatform}`));
     });
 
     it("keeps `chakra-ui-light` in the dark fixtures a recorded fact rather than a stale one", () => {

--- a/tests/unit/visual/playwright/harnessPage.contract.test.ts
+++ b/tests/unit/visual/playwright/harnessPage.contract.test.ts
@@ -47,8 +47,13 @@ describe("harness page visual environment contract", () => {
             /await page\.route\("\*\*\/\*",[\s\S]*?\);/,
         )?.[0];
         expect(routeRegistration).toBeDefined();
-        expect(routeRegistration).toContain(
-            "routeHarnessRequest(route, HARNESS_ORIGIN, DIST_DIR, () => documentHtml, networkEscapes)",
+        // Prettier reflows this call across lines whenever the argument list crosses the print
+        // width, so matching the source layout would make the formatter -- not a behaviour change
+        // -- the thing that turns this red. Collapsing whitespace and the trailing comma leaves the
+        // assertion policing what it means to police: the delegation and its exact argument list.
+        const withoutLayout = (source: string) => source.replace(/\s+/g, "").replace(/,\)/g, ")");
+        expect(withoutLayout(routeRegistration ?? "")).toContain(
+            "routeHarnessRequest(route,HARNESS_ORIGIN,DIST_DIR,()=>documentHtml,networkEscapes)",
         );
     });
 });

--- a/tests/unit/visual/playwrightVisualConfig.test.ts
+++ b/tests/unit/visual/playwrightVisualConfig.test.ts
@@ -107,8 +107,7 @@ describe("visual Playwright config", () => {
             animations: "disabled",
         });
         expect(
-            (visualConfig.expect?.toHaveScreenshot as Record<string, unknown>)
-                .snapshotPathTemplate,
+            (visualConfig.expect?.toHaveScreenshot as Record<string, unknown>).snapshotPathTemplate,
         ).toBeUndefined();
         expect(visualConfig.snapshotDir).toBe("tests/visual/__screenshots__");
         expect(visualConfig.retries).toBe(0);

--- a/tests/unit/visual/publishWorkflow.test.ts
+++ b/tests/unit/visual/publishWorkflow.test.ts
@@ -169,7 +169,11 @@ function runVersionGate(script: string, version: string, options: VersionGateOpt
             HOME: workspace,
         });
         const git = (...args: readonly string[]) => {
-            const result = spawnSync("git", args, { cwd: workspace, encoding: "utf8", env: gitEnv });
+            const result = spawnSync("git", args, {
+                cwd: workspace,
+                encoding: "utf8",
+                env: gitEnv,
+            });
             if (result.status !== 0) {
                 throw new Error(
                     `git ${args.join(" ")} failed with status ${result.status}: ${result.stderr ?? ""}`,
@@ -179,7 +183,10 @@ function runVersionGate(script: string, version: string, options: VersionGateOpt
         git("init", "--initial-branch=main");
         git("config", "user.email", "test@example.invalid");
         git("config", "user.name", "Test");
-        writeFileSync(packageJsonPath, JSON.stringify({ version: options.previousVersion ?? version }));
+        writeFileSync(
+            packageJsonPath,
+            JSON.stringify({ version: options.previousVersion ?? version }),
+        );
         git("add", "package.json");
         git("commit", "-m", "previous");
         writeFileSync(packageJsonPath, JSON.stringify({ version }));
@@ -279,11 +286,7 @@ function runTagStep(script: string, tagPlacement: "head" | "older" | "absent") {
         writeFileSync(ghArgsPath, "");
         writeFileSync(
             statePath,
-            tagPlacement === "absent"
-                ? ""
-                : tagPlacement === "head"
-                  ? RELEASE_SHA
-                  : STRANDED_SHA,
+            tagPlacement === "absent" ? "" : tagPlacement === "head" ? RELEASE_SHA : STRANDED_SHA,
         );
         writeFileSync(
             join(binDir, "gh"),
@@ -370,9 +373,10 @@ describe("publish visual workflow", () => {
         const releaseJob = extractJobBlock(readFileSync(WORKFLOW_PATH, "utf8"), "release");
         const needsLine = releaseJob.match(/^\s+needs:.*$/m)?.[0].trim() ?? "";
 
-        expect(needsLine, "release must wait for build, validation, eligibility, and attestation").toBe(
-            "needs: [build, visual, e2e-full, package-smoke, release-eligibility, attest]",
-        );
+        expect(
+            needsLine,
+            "release must wait for build, validation, eligibility, and attestation",
+        ).toBe("needs: [build, visual, e2e-full, package-smoke, release-eligibility, attest]");
     });
 
     it("never cancels an in-flight release run on main", () => {
@@ -446,9 +450,10 @@ describe("publish visual workflow", () => {
         // The block's own close, found by indentation: `extractRunScript` dedents the run body, so
         // only the top-level `fi` sits at column zero and a nested one cannot end the slice early.
         const comparisonEnd = gateScript.indexOf("fi", comparisonStart);
-        expect(comparisonEnd, "the version comparison must be a closed if/fi block").toBeGreaterThan(
-            comparisonStart,
-        );
+        expect(
+            comparisonEnd,
+            "the version comparison must be a closed if/fi block",
+        ).toBeGreaterThan(comparisonStart);
         expect(
             gateScript.slice(comparisonStart, comparisonEnd + 1).join("\n"),
             "comparing this commit's version against the previous one must not decide the release",
@@ -514,7 +519,10 @@ describe("publish visual workflow", () => {
                 "release-eligibility",
             );
             return extractRunScript(
-                extractStepBlock(eligibilityJob, "Check whether this version still needs releasing"),
+                extractStepBlock(
+                    eligibilityJob,
+                    "Check whether this version still needs releasing",
+                ),
             );
         }
 
@@ -667,7 +675,10 @@ describe("publish visual workflow", () => {
                 "release-eligibility",
             );
             const script = extractRunScript(
-                extractStepBlock(eligibilityJob, "Check whether this version still needs releasing"),
+                extractStepBlock(
+                    eligibilityJob,
+                    "Check whether this version still needs releasing",
+                ),
             );
             expect(script, "the version gate step must carry a run script").not.toBe("");
             // The previous version is left at its default, equal to this one: an unchanged version
@@ -819,9 +830,10 @@ describe("publish visual workflow", () => {
             expect(run.liveTagCommit, "the mismatched tag must be left exactly where it was").toBe(
                 run.older,
             );
-            expect(run.ghArgs, "a mismatched tag must never be force-moved onto this run").not.toContain(
-                "POST",
-            );
+            expect(
+                run.ghArgs,
+                "a mismatched tag must never be force-moved onto this run",
+            ).not.toContain("POST");
         });
 
         it("reuses a tag that already names this commit, so a re-run can still recover", () => {
@@ -836,7 +848,9 @@ describe("publish visual workflow", () => {
             // only shows up on the mismatch path, where the tag it was supposed to refuse has
             // already been overwritten.
             expect(run.liveTagCommit, "reuse must leave the live tag untouched").toBe(run.head);
-            expect(run.ghArgs, "an already-correct tag must not be rewritten").not.toContain("POST");
+            expect(run.ghArgs, "an already-correct tag must not be rewritten").not.toContain(
+                "POST",
+            );
         });
 
         it("creates the tag when none exists", () => {

--- a/tests/unit/visual/recorder/recordCommitGraphWebviewFixture.test.ts
+++ b/tests/unit/visual/recorder/recordCommitGraphWebviewFixture.test.ts
@@ -45,7 +45,11 @@ vi.mock("vscode", () => createCommitInfoVscodeDouble());
 
 import { setE2eControlChannelActive } from "../../../../src/e2e/activationState";
 import { resetE2eWebviewCaptureSinkForTests } from "../../../../src/e2e/webviewCapture";
-import { FIXTURE_REFS, seedFixtureTemplate, type FixtureTemplate } from "../../../fixtures/repo/seed";
+import {
+    FIXTURE_REFS,
+    seedFixtureTemplate,
+    type FixtureTemplate,
+} from "../../../fixtures/repo/seed";
 import {
     buildProviderOptions,
     COMMIT_GRAPH_CLEAN_SCENARIO,

--- a/tests/unit/visual/recorder/validateWebviewFixture.test.ts
+++ b/tests/unit/visual/recorder/validateWebviewFixture.test.ts
@@ -104,12 +104,15 @@ describe("parseWebviewFixture -- rejects structurally malformed fixtures", () =>
     it.each([
         ["an older", WEBVIEW_FIXTURE_SCHEMA_VERSION - 1],
         ["a newer", WEBVIEW_FIXTURE_SCHEMA_VERSION + 1],
-    ])("rejects %s schemaVersion, naming both the found and expected version", (_label, version) => {
-        const raw = { ...VALID_RAW, schemaVersion: version };
-        expect(() => parseWebviewFixture(raw)).toThrow(
-            new RegExp(`is ${version}.*schema version ${WEBVIEW_FIXTURE_SCHEMA_VERSION}`),
-        );
-    });
+    ])(
+        "rejects %s schemaVersion, naming both the found and expected version",
+        (_label, version) => {
+            const raw = { ...VALID_RAW, schemaVersion: version };
+            expect(() => parseWebviewFixture(raw)).toThrow(
+                new RegExp(`is ${version}.*schema version ${WEBVIEW_FIXTURE_SCHEMA_VERSION}`),
+            );
+        },
+    );
 
     it("accepts exactly the current schemaVersion", () => {
         const raw = { ...VALID_RAW, schemaVersion: WEBVIEW_FIXTURE_SCHEMA_VERSION };

--- a/tests/unit/visual/sectionHeaderStatContrast.test.ts
+++ b/tests/unit/visual/sectionHeaderStatContrast.test.ts
@@ -83,10 +83,9 @@ const fixtureFiles = readdirSync(FIXTURE_DIR).filter((name) => name.endsWith(".j
 describe("commit-panel section header totals stay legible", () => {
     it("finds the host fixtures to measure against", () => {
         // Without this the suite below would silently iterate an empty list and pass.
-        expect(
-            fixtureFiles.length,
-            `no *.json fixtures in ${FIXTURE_DIR}`,
-        ).toBeGreaterThanOrEqual(4);
+        expect(fixtureFiles.length, `no *.json fixtures in ${FIXTURE_DIR}`).toBeGreaterThanOrEqual(
+            4,
+        );
     });
 
     /** Every cell the loop below actually measures — known at collection time, so the

--- a/tests/unit/webviews/paneBudget.test.ts
+++ b/tests/unit/webviews/paneBudget.test.ts
@@ -63,9 +63,11 @@ describe("resolvePaneBudget", () => {
         );
 
         expect(Object.values(result.widths).every((width) => width >= 0)).toBe(true);
-        expect(Object.entries(result.widths).every(([key, width]) => width >= ({ a: 80, b: 120, c: 60 }[key] ?? 0))).toBe(
-            true,
-        );
+        expect(
+            Object.entries(result.widths).every(
+                ([key, width]) => width >= ({ a: 80, b: 120, c: 60 }[key] ?? 0),
+            ),
+        ).toBe(true);
         expect(visibleTotal(result.widths, 4)).toBeCloseTo(320);
     });
 
@@ -79,7 +81,9 @@ describe("resolvePaneBudget", () => {
         const second = resolvePaneBudget(0, panes, dropOrder, -4);
 
         expect(first).toEqual(second);
-        expect(Object.values(first.widths).every((width) => Number.isFinite(width) && width >= 0)).toBe(true);
+        expect(
+            Object.values(first.widths).every((width) => Number.isFinite(width) && width >= 0),
+        ).toBe(true);
         expect(panes).toEqual(beforePanes);
         expect(dropOrder).toEqual(beforeDropOrder);
     });
@@ -101,11 +105,16 @@ describe("resolvePaneBudget", () => {
     });
 
     it("never emits a negative width for a negative viewport", () => {
-        const result = resolvePaneBudget(-500, [pane("a", 100, 200), pane("b", 100, 200)], ["b"], 4);
-
-        expect(Object.values(result.widths).every((width) => Number.isFinite(width) && width >= 0)).toBe(
-            true,
+        const result = resolvePaneBudget(
+            -500,
+            [pane("a", 100, 200), pane("b", 100, 200)],
+            ["b"],
+            4,
         );
+
+        expect(
+            Object.values(result.widths).every((width) => Number.isFinite(width) && width >= 0),
+        ).toBe(true);
     });
 
     it("keeps the commit list visible at the measured 320px graph width", () => {

--- a/tests/visual/playwright/harnessPage.ts
+++ b/tests/visual/playwright/harnessPage.ts
@@ -183,7 +183,13 @@ export const test = base.extend<VisualFixtures, VisualWorkerFixtures>({
             pageExceptions.push(error.stack ?? error.message);
         });
         await page.route("**/*", (route) =>
-            routeHarnessRequest(route, HARNESS_ORIGIN, DIST_DIR, () => documentHtml, networkEscapes),
+            routeHarnessRequest(
+                route,
+                HARNESS_ORIGIN,
+                DIST_DIR,
+                () => documentHtml,
+                networkEscapes,
+            ),
         );
 
         // This runs before every navigation and delegates the implementation to


### PR DESCRIPTION
**1 of 2.** Merge this one first — [the other half](../../pull/210) carries the gate change and stays red until this lands.

`format:check` only ever covered `src/**/*.{ts,tsx}` and `scripts/**/*.js`. The entire `tests/` tree and every root config file were outside the gate and had drifted out of Prettier style. Closing that gap touches 124 files at once, which is more than CodeRabbit will review, so the work is split in two halves that are each reviewable and each independently green.

This half is `tests/unit/**` (80 files) plus `tests/visual/playwright/harnessPage.ts`, which lives here rather than with the rest of the visual tree because `tests/unit/visual/playwright/harnessPage.contract.test.ts` reads its source text — keeping the reflow and the assertion that reads it in the same PR removes an ordering hazard between the two halves.

### The one non-mechanical change

`harnessPage.contract.test.ts` asserted on the source *layout* of the `routeHarnessRequest(...)` call:

```ts
expect(routeRegistration).toContain(
    "routeHarnessRequest(route, HARNESS_ORIGIN, DIST_DIR, () => documentHtml, networkEscapes)",
);
```

Prettier reflows that call across lines once the argument list crosses the print width, which would make the formatter — not a behaviour change — the thing that turns the test red. The assertion now collapses whitespace and the trailing comma before matching, so it polices what it means to police: the delegation and its exact argument list.

Verified it still has teeth — each mutation turns **`keeps route interception delegated to the shared harness utility`** red by name, and restoring returns it to green:

| Mutation to `harnessPage.ts` | Result |
| --- | --- |
| drop the `networkEscapes` argument | ✗ 1 failed, 2 passed |
| swap `HARNESS_ORIGIN` and `DIST_DIR` | ✗ 1 failed, 2 passed |
| restored | ✓ 3 passed |

### `.coderabbit.yaml`

`path_filters` is applied as a sparse checkout: an excluded path is never fetched, so it never counts against CodeRabbit's 100-changed-file cap. That made the exclusion list an attractive place to buy review budget from, and eight test directories had been added to it for exactly that reason — 110 test files that no longer got reviewed, on every branch, forever.

Removing them restores review of `tests/webview`, `tests/integration/{extension,webviews,shelf}` and `tests/unit/{views,activation,localization,services}`. Branches that cross 100 files get split instead — which is what this PR pair is.

`tests/visual/fixtures/**` is deliberately **not** excluded despite looking like machine output: three of its top-level files are the visual gate's known-bad ratchet baselines (`knownFindings.json`, `knownLocaleFindings.json`) and its container digest pin (`baselineEnvironment.json`) — the highest-value files in the tree to have a reviewer look at.

## Test plan

Run on this branch, all rc=0:

- [x] `bun run format:check` — passes (old scope; the widened gate is in the other half)
- [x] `bun run lint:strict`
- [x] `bun run lint:complexity`
- [x] `bun run architecture:check` — 299 modules, 0 violations
- [x] `bun run typecheck` — 3 projects
- [x] `bun run test` — **290 files, 3997 tests, rc=0**
- [x] `bun run build`
- [x] mutation table above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized formatting across test and visual validation files for improved readability and consistency.
  * Reformatted assertions, imports, callbacks, objects, and function calls without changing behavior.

* **Tests**
  * Preserved all existing test logic, assertions, coverage, setup, cleanup, and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->