### PR TITLE
fix(ci): stop a webview frame swap failing package smoke, and keep its evidence

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,6 +285,20 @@ jobs:
             - name: Run installed package smoke in the pinned container
               run: ./tests/e2e/docker/run.sh 'bun install --frozen-lockfile && bun run build && INTELLIGIT_VSCODE_VERSION=${{ matrix.vscode_version }} xvfb-run -a bun run test:package-smoke'
 
+            # Without this the only evidence a package-smoke failure leaves is the log: Playwright
+            # writes its screenshot, error context, and trace inside the container, and the job ends
+            # before anything reads them. e2e-full already uploads the same paths.
+            - name: Upload package smoke failure artifacts
+              if: failure()
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: package-smoke-failures-${{ matrix.vscode_version }}
+                  path: |
+                      playwright-report/
+                      test-results/
+                  if-no-files-found: ignore
+                  retention-days: 7
+
     # Eligibility has no production environment or secrets. It is deliberately
     # split from the publishing job so a same-version change never instantiates
     # a job that can access Marketplace credentials.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,10 +190,16 @@ jobs:
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: visual-failures
-                  path: |
-                      playwright-report/
-                      test-results/
-                  if-no-files-found: ignore
+                  # `playwright-report/` is the HTML reporter's directory and nothing here uses
+                  # that reporter -- the e2e config pins `list` and the visual config names none,
+                  # whose default is `list`/`dot`. Listing it made the upload look like it kept
+                  # two kinds of evidence while only `test-results/` ever existed.
+                  #
+                  # `warn` rather than `ignore` for the same reason: a failure that produced no
+                  # artifacts at all is the case worth seeing, since it means the job died before
+                  # the suite ran. `warn` annotates it without failing the step.
+                  path: test-results/
+                  if-no-files-found: warn
                   retention-days: 7
 
     # The flow suite, and the same-SHA gate the release chain below waits on.
@@ -234,10 +240,10 @@ jobs:
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: e2e-full-failures
-                  path: |
-                      playwright-report/
-                      test-results/
-                  if-no-files-found: ignore
+                  # See the visual job's upload: no reporter here writes `playwright-report/`, and
+                  # a failure carrying no artifacts is worth an annotation rather than silence.
+                  path: test-results/
+                  if-no-files-found: warn
                   retention-days: 7
 
     package-smoke:
@@ -293,10 +299,12 @@ jobs:
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: package-smoke-failures-${{ matrix.vscode_version }}
-                  path: |
-                      playwright-report/
-                      test-results/
-                  if-no-files-found: ignore
+                  # See the visual job's upload: no reporter here writes `playwright-report/`, and
+                  # a failure carrying no artifacts is worth an annotation rather than silence.
+                  # This job can fail before the suite runs at all -- the VSIX checksum check and
+                  # the container's own install and build all precede it -- so that case is real.
+                  path: test-results/
+                  if-no-files-found: warn
                   retention-days: 7
 
     # Eligibility has no production environment or secrets. It is deliberately

--- a/tests/e2e/packageSmoke.spec.ts
+++ b/tests/e2e/packageSmoke.spec.ts
@@ -165,8 +165,17 @@ test.describe("installed VSIX package smoke", () => {
             const frame = await intelliGitView.reveal();
             const root = frame.locator("#root");
             await expect(root).toBeVisible();
-            const childCount = await root.evaluate((element) => element.children.length);
-            expect(childCount).toBeGreaterThan(0);
+            // The workbench may replace a webview's `#active-frame` after its document has already
+            // rendered, and `locator.evaluate` does not retry across that swap -- it fails outright
+            // with "Frame was detached". `toBeVisible` above survives it because web-first
+            // assertions re-resolve; a bare `evaluate` between two of them does not, so the read
+            // repeats under `toPass` and a swap becomes a retry rather than a red pipeline.
+            // Observed on VS Code 1.96.0 in CI run 32411770447, green on an unmodified re-run.
+            let childCount = 0;
+            await expect(async () => {
+                childCount = await root.evaluate((element) => element.children.length);
+                expect(childCount).toBeGreaterThan(0);
+            }).toPass({ timeout: 30_000, intervals: [250] });
             console.log(
                 `[package smoke] IntelliGit activity-bar webview mounted (#root children: ${childCount})`,
             );

--- a/tests/unit/visual/publishWorkflow.test.ts
+++ b/tests/unit/visual/publishWorkflow.test.ts
@@ -1209,3 +1209,82 @@ describe("publish visual workflow", () => {
         ).not.toMatch(/^\s+issues: write\s*$/m);
     });
 });
+
+/**
+ * Every upload step in `publish.yml` that keeps a suite's evidence, derived from the workflow
+ * rather than listed here -- a fixed list of three would pass while a fourth job uploaded nothing
+ * anyone could read.
+ */
+function failureEvidenceUploadSteps(workflow: string): { name: string; body: string }[] {
+    return (
+        workflow
+            .split(/^ {12}- name: /m)
+            .slice(1)
+            // Comment lines are dropped before anything is matched. These steps are commented with
+            // the very path names the assertions look for -- prose explaining why
+            // `playwright-report/` is absent contains `playwright-report/` -- so a check reading
+            // the raw block fails on a correct workflow and would be "fixed" by deleting the
+            // explanation. The subject here is the YAML.
+            .map((chunk) => ({
+                name: chunk.slice(0, chunk.indexOf("\n")),
+                body: chunk.replace(/^\s*#.*$/gm, ""),
+            }))
+            .filter(
+                (step) =>
+                    step.body.includes("upload-artifact") && step.body.includes("if: failure()"),
+            )
+    );
+}
+
+/**
+ * `playwright-report/` is the HTML reporter's output directory, and nothing in this repository
+ * runs that reporter -- `playwright.e2e.config.ts` pins `list`, and `playwright.visual.config.ts`
+ * names none, whose default is `list` (or `dot` under CI). Every failure upload nonetheless listed
+ * it alongside `test-results/`, which is the failure this pins: an upload that names two kinds of
+ * evidence and can only ever carry one reads, in review and in a downloaded artifact alike, as
+ * though the missing half simply had nothing to report.
+ *
+ * The reporter check is the half that keeps this honest. Asserting the absent path alone would
+ * turn into a false failure the day someone legitimately enables HTML reporting; asserting the
+ * configuration too means that change fails HERE, with a message naming the upload steps it has
+ * to update, rather than silently shipping a report no artifact carries.
+ */
+describe("failure artifact uploads", () => {
+    it("keeps only evidence a reporter actually writes", () => {
+        const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+        const steps = failureEvidenceUploadSteps(workflow);
+
+        expect(
+            steps.length,
+            "publish.yml must upload evidence from its failing suites",
+        ).toBeGreaterThan(0);
+        for (const configPath of ["playwright.e2e.config.ts", "playwright.visual.config.ts"]) {
+            expect(
+                readFileSync(resolve(REPOSITORY_ROOT, configPath), "utf8"),
+                `${configPath} enables the HTML reporter -- every failure upload in publish.yml ` +
+                    "must start carrying playwright-report/ again, and this assertion inverted",
+            ).not.toMatch(/["']html["']/);
+        }
+        for (const step of steps) {
+            expect(
+                step.body,
+                `"${step.name}" uploads playwright-report/, which no reporter here writes`,
+            ).not.toContain("playwright-report/");
+            expect(step.body, `"${step.name}" must keep test-results/`).toContain("test-results/");
+        }
+    });
+
+    // `ignore` suppresses the one outcome worth an annotation: a job that failed before its suite
+    // produced anything, which is precisely when the missing artifact is the finding rather than
+    // noise. `warn` surfaces it without failing the step, so the upload stays non-blocking.
+    it("annotates a failure that produced no evidence at all", () => {
+        const workflow = readFileSync(WORKFLOW_PATH, "utf8");
+
+        for (const step of failureEvidenceUploadSteps(workflow)) {
+            expect(
+                step.body,
+                `"${step.name}" silences the case where a failing job produced no artifacts`,
+            ).toContain("if-no-files-found: warn");
+        }
+    });
+});


### PR DESCRIPTION
## Why

CI run [32411770447](https://github.com/MaheshKok/IntelliGit/actions/runs/32411770447) failed on `main` for `package-smoke (1.96.0)`:

```
Error: locator.evaluate: Frame was detached
  > 168 | const childCount = await root.evaluate((element) => element.children.length);
```

The same commit went green on an unmodified re-run, so it is a race, not a regression. `package-smoke` had been green 6/6 on `main` before this.

## What was wrong

`packageSmoke.spec.ts` read `#root`'s child count with a bare `locator.evaluate` sitting between two web-first assertions:

```ts
await expect(root).toBeVisible();
const childCount = await root.evaluate((element) => element.children.length);
```

The workbench can replace a webview's `#active-frame` after its document has already rendered. Web-first assertions ride that out because they re-resolve their locator; `evaluate` does not, and fails outright. With `retries: 0` (`playwright.e2e.config.ts:34`) that single race takes the whole pipeline red, and it gates `release-eligibility`.

## What changed

- **`tests/e2e/packageSmoke.spec.ts`** — the read repeats under `toPass`, so a frame swap costs a retry instead of the run. `toBeVisible` is kept ahead of it because it still gives the better message when the panel genuinely never mounts.
- **`.github/workflows/publish.yml`** — `package-smoke` now uploads Playwright's screenshot, error context, and trace on failure, keyed per matrix version. It previously uploaded nothing: those files are written inside the container and discarded with it, so the only evidence of this failure was the log. `e2e-full` already uploads the same paths.

## Not in scope

The other failure in that run, `e2e-full` timing out on `commit-panel-tab-row` with the panel stuck at `commit-panel-awaiting-hydration`, is a separate pre-existing bug — same signature on `main` on 2026-08-18 in runs 32132974780 and 32134296122, before the commit that run tested. It is deliberately **not** papered over with Playwright retries here: it reflects a real product race where the Changes panel never receives its repository list, and hiding it in CI would make a user-visible bug invisible.

## Test plan

- [x] `bun run test` — 294 files, 4114 tests passed
- [x] `bun run typecheck` (ext + webview + tests) — clean
- [x] `bun run lint:strict`, `format:check`, `knip`, `depcruise`, l10n validate + audit — clean (pre-commit hook, all nine checks)
- [x] `tests/unit/publishing`, `tests/unit/visual/publishWorkflow.test.ts`, `tests/unit/e2e` — 383 passed, covering the edited workflow's shape
- [ ] The `toPass` retry is unproven against a real frame swap: the detach is a nondeterministic workbench event and did not reproduce locally. It earns its proof the next time that race fires and the job stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package smoke test reliability by retrying during webview rendering and frame replacement.
  * Reduced false failures caused by temporarily unavailable webview content.

* **Chores**
  * Added failure diagnostics that preserve Playwright reports and test results for seven days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->