### PR TITLE
fix(views): answer the commit panel that asked, not the last one recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.11] - 2026-08-18
+
+### Fixed
+
+- Fixed the Commit panel coming up permanently blank while the Graph beside it filled in normally. When the panel loads it announces itself, IntelliGit answers with the list of repositories, and the panel keeps re-asking until that answer arrives. IntelliGit sent the answer to whichever panel it had recorded last, rather than to the panel that had just asked. It forgets that record when the view is closed, and the panel can be reloaded without IntelliGit being told — so once the two disagreed, every answer went nowhere. Nothing reported it, because sending to a panel that is not open is an ordinary thing to do and is not treated as a fault, so the panel re-asked for as long as the window stayed open and stayed empty throughout. A panel that has just sent a message is by definition there, so IntelliGit now treats it as the panel to answer whenever it is holding no record of one — while leaving an existing record untouched, so a panel that has since been replaced cannot take answers meant for the one actually on screen.
+
 ## [0.25.10] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.25.10",
+    "version": "0.25.11",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -1095,6 +1095,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
         });
         webviewView.webview.onDidReceiveMessage(async (msg) => {
+            this.adoptLiveSender(thisView);
             const message: unknown = msg;
             try {
                 await this.handleMessage(message);
@@ -2062,6 +2063,36 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         if (!this.view) return false;
         this.postToWebview(message);
         return true;
+    }
+
+    /**
+     * Re-adopts a webview that is provably live, because it just posted a message.
+     *
+     * `onDidDispose` clears `this.view`, and VS Code can reload a hidden view's document without
+     * re-running `resolveWebviewView` -- the case {@link handleReadyMessage}'s own comment already
+     * describes. A `ready` arriving while the record is empty is therefore answered to nothing:
+     * every reply hits {@link postToWebview}'s `!view` early return, which is the single path in
+     * this whole delivery layer that reports nothing at all, so the panel stays on
+     * `commit-panel-awaiting-hydration` for the rest of the session -- however many times the
+     * webview re-asks, because every re-ask is answered exactly as silently as the first.
+     *
+     * Adopts ONLY when the record is empty. A different live view recorded there is the correct
+     * target, and stealing the record would blank the view actually on screen to fix one that
+     * isn't. The theme bindings are restored alongside it because `onDidDispose` tore them down;
+     * `attachWebview` is built to rebind (it clears its own `disposed` flag).
+     *
+     * This rests on VS Code not delivering messages from a webview it has already torn down. If
+     * it ever did, the record would name a dead view until the next resolve, and
+     * {@link showRebaseDialog} would report a dialog it could not raise. That failure is loud --
+     * every post to a dead webview is reported by {@link postWebviewMessage} -- whereas the one
+     * this method exists to prevent is completely silent, which is why it went undiagnosed across
+     * four investigations. Trading a reported failure for an unreported one is the point.
+     */
+    private adoptLiveSender(sender: vscode.WebviewView): void {
+        if (this.view !== undefined) return;
+        this.view = sender;
+        this.iconTheme.attachWebview(sender.webview);
+        this.registerThemeChangeListeners();
     }
 
     /**

--- a/tests/unit/views/CommitPanelViewProvider.test.ts
+++ b/tests/unit/views/CommitPanelViewProvider.test.ts
@@ -103,8 +103,10 @@ function createInspectableCommitPanelWebviewView(outcome: DeliveryOutcome = "del
     readonly webviewView: vscode.WebviewView;
     readonly posted: unknown[];
     receiveMessage(message: unknown): Promise<void>;
+    disposeView(): void;
 } {
     let messageHandler: ((message: unknown) => unknown) | undefined;
+    let disposeHandler: (() => void) | undefined;
     const posted: unknown[] = [];
 
     const webview = {
@@ -128,7 +130,10 @@ function createInspectableCommitPanelWebviewView(outcome: DeliveryOutcome = "del
     const webviewView = {
         webview,
         visible: true,
-        onDidDispose: () => inertDisposable(),
+        onDidDispose: (listener: () => void) => {
+            disposeHandler = listener;
+            return inertDisposable();
+        },
         onDidChangeVisibility: () => inertDisposable(),
     } as unknown as vscode.WebviewView;
 
@@ -143,6 +148,15 @@ function createInspectableCommitPanelWebviewView(outcome: DeliveryOutcome = "del
                 );
             }
             await messageHandler(message);
+        },
+        disposeView: (): void => {
+            if (!disposeHandler) {
+                throw new Error(
+                    "createInspectableCommitPanelWebviewView.disposeView: no dispose handler was " +
+                        "registered yet -- resolveWebviewView() must run first.",
+                );
+            }
+            disposeHandler();
         },
     };
 }
@@ -506,5 +520,123 @@ describe("CommitPanelViewProvider webview delivery failures", () => {
             "reporting that a post failed without the reason leaves the next reader exactly " +
                 "where the silent version did -- the cause is the whole payload",
         ).toContain("Webview is disposed");
+    });
+});
+
+/**
+ * The panel's only hydration path is the host's answer to `ready`, and `postToWebview` answers
+ * through the provider's cached `this.view` rather than through the webview that actually asked.
+ * Those are not the same thing. `onDidDispose` clears `this.view`, and `handleReadyMessage`'s own
+ * comment records that VS Code tears a hidden view's context down and reloads it on show WITHOUT
+ * re-running `resolveWebviewView` -- so a `ready` can arrive while the record is empty. It is then
+ * answered to nothing, and `postToWebview`'s `if (!view) return` is the single path in the entire
+ * delivery layer that logs nothing at all: every other outcome goes through `postWebviewMessage`,
+ * which reports refusals and rejections. The pane stays blank for the rest of the session with no
+ * host-side evidence.
+ *
+ * That is exactly the signature CI keeps capturing on `e2e-full`: a mounted React app rendering
+ * `commit-panel-awaiting-hydration` -- which `SET_REPOSITORIES` would have cleared unconditionally,
+ * even for an empty list, so it proves zero hydrations were applied -- beside a clean extension-host
+ * console, next to a fully populated graph webview.
+ *
+ * The invariant pinned here is the protocol one, not a repair recipe: a request that arrives from a
+ * live webview must be answered TO that webview. A webview that just posted a message is alive by
+ * construction, whatever the provider's own record happens to say.
+ */
+describe("CommitPanelViewProvider hydration answers the webview that asked", () => {
+    afterEach(async () => {
+        await scratch.removeAll();
+    });
+
+    it("answers a `ready` from a live webview whose view record was already cleared", async () => {
+        // A REAL seeded working tree, not a bare path: `handleReadyMessage` runs git behind
+        // `postRepositoryListHydration`, and against a non-existent root it throws `spawn git
+        // ENOENT` -- which fails this test through the error path instead of through its own
+        // assertion, and so would prove nothing about hydration either way.
+        const parentDir = await mkdtemp(
+            path.join(tmpdir(), "intelligit-ready-after-view-record-loss-"),
+        );
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env))),
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+
+        const { webviewView, posted, receiveMessage, disposeView } =
+            createInspectableCommitPanelWebviewView();
+        provider.resolveWebviewView(webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const hydrationsBefore = messagesOfType(posted, "setRepositories").length;
+
+        // VS Code disposes the WebviewView when the container is hidden. The webview document can
+        // outlive that record and re-announce itself without `resolveWebviewView` running again --
+        // the case `handleReadyMessage`'s own comment already describes. No re-resolve here is the
+        // entire point: a test that resolved again would restore `this.view` and prove nothing.
+        disposeView();
+        await receiveMessage({ type: "ready", attempt: 2 });
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(posted, "setRepositories").length,
+            "a `ready` from a webview that is provably live -- it just posted this very message " +
+                "-- must be answered to that webview. Answering through a cleared `this.view` " +
+                "drops the reply in silence and strands the pane on " +
+                "commit-panel-awaiting-hydration for the rest of the session, however many times " +
+                "the webview re-asks",
+        ).toBeGreaterThan(hydrationsBefore);
+    });
+
+    it("keeps answering the view on screen when a replaced view posts a late message", async () => {
+        const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-stale-sender-"));
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env))),
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+
+        // VS Code replaced the view: a second resolve, so `this.view` is the NEW one and is not
+        // empty. The old document can still post -- a retained context, or a message already in
+        // flight when the replacement landed.
+        const replaced = createInspectableCommitPanelWebviewView();
+        provider.resolveWebviewView(replaced.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const onScreen = createInspectableCommitPanelWebviewView();
+        provider.resolveWebviewView(onScreen.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        const replacedBefore = messagesOfType(replaced.posted, "setRepositories").length;
+        const onScreenBefore = messagesOfType(onScreen.posted, "setRepositories").length;
+
+        await replaced.receiveMessage({ type: "ready", attempt: 2 });
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(onScreen.posted, "setRepositories").length,
+            "the reply must go to the view actually on screen -- adopting every sender would " +
+                "hand the record back to a view VS Code already replaced, and blank the live " +
+                "pane to un-blank a dead one",
+        ).toBeGreaterThan(onScreenBefore);
+        expect(
+            messagesOfType(replaced.posted, "setRepositories").length,
+            "a replaced view must not capture the provider's view record just by posting: the " +
+                "empty-record guard is what keeps adoption a recovery rather than a hijack",
+        ).toBe(replacedBefore);
     });
 });


### PR DESCRIPTION
## What this fixes

`e2e-full` has failed on every `main` run since 0.25.8, on one flow row per run — a
different row each time. The signature in every artifact is identical:

- the COMMIT pane renders `commit-panel-awaiting-hydration`
- the GRAPH pane, right beside it, renders fully
- zero `[IntelliGit]` lines in the captured console

The commit panel's only hydration path is the host's answer to the webview's `ready`
message, and `postToWebview` routed that answer through `this.view`. `onDidDispose`
clears that field, and `resolveWebviewView` does **not** re-run when VS Code tears a
hidden view's document down and reloads it on show — `handleReadyMessage`'s own comment
already recorded that reload happening without a re-resolve.

Once the record and the live document disagreed, every answer hit `postToWebview`'s
`if (!view) return`. That is the **single path in the whole delivery layer that reports
nothing at all** — every other outcome (sync throw, `delivered === false`, rejection) is
logged by `postWebviewMessage`. So the webview re-asked for the full 30s and every
re-ask was answered exactly as silently as the first, and four prior investigations that
read the logs found nothing, because there was nothing to find.

### The fix

A webview that has just posted a message is live by construction. `adoptLiveSender`
re-adopts it **only when the record is empty**, restoring the theme bindings
`onDidDispose` tore down (`attachWebview` is built to rebind — it clears its own
`disposed` flag).

Adopting **only** when empty is load-bearing: a different live view already recorded
there is the correct target, and stealing the record would blank the pane actually on
screen to fix one that is not.

## Verified

| Gate | Result |
|---|---|
| Unit suite | **3999 passed / 3999**, 290 files, exit 0 (idle machine) |
| `CommitPanelViewProvider.test.ts` | 7/7 against final bytes |
| `lint:strict` | clean (`--max-warnings=0`) |
| `tsc --noEmit` | rc=0 |
| `format:check` | clean on all four changed files |

Mutation-proven in **both** directions, each reddening a *different* assertion:

| Mutation | Red test |
|---|---|
| remove the `adoptLiveSender` call | `answers a ready from a live webview whose view record was already cleared` |
| adopt unconditionally (drop the `!== undefined` guard) | `keeps answering the view on screen when a replaced view posts a late message` |

Two facts turn this from a guess into a diagnosis:

- `SET_REPOSITORIES` sets `hydrated: true` **unconditionally**, even for an empty list.
  So a pane rendering `commit-panel-awaiting-hydration` proves **zero** hydrations were
  applied — not "one applied with nothing in it".
- The graph pane rendered fully in the same screenshot from a **different provider**, so
  the extension host was demonstrably not blocked. That excludes "the host was just slow".

A throwaway probe in the pinned container confirmed extension-host `console.error` **does**
reach the harness (tagged `[Extension Host]`, arriving as type `error`, which the harness
records). So the clean console is real evidence that no post was ever attempted — not an
instrument blind spot.

## Assumed — NOT proven

**Attribution to the CI flake is not proven.** The local container run did not reproduce:
0 failures in 14 complete invocations under 6 CPU burners (27 reveals across two runs).
That is not a negative result — at CI's observed ~1 failure per ~12 reveals (~2%/reveal),
P(zero failures across 27) ≈ 0.58, so the local run had almost no discriminating power.

A single green `e2e-full` after merge must **not** be read as proof either. What is
certain is narrower and still worth having: the `!this.view` branch is now eliminated by
construction, so if `e2e-full` goes red again with the same signature, the remaining
search space collapses to "`ready` never reached the host at all".

## Risk — please read

GitNexus rates the touched surface **CRITICAL**: `postToWebview` upstream is 51 impacted
symbols, 23 direct callers, 7 execution flows, 5 modules. `detect_changes` reports risk
`high`, 5 changed symbols, 8 affected processes.

`postToWebview` itself is byte-unchanged. What changed is that `this.view` can now
transition `undefined -> the sender that just posted`, and those 51 symbols read through
that path.

The one assumption this rests on, stated plainly: VS Code does not deliver messages from a
webview it has already torn down. If it ever did, the record would name a dead view until
the next resolve, and `showRebaseDialog` would report a dialog it could not raise. That
failure is **loud** — every post to a dead webview is reported. The one being fixed is
completely silent. Trading a reported failure for an unreported one is the point, and the
tradeoff is documented in the method's doc comment so the next reader does not have to
re-derive it.

## Release

**v0.25.9 and v0.25.10 are both built and unpublished** (latest release is v0.25.8).
`e2e-full` gates `release-eligibility` in `publish.yml`, so nothing has shipped since.

This PR bumps to **0.25.11**, which is what unblocks all three. The version has to move
for the release to happen at all: `version_changed` compares `package.json` at HEAD
against the push's before-SHA, so merging on an unchanged 0.25.10 would compare 0.25.10
against itself, report no change, and leave both versions' fixes sitting on `main`.

## Test plan

- [x] `bun run test` — 3999/3999
- [x] `bun run lint:strict`
- [x] `bun run format:check`
- [x] `tsc --noEmit`
- [x] mutation proof, both directions, distinct assertions
- [ ] `e2e-full` green on this PR (and, per above, one green run is not attribution)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored commit panel functionality after its webview is disposed and recreated.
  * Ensured responses are delivered to the currently active commit panel, preventing stale views from interfering.

* **Tests**
  * Added coverage for view disposal, recreation, and message handling.

* **Chores**
  * Updated the extension version to 0.25.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->