### PR TITLE
test(e2e): name which leg of the commit-panel handshake dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-08-20
+
+### Changed
+
+- Added development-only diagnostics to the Commit panel's hydration handshake, so an intermittent CI failure in which the panel mounts and is never given anything to show can be told apart from one in which it is answered and fails to display the answer. The counters record how many times the panel asked the extension host to hydrate it and how many messages came back, and they are reported in the end-to-end suite's timeout message. They are gated on the same development-only flag as the rest of the test control channel: an installed extension allocates nothing and carries no global, and no behaviour a user can see changes.
+
 ## [0.27.0] - 2026-08-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.27.0",
+    "version": "0.27.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
+++ b/src/webviews/react/commit-panel/hooks/useExtensionMessages.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import type { WorkingFile } from "../../../../types";
 import { commitMessageGenerationPrefix } from "../../shared/commitMessageDraft";
+import { recordHostMessage, recordHydrationAsk } from "../../shared/hydrationDiagnostics";
 
 const LEGACY_REPOSITORY_ROOT = "";
 
@@ -460,6 +461,10 @@ export function useExtensionMessages(): [
 
         const handler = (event: MessageEvent<InboundMessage>) => {
             const msg = event.data;
+            // Counted before the switch, so a payload no case matches still counts as "the host
+            // is talking to us". A blank panel whose diagnostics report messages the reducer
+            // dropped is a different bug from one that was never answered at all.
+            recordHostMessage(msg);
             switch (msg.type) {
                 case "setRepositories":
                     applyAction({
@@ -594,6 +599,7 @@ export function useExtensionMessages(): [
         window.addEventListener("message", handler);
         let attempt = 1;
         let elapsed = 0;
+        recordHydrationAsk();
         vscode.postMessage({ type: "ready", attempt });
 
         // Re-asking is safe to repeat: the host's `ready` handler posts the repository list and its
@@ -609,6 +615,7 @@ export function useExtensionMessages(): [
         const askAgain = (): void => {
             if (stateRef.current.hydrated) return;
             attempt += 1;
+            recordHydrationAsk();
             vscode.postMessage({ type: "ready", attempt });
             scheduleRetry();
         };

--- a/src/webviews/react/shared/hydrationDiagnostics.ts
+++ b/src/webviews/react/shared/hydrationDiagnostics.ts
@@ -1,0 +1,78 @@
+// Development-only counters that make a commit panel stuck on
+// `commit-panel-awaiting-hydration` diagnosable from the E2E failure message alone. Gated at
+// runtime on `window.intelligitE2E` -- the same flag the webview shell (src/views/webviewHtml.ts)
+// injects only when the extension host's three-gate check passed -- so a production webview
+// allocates nothing and carries no global. Runtime-gated rather than build-gated for the reason
+// `e2eStateBridge.ts` gives: a build-time `define` would ship a different bundle to tests than to
+// users.
+//
+// Why this exists at all: a blank panel has exactly two causes and the artifact cannot separate
+// them. Either the host never answered the `ready` handshake, or it answered and the webview
+// never applied the answer. Both render byte-identically -- three CI failures across two runs
+// produced the same `root=<children:2 chars:147>` and the same clean console. `asks` and
+// `hostMessages` split that fork in one number each: asks>0 with hostMessages 0 is a webview
+// talking to a host that never replies, and hostMessages>0 without hydration is a reply the
+// reducer refused.
+
+/** Name of the diagnostic global, read by `tests/e2e/pageObjects/intelliGitView.ts`. */
+const GLOBAL_KEY = "intelligitHydrationDiagnostics";
+
+/**
+ * What the E2E reveal-timeout dump reports about a webview's handshake.
+ *
+ * Deliberately not exported: the only reader is a Playwright page-side callback
+ * (`tests/e2e/pageObjects/intelliGitView.ts`), which is serialized into the webview document and
+ * so cannot import anything. It restates this shape inline, and `tests/unit/e2e/pageObjects.test.ts`
+ * runs that callback against a body built to match, which is what keeps the two in step.
+ */
+interface HydrationDiagnostics {
+    /** How many `ready` messages this document has posted, including the first. */
+    asks: number;
+    /** How many messages of any type the host has posted back to this document. */
+    hostMessages: number;
+    /** `type` of the most recent host message, or `null` while none has arrived. */
+    lastHostMessageType: string | null;
+}
+
+declare global {
+    interface Window {
+        /** Present only while the E2E control channel is active. See {@link HydrationDiagnostics}. */
+        intelligitHydrationDiagnostics?: HydrationDiagnostics;
+    }
+}
+
+/**
+ * Returns the live diagnostics record, or `undefined` when the E2E gate is off.
+ *
+ * Allocates on first use so the gate-off path touches nothing: a production webview must not
+ * grow a global just because a hook called a recorder.
+ */
+function diagnostics(): HydrationDiagnostics | undefined {
+    if (typeof window === "undefined" || window.intelligitE2E !== true) return undefined;
+    window[GLOBAL_KEY] ??= { asks: 0, hostMessages: 0, lastHostMessageType: null };
+    return window[GLOBAL_KEY];
+}
+
+/** Records that this document posted a `ready` message to the host. */
+export function recordHydrationAsk(): void {
+    const record = diagnostics();
+    if (!record) return;
+    record.asks += 1;
+}
+
+/**
+ * Records that the host posted a message to this document.
+ *
+ * `message` is whatever arrived, unvalidated -- the point is to count messages the reducer may
+ * have rejected, so a payload this webview cannot parse still has to be counted.
+ */
+export function recordHostMessage(message: unknown): void {
+    const record = diagnostics();
+    if (!record) return;
+    record.hostMessages += 1;
+    const type =
+        typeof message === "object" && message !== null
+            ? (message as { type?: unknown }).type
+            : undefined;
+    record.lastHostMessageType = typeof type === "string" ? type : null;
+}

--- a/tests/e2e/pageObjects/intelliGitView.ts
+++ b/tests/e2e/pageObjects/intelliGitView.ts
@@ -41,6 +41,38 @@ const CONSOLE_LINE_LIMIT = 300;
  * came from a webview or from the workbench shell around it. */
 const WEBVIEW_URL_SCHEME = "vscode-webview://";
 
+/**
+ * Renders the commit panel's handshake counters (`src/webviews/react/shared/hydrationDiagnostics.ts`)
+ * for the timeout message.
+ *
+ * The blank-panel failure this instrument exists for has three causes that the rest of the dump
+ * reports identically -- three CI failures across two runs produced the same
+ * `root=<children:2 chars:147>` with the same clean console -- and each leaves a different
+ * signature here:
+ *
+ * - `(none)`: the global was never created, so the effect that posts `ready` never ran. Only
+ *   meaningful while the E2E gate is on; with the gate off no webview ever carries the global.
+ * - `asks:N received:0`: the webview asked N times and the host answered nothing. The drop is on
+ *   the host side of the handshake, or inbound before it.
+ * - `asks:N received:M`: the host is answering and the reducer is not hydrating from what it
+ *   sends -- `last` names the message type that arrived most recently.
+ *
+ * Surfaces on every webview rather than the commit panel alone: a graph panel reporting `(none)`
+ * while the commit panel reports counters is what proves the absence is specific rather than a
+ * bundle-wide failure.
+ */
+function describeHydration(
+    diagnostics:
+        | { asks: number; hostMessages: number; lastHostMessageType: string | null }
+        | undefined,
+): string {
+    if (!diagnostics) return "(none)";
+    return (
+        `<asks:${diagnostics.asks} received:${diagnostics.hostMessages} ` +
+        `last:${JSON.stringify(diagnostics.lastHostMessageType)}>`
+    );
+}
+
 /** Locates IntelliGit's webview surfaces: the activity-bar view and the full-width graph panel. */
 export class IntelliGitView {
     /** Errors and warnings the page emitted, newest last. See `describeConsole`. */
@@ -164,7 +196,14 @@ export class IntelliGitView {
                     .evaluate((body: HTMLElement) => {
                         const document = body.ownerDocument;
                         const shellGlobals = document.defaultView as
-                            | (Window & { intelligitI18n?: unknown })
+                            | (Window & {
+                                  intelligitI18n?: unknown;
+                                  intelligitHydrationDiagnostics?: {
+                                      asks: number;
+                                      hostMessages: number;
+                                      lastHostMessageType: string | null;
+                                  };
+                              })
                             | null;
                         const root = document.getElementById("root");
                         return {
@@ -173,6 +212,7 @@ export class IntelliGitView {
                             rootChildren: root?.childElementCount ?? -1,
                             rootChars: root?.innerHTML.length ?? -1,
                             bootstrapped: shellGlobals?.intelligitI18n !== undefined,
+                            hydration: shellGlobals?.intelligitHydrationDiagnostics,
                             testIds: Array.from(body.querySelectorAll("[data-testid]"))
                                 .slice(0, 8)
                                 .map((element) => element.getAttribute("data-testid")),
@@ -185,6 +225,7 @@ export class IntelliGitView {
                           `bodyChars=${summary.bodyChars} ` +
                           `bootstrap=${summary.bootstrapped ? "yes" : "no"} ` +
                           `root=<children:${summary.rootChildren} chars:${summary.rootChars}> ` +
+                          `hydration=${describeHydration(summary.hydration)} ` +
                           `testIds=${JSON.stringify(summary.testIds)}`;
             }),
         );

--- a/tests/unit/e2e/pageObjects.test.ts
+++ b/tests/unit/e2e/pageObjects.test.ts
@@ -339,6 +339,7 @@ describe("IntelliGitView", () => {
     function webview(
         markers: readonly string[] | undefined,
         title = "IntelliGit",
+        hydration?: { asks: number; hostMessages: number; lastHostMessageType: string | null },
     ): {
         outer: unknown;
         inner: unknown;
@@ -369,7 +370,16 @@ describe("IntelliGitView", () => {
                         extract({
                             ownerDocument: {
                                 title,
-                                defaultView: { intelligitI18n: {} },
+                                // A real webview carries the hydration counters only while the
+                                // E2E gate is on and only once its handshake effect has run, so
+                                // the absent case is modelled by leaving the key off entirely --
+                                // the same shape a document that never reached the effect has.
+                                defaultView: {
+                                    intelligitI18n: {},
+                                    ...(hydration
+                                        ? { intelligitHydrationDiagnostics: hydration }
+                                        : {}),
+                                },
                                 getElementById: (id: string) => (id === "root" ? root : null),
                             },
                             innerHTML: `<div id="root">${rendered}</div>`,
@@ -515,7 +525,45 @@ describe("IntelliGitView", () => {
         const { page } = workbenchPage([webview([])]);
 
         await expect(new IntelliGitView(page).revealPanel(50)).rejects.toThrow(
-            /bootstrap=yes root=<children:0 chars:0> testIds=\[\]/,
+            /bootstrap=yes root=<children:0 chars:0> hydration=\(none\) testIds=\[\]/,
+        );
+    });
+
+    /**
+     * `bootstrap=yes root=<children:2` says the app mounted and was given nothing. It does not say
+     * WHICH leg of the handshake failed, and the three CI failures this instrument was built from
+     * were byte-identical on every other field -- same `root`, same console, three different flows
+     * across two runs. The counters are the only field that differs by cause, so each shape is
+     * pinned here: a document that never reached the effect, and one whose asks went unanswered.
+     */
+    it("reports a handshake that never started apart from one that went unanswered", async () => {
+        const { page: silent } = workbenchPage([webview([])]);
+        await expect(new IntelliGitView(silent).revealPanel(50)).rejects.toThrow(
+            /hydration=\(none\)/,
+        );
+
+        const { page: asking } = workbenchPage([
+            webview([], "IntelliGit", { asks: 17, hostMessages: 0, lastHostMessageType: null }),
+        ]);
+        await expect(new IntelliGitView(asking).revealPanel(50)).rejects.toThrow(
+            /hydration=<asks:17 received:0 last:null>/,
+        );
+    });
+
+    // The other side of the same fork: the host IS answering and the panel still shows nothing, so
+    // the defect is in what the reducer does with the answer rather than in delivery. A report that
+    // collapsed both into "not hydrated" would send the next investigation to the wrong process.
+    it("reports an answered handshake that failed to hydrate", async () => {
+        const { page } = workbenchPage([
+            webview([], "IntelliGit", {
+                asks: 3,
+                hostMessages: 4,
+                lastHostMessageType: "setRepositories",
+            }),
+        ]);
+
+        await expect(new IntelliGitView(page).revealPanel(50)).rejects.toThrow(
+            /hydration=<asks:3 received:4 last:"setRepositories">/,
         );
     });
 

--- a/tests/webview/unit/commit-panel-hydration-handshake.test.tsx
+++ b/tests/webview/unit/commit-panel-hydration-handshake.test.tsx
@@ -198,6 +198,46 @@ describe("commit-panel hydration handshake", () => {
         }
     });
 
+    /**
+     * The diagnostics global is the only thing that will name WHICH leg of this handshake dropped
+     * the next time CI produces a blank panel, so it has to be wired to the handshake itself
+     * rather than to a counter that happens to agree with it. Asserted as an identity against the
+     * posts the rest of this file measures: "at least one ask" would still pass for a recorder
+     * that fired once and then went quiet, which is precisely the failure the counter exists to
+     * report.
+     */
+    it("records every ask and every host message for the E2E timeout dump", async () => {
+        window.intelligitE2E = true;
+        const { root, host } = await mountHarness();
+        try {
+            await advance(4_000);
+            const diagnostics = window.intelligitHydrationDiagnostics;
+
+            expect(
+                diagnostics?.asks,
+                "the recorder must count the same asks the host actually received, or a dump " +
+                    "reading `asks:1` would exonerate a retry loop that had in fact stopped",
+            ).toBe(readyCount());
+            expect(
+                diagnostics?.hostMessages,
+                "nothing has been sent back yet, so a non-zero count here would mean the " +
+                    "instrument invents traffic and can never prove the host stayed silent",
+            ).toBe(0);
+
+            await act(async () => sendRepositoryList([]));
+
+            expect(window.intelligitHydrationDiagnostics).toMatchObject({
+                hostMessages: 1,
+                lastHostMessageType: "setRepositories",
+            });
+        } finally {
+            await act(async () => root.unmount());
+            host.remove();
+            delete (window as unknown as Record<string, unknown>).intelligitHydrationDiagnostics;
+            delete (window as unknown as Record<string, unknown>).intelligitE2E;
+        }
+    });
+
     it("stops retrying when the panel is torn down", async () => {
         const { root, host } = await mountHarness();
         await act(async () => root.unmount());

--- a/tests/webview/unit/hydration-diagnostics.test.ts
+++ b/tests/webview/unit/hydration-diagnostics.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+    recordHostMessage,
+    recordHydrationAsk,
+} from "../../../src/webviews/react/shared/hydrationDiagnostics";
+
+/** The global under test, read by `tests/e2e/pageObjects/intelliGitView.ts`'s timeout dump. */
+const GLOBAL_KEY = "intelligitHydrationDiagnostics";
+
+function readDiagnostics(): unknown {
+    return (window as unknown as Record<string, unknown>)[GLOBAL_KEY];
+}
+
+afterEach(() => {
+    // Unstubbed first: the no-window case replaces `window` with `undefined`, and cleanup that
+    // reached for its properties would fail in the very test that proves the guard works.
+    vi.unstubAllGlobals();
+    delete (window as unknown as Record<string, unknown>)[GLOBAL_KEY];
+    delete (window as unknown as Record<string, unknown>).intelligitE2E;
+});
+
+describe("hydration diagnostics", () => {
+    it("allocates nothing when the E2E gate is off", () => {
+        recordHydrationAsk();
+        recordHostMessage({ type: "setRepositories" });
+
+        expect(
+            readDiagnostics(),
+            "a production webview must not grow a diagnostic global just because the hook called " +
+                "a recorder -- the gate-off path is the one every user runs, and `undefined` here " +
+                "is the only evidence that nothing was allocated",
+        ).toBeUndefined();
+    });
+
+    it("counts asks and host messages once the gate is on", () => {
+        window.intelligitE2E = true;
+
+        recordHydrationAsk();
+        recordHydrationAsk();
+        recordHostMessage({ type: "setRepositories" });
+
+        expect(readDiagnostics()).toEqual({
+            asks: 2,
+            hostMessages: 1,
+            lastHostMessageType: "setRepositories",
+        });
+    });
+
+    it("counts a host message the reducer could never parse", () => {
+        window.intelligitE2E = true;
+
+        recordHostMessage("not-a-message");
+        recordHostMessage(null);
+        recordHostMessage({ type: 7 });
+
+        expect(
+            readDiagnostics(),
+            "the fork this instrument exists to split is `the host never answered` versus `the " +
+                "host answered and the webview ignored it`, so a payload no case matches is " +
+                "exactly the evidence that must still be counted",
+        ).toEqual({ asks: 0, hostMessages: 3, lastHostMessageType: null });
+    });
+
+    it("reports the most recent host message type, not the first", () => {
+        window.intelligitE2E = true;
+
+        recordHostMessage({ type: "setRepositories" });
+        recordHostMessage({ type: "update" });
+
+        expect(readDiagnostics()).toMatchObject({ lastHostMessageType: "update" });
+    });
+
+    it("does not throw outside a browser document", () => {
+        vi.stubGlobal("window", undefined);
+
+        expect(() => {
+            recordHydrationAsk();
+            recordHostMessage({ type: "setRepositories" });
+        }, "`getVsCodeApi` is exercised from plain Node unit tests, so a recorder that assumed a window would turn every one of them red").not.toThrow();
+    });
+});


### PR DESCRIPTION
## Why

`e2e-full` fails roughly 1 run in 3 with the Changes panel stuck on `commit-panel-awaiting-hydration`. This does **not** fix that. It makes the next occurrence diagnosable, because the current artifact provably cannot separate its remaining causes.

Evidence, from run [32411770447](https://github.com/MaheshKok/IntelliGit/actions/runs/32411770447)'s two failed `e2e-full` attempts (artifacts `9422524455`, `9422915422`) — three different flows, two different attempts:

```
#0: active-frame=1 title="Changes" bodyChars=33502 bootstrap=yes root=<children:2 chars:147> testIds=["commit-panel-awaiting-hydration"]
    console: 47 seen (2 from webviews); 5 error/warning:   <- all five are workbench sandbox/feature warnings
```

`push`, `shelf-apply` and `abort-active-operation` produced **byte-identical** `bodyChars`, `root` and console counts. The graph webview in the same sidebar hydrated fully in every one of them. So the panel mounted React, was answered nothing, and nothing anywhere logged a reason.

## What this could still be, and why the artifact can't say

`SET_REPOSITORIES` sets `hydrated: true` unconditionally, so the placeholder proves zero repository lists were applied. Three causes produce that identical dump:

1. the effect that posts `ready` never ran,
2. it ran, asked, and the host answered nothing,
3. the host answered and the reducer did not hydrate.

Static reasoning has run out on this: `postWebviewMessage` logs on every failure branch (`webviewDelivery.ts:58-66`) and the console is clean; `adoptLiveSender` (`CommitPanelViewProvider.ts:2101`) closes the cleared-`this.view` drop that #211 found; the webview attaches its listener before posting (`useExtensionMessages.ts:594-597`) and retries unbounded. Notably `CommitGraphViewProvider` has the *unhardened* version of the same `this.view` pattern and hydrates fine in every failing run — so the mechanism #211 fixed is not the one still biting.

## What changed

- **`src/webviews/react/shared/hydrationDiagnostics.ts`** (new) — two counters on a window global: `asks` (how many `ready` posts this document made) and `hostMessages` / `lastHostMessageType` (what came back). Runtime-gated on `window.intelligitE2E`, the same flag as the rest of the E2E control channel, so a production webview allocates nothing and carries no global.
- **`useExtensionMessages.ts`** — records each ask and each inbound message. The inbound recorder runs *before* the switch, so a payload no case matches still counts.
- **`tests/e2e/pageObjects/intelliGitView.ts`** — the reveal-timeout dump prints `hydration=(none)` / `hydration=<asks:N received:M last:"type">`, which is one field per cause above.

## Test plan

- [x] `tests/webview/unit/hydration-diagnostics.test.ts` (new, 5 cases incl. gate-off allocates nothing, unparseable payloads counted, no-window guard)
- [x] `tests/webview/unit/commit-panel-hydration-handshake.test.tsx` — new case asserts `asks` equals the `ready` posts the rest of that file measures, as an identity rather than `>= 1`
- [x] `tests/unit/e2e/pageObjects.test.ts` — two new cases pin each dump shape; the fake runs the real page-side callback
- [x] Mutations, each red on a named assertion: gate removed → "allocates nothing when the E2E gate is off"; `asks += 1` → `= 1` → "counts asks and host messages once the gate is on"; recorder unwired from the hook → "records every ask and every host message"; `hydration=` dropped from the dump → 3 dump cases; `describeHydration` pinned to `(none)` → 2 dump cases
- [x] `bun run test` — 295 files, 4122 tests passed. (A first run had one red, `tests/unit/visual/screenshotComparatorMeta.test.ts`; it passes in isolation in 3.9s, touches nothing here, and the re-run was clean — recorded as a flake rather than ignored.)
- [x] `typecheck`, `lint:strict`, `format:check`, `build`, and the pre-commit hook's nine checks including `knip` and the VSIX package
- [ ] The instrument itself is unproven against the real failure — that is the point of it. It earns its proof on the next `e2e-full` run that goes red.

## Version

`0.27.1`, with a CHANGELOG entry that says plainly this changes no behaviour a user can see.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for webview hydration handshakes, including request counts, host responses, and the latest message type.
  * Enhanced failure reporting to distinguish between unstarted, unanswered, and unsuccessful hydration attempts.

* **Tests**
  * Added coverage for hydration diagnostics, malformed messages, disabled diagnostics, and browser-independent behavior.

* **Chores**
  * Updated the extension version to 0.27.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->