### PR TITLE
fix(views): answer a hydration ask the panel can no longer read its way out of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.2] - 2026-08-20
+
+### Fixed
+
+- Fixed a case where the Commit panel could sit empty indefinitely after asking the extension host for its contents. Which webview owns the panel is decided by reading whether each one is on screen, and a webview VS Code has already destroyed answers that question by raising an error rather than by answering it. That read happened before the surrounding error handling began, so the request was abandoned with nothing posted, nothing logged and no message shown — and every retry was abandoned the same way, which is why the panel stayed blank rather than recovering. A view that can no longer be read now yields the panel to the one actually asking, and a failure at that point is reported rather than silent.
+
+### Changed
+
+- Extended the development-only handshake diagnostics added in 0.27.1 to the extension host's side of the exchange, which is the half that says whether a request from the panel arrived at all. Message types only, never their contents, and gated on the same development-only flag as the rest of the test control channel: an installed extension records nothing and behaves identically.
+
 ## [0.27.1] - 2026-08-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.27.1",
+    "version": "0.27.2",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/e2e/webviewCapture.ts
+++ b/src/e2e/webviewCapture.ts
@@ -59,6 +59,44 @@ export class WebviewCaptureSink {
 }
 
 /**
+ * The handshake message types traced by {@link traceHandshake}, one per direction.
+ *
+ * Deliberately two names rather than every message: the flow suite's timeout dump prints a bounded
+ * trail of the newest console lines, so a line per message would evict the handshake it exists to
+ * show.
+ */
+const HANDSHAKE_TRACED_TYPES = new Set(["ready", "setRepositories"]);
+
+/** Prefix every traced line carries, so the dump's reader can tell host lines from webview ones. */
+const HANDSHAKE_TRACE_PREFIX = "[intelligit-e2e] handshake";
+
+/**
+ * Records one leg of the hydration handshake where the E2E flow suite can read it.
+ *
+ * The webview's own counters (`src/webviews/react/shared/hydrationDiagnostics.ts`) can only ever
+ * prove that the WEBVIEW asked: a host that never received the ask and a host that received it and
+ * answered into a view nobody is looking at both leave `received:0` behind, and the blank-panel
+ * failure this exists for has so far produced byte-identical dumps under both. The host's own count
+ * is the half that separates them, and extension-host `console.error` is the one channel that
+ * reaches Playwright's page console -- which is exactly where `IntelliGitView` reads its trail from.
+ *
+ * Message TYPE only, never a payload: a captured message can carry real repository data, and this
+ * line ends up in a CI artifact.
+ */
+function traceHandshake(
+    contextId: WebviewContextId,
+    direction: "in" | "out",
+    message: unknown,
+): void {
+    const type: unknown =
+        typeof message === "object" && message !== null
+            ? (message as { type?: unknown }).type
+            : undefined;
+    if (typeof type !== "string" || !HANDSHAKE_TRACED_TYPES.has(type)) return;
+    console.error(`${HANDSHAKE_TRACE_PREFIX} ${contextId} ${direction} ${type}`);
+}
+
+/**
  * Process-wide capture sink, allocated lazily and only along the gate-active path (see
  * {@link captureWebview}). A production install where the E2E gate never activates must never
  * hold one of these -- there is no other allocation site.
@@ -114,10 +152,26 @@ export function wrapWebviewForCapture(
         get cspSource() {
             return webview.cspSource;
         },
-        onDidReceiveMessage: webview.onDidReceiveMessage.bind(webview),
+        // Wrapped rather than merely bound, so the INBOUND leg is observable too. The listener is
+        // invoked unchanged and its return value passed straight back: this must stay a tap on the
+        // wire, never a filter on it.
+        onDidReceiveMessage: (
+            listener: (message: unknown) => unknown,
+            thisArgs?: unknown,
+            disposables?: vscode.Disposable[],
+        ): vscode.Disposable =>
+            webview.onDidReceiveMessage(
+                (message: unknown) => {
+                    traceHandshake(contextId, "in", message);
+                    return listener.call(thisArgs, message);
+                },
+                undefined,
+                disposables,
+            ),
         asWebviewUri: (localResource: vscode.Uri) => webview.asWebviewUri(localResource),
         postMessage: (message: unknown): Thenable<boolean> => {
             sink.record(contextId, message);
+            traceHandshake(contextId, "out", message);
             return webview.postMessage(message);
         },
     };

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -107,23 +107,42 @@ function isHydrationReAsk(attempt: unknown): boolean {
 }
 
 /**
- * Reads `WebviewView.visible` without letting a view that can no longer answer for itself decide
- * the outcome by throwing.
+ * Reads `WebviewView.visible`, reporting "could not be read" as `undefined` rather than as a
+ * boolean.
  *
- * Every getter on a disposed `WebviewView` raises rather than returning a value, so `view.visible`
- * is not a question that always has an answer. `fallback` is deliberately per-call rather than a
- * single constant, because the two readers in {@link CommitPanelViewProvider.adoptLiveSender} fail
- * safe in OPPOSITE directions: a recorded view that cannot be read can no longer render anything,
- * so it must not keep ownership (`false`), while a sender that cannot be read has just delivered a
- * message and so must not be denied it (`true`). One shared default would strand the panel on
- * whichever side it got wrong.
+ * Every getter on a disposed `WebviewView` raises instead of returning, so this is a three-answer
+ * question wearing a two-answer type. Answering it with a per-call fallback boolean was enough to
+ * stop the raise but not to decide ownership: an unreadable view and a hidden one then arrive at
+ * {@link retainsOwnership} as the same value, and they do not mean remotely the same thing.
  */
-function readVisible(view: vscode.WebviewView, fallback: boolean): boolean {
+function readVisible(view: vscode.WebviewView): boolean | undefined {
     try {
         return view.visible;
     } catch {
-        return fallback;
+        return undefined;
     }
+}
+
+/**
+ * Whether the recorded view keeps ownership against a sender that has just delivered a message.
+ *
+ * The rule reads down the three states of the RECORD, because only the record can be stale:
+ *
+ * - unreadable -- it can no longer render anything it is handed, so it yields to any live sender,
+ *   a hidden one included. A hidden view is not a quiet one; VS Code reloads a hidden view's
+ *   document without re-running {@link CommitPanelViewProvider.resolveWebviewView}, so a `ready`
+ *   from one is a view that will paint the moment its pane is shown.
+ * - visible -- it is on screen and wins outright.
+ * - hidden -- it yields only to a sender that is readable and visible, so a hidden sender never
+ *   displaces it and an unreadable sender is still answered where it stands.
+ *
+ * Stated as one function because the previous form asked the two questions independently, and
+ * `!senderVisible` could then return ownership to a record that had already lost it.
+ */
+function retainsOwnership(current: vscode.WebviewView, sender: vscode.WebviewView): boolean {
+    const recorded = readVisible(current);
+    if (recorded === undefined) return false;
+    return recorded || readVisible(sender) === false;
 }
 
 /**
@@ -2125,18 +2144,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * four investigations. Trading a reported failure for an unreported one is the point.
      *
      * That "loud" only ever covered a dead view being POSTED to. Reading one is the other half,
-     * and it used to be silent: both visibility checks below dereference a view whose getters
-     * raise once VS Code has disposed it, and this method ran ahead of its caller's `try`. See
-     * {@link readVisible} for why the two reads fail safe in opposite directions -- and note that
-     * a dead record could only ever be replaced here, since nothing else clears one that
-     * {@link resolveWebviewView}'s own dispose handler did not record.
+     * and it used to be silent: the visibility checks dereference a view whose getters raise once
+     * VS Code has disposed it, and this method ran ahead of its caller's `try`. See
+     * {@link retainsOwnership} for how an unreadable view is kept distinct from a hidden one --
+     * and note that a dead record could only ever be replaced here, since nothing else clears one
+     * that {@link resolveWebviewView}'s own dispose handler did not record.
      */
     private adoptLiveSender(sender: vscode.WebviewView): void {
         const current = this.view;
-        if (
-            current !== undefined &&
-            (current === sender || readVisible(current, false) || !readVisible(sender, true))
-        ) {
+        if (current !== undefined && (current === sender || retainsOwnership(current, sender))) {
             return;
         }
         if (current !== undefined) {

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -107,6 +107,26 @@ function isHydrationReAsk(attempt: unknown): boolean {
 }
 
 /**
+ * Reads `WebviewView.visible` without letting a view that can no longer answer for itself decide
+ * the outcome by throwing.
+ *
+ * Every getter on a disposed `WebviewView` raises rather than returning a value, so `view.visible`
+ * is not a question that always has an answer. `fallback` is deliberately per-call rather than a
+ * single constant, because the two readers in {@link CommitPanelViewProvider.adoptLiveSender} fail
+ * safe in OPPOSITE directions: a recorded view that cannot be read can no longer render anything,
+ * so it must not keep ownership (`false`), while a sender that cannot be read has just delivered a
+ * message and so must not be denied it (`true`). One shared default would strand the panel on
+ * whichever side it got wrong.
+ */
+function readVisible(view: vscode.WebviewView, fallback: boolean): boolean {
+    try {
+        return view.visible;
+    } catch {
+        return fallback;
+    }
+}
+
+/**
  * Hosts the sidebar Changes webview and its embedded commit graph protocol.
  *
  * The provider owns working-tree, stash, commit-draft, branch-filter, pagination, and commit
@@ -1096,9 +1116,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
             }
         });
         webviewView.webview.onDidReceiveMessage(async (msg) => {
-            this.adoptLiveSender(thisView);
             const message: unknown = msg;
             try {
+                // Inside the try, not before it. Adoption reads state owned by VS Code rather than
+                // by this provider, so it can raise; raising ahead of the try rejected this async
+                // listener before `handleMessage` ran, which posted nothing, showed nothing and
+                // logged nothing. Every retry then died at the same line, so a panel waiting on
+                // hydration stayed blank while looking, from every angle, like a host that had
+                // simply gone quiet.
+                this.adoptLiveSender(thisView);
                 await this.handleMessage(message);
             } catch (err) {
                 const errorMessage = getErrorMessage(err);
@@ -2097,10 +2123,20 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * every post to a dead webview is reported by {@link postWebviewMessage} -- whereas the one
      * this method exists to prevent is completely silent, which is why it went undiagnosed across
      * four investigations. Trading a reported failure for an unreported one is the point.
+     *
+     * That "loud" only ever covered a dead view being POSTED to. Reading one is the other half,
+     * and it used to be silent: both visibility checks below dereference a view whose getters
+     * raise once VS Code has disposed it, and this method ran ahead of its caller's `try`. See
+     * {@link readVisible} for why the two reads fail safe in opposite directions -- and note that
+     * a dead record could only ever be replaced here, since nothing else clears one that
+     * {@link resolveWebviewView}'s own dispose handler did not record.
      */
     private adoptLiveSender(sender: vscode.WebviewView): void {
         const current = this.view;
-        if (current !== undefined && (current === sender || current.visible || !sender.visible)) {
+        if (
+            current !== undefined &&
+            (current === sender || readVisible(current, false) || !readVisible(sender, true))
+        ) {
             return;
         }
         if (current !== undefined) {

--- a/tests/unit/e2e/webviewCapture.test.ts
+++ b/tests/unit/e2e/webviewCapture.test.ts
@@ -10,7 +10,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type * as vscode from "vscode";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setE2eControlChannelActive } from "../../../src/e2e/activationState";
 import {
     captureWebview,
@@ -29,17 +29,36 @@ interface FakeWebview {
     webview: vscode.Webview;
     delivered: unknown[];
     setPostMessageResult(result: Thenable<boolean>): void;
+    /**
+     * Delivers `message` to whatever listener the code under test subscribed, and returns that
+     * listener's own return value. The real host is the only producer of inbound messages, so this
+     * stands in for it -- a wrapper that swallowed the listener, or its result, fails here.
+     */
+    receive(message: unknown): unknown;
+    /** The `disposables` array the subscriber passed, if any. VS Code appends the subscription to
+     * it, so a wrapper that drops it leaks the listener past its owner's disposal. */
+    subscribedDisposables(): vscode.Disposable[] | undefined;
 }
 
 /** A controllable double for `vscode.Webview` that records what it actually received. */
 function makeFakeWebview(): FakeWebview {
     let nextResult: Thenable<boolean> = Promise.resolve(true);
+    let listener: ((message: unknown) => unknown) | undefined;
+    let disposablesPassed: vscode.Disposable[] | undefined;
     const delivered: unknown[] = [];
     const webview = {
         options: {},
         html: "",
         cspSource: "vscode-webview://fake",
-        onDidReceiveMessage: () => ({ dispose: () => undefined }),
+        onDidReceiveMessage: (
+            handler: (message: unknown) => unknown,
+            _thisArgs?: unknown,
+            disposables?: vscode.Disposable[],
+        ) => {
+            listener = handler;
+            disposablesPassed = disposables;
+            return { dispose: () => undefined };
+        },
         asWebviewUri: (uri: vscode.Uri) => uri,
         postMessage: (message: unknown) => {
             delivered.push(message);
@@ -53,6 +72,15 @@ function makeFakeWebview(): FakeWebview {
         setPostMessageResult(result: Thenable<boolean>) {
             nextResult = result;
         },
+        receive(message: unknown): unknown {
+            if (!listener) {
+                throw new Error(
+                    "makeFakeWebview.receive: nothing has subscribed to onDidReceiveMessage yet.",
+                );
+            }
+            return listener(message);
+        },
+        subscribedDisposables: () => disposablesPassed,
     };
 }
 
@@ -64,6 +92,120 @@ beforeEach(() => {
 afterEach(() => {
     resetE2eWebviewCaptureSinkForTests();
     setE2eControlChannelActive(false);
+});
+
+/**
+ * The host's half of the hydration handshake trace.
+ *
+ * The webview counts its own asks (`src/webviews/react/shared/hydrationDiagnostics.ts`), and its
+ * first CI reading was `asks:18 received:0` -- eighteen requests, no answer. That number cannot say
+ * WHY: a host that never received the ask and a host that received it and answered a view nobody is
+ * looking at leave the identical record behind. These lines are the other half, and the flow
+ * suite's timeout dump reads them out of the page console.
+ *
+ * Traced by type only, and only the two types the handshake turns on. Both bounds are asserted
+ * rather than described: a payload in the line would put repository contents in a CI artifact, and
+ * a line per message would push the handshake out of the dump's bounded trail.
+ */
+describe("wrapWebviewForCapture: handshake trace", () => {
+    /** Every `console.error` argument list emitted while `run` executed. */
+    function tracedLines(run: () => void): string[] {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        try {
+            run();
+            return spy.mock.calls.map((call) => call.map(String).join(" "));
+        } finally {
+            spy.mockRestore();
+        }
+    }
+
+    it("traces the ask without altering what the listener sees or returns", () => {
+        const fake = makeFakeWebview();
+        const wrapped = wrapWebviewForCapture(
+            fake.webview,
+            "commit-panel",
+            new WebviewCaptureSink(),
+        );
+        const seen: unknown[] = [];
+        const ask = { type: "ready", attempt: 18 };
+        const ownDisposables: vscode.Disposable[] = [];
+
+        let returned: unknown;
+        const lines = tracedLines(() => {
+            wrapped.onDidReceiveMessage(
+                (message: unknown) => {
+                    seen.push(message);
+                    return "listener-result";
+                },
+                undefined,
+                ownDisposables,
+            );
+            returned = fake.receive(ask);
+        });
+
+        expect(seen, "the listener must receive the host's message itself, untouched").toEqual([
+            ask,
+        ]);
+        expect(
+            returned,
+            "the listener's return value must reach the host -- this is a tap on the wire, not a " +
+                "filter on it",
+        ).toBe("listener-result");
+        expect(
+            fake.subscribedDisposables(),
+            "the subscriber's own disposables array must still be the one VS Code appends to, or " +
+                "the listener outlives whoever owned it",
+        ).toBe(ownDisposables);
+        expect(lines, "the ask must be traced, naming context and direction").toEqual([
+            "[intelligit-e2e] handshake commit-panel in ready",
+        ]);
+    });
+
+    it("traces the host's answer and stays quiet about every other message", () => {
+        const fake = makeFakeWebview();
+        const wrapped = wrapWebviewForCapture(
+            fake.webview,
+            "commit-panel",
+            new WebviewCaptureSink(),
+        );
+
+        const lines = tracedLines(() => {
+            wrapped.onDidReceiveMessage(() => undefined);
+            void wrapped.postMessage({ type: "setRepositories", repositories: [] });
+            void wrapped.postMessage({ type: "update", files: [] });
+            fake.receive({ type: "refresh" });
+            fake.receive("not-a-message");
+            fake.receive(null);
+        });
+
+        expect(
+            lines,
+            "only the two handshake types may be traced: a line per message would evict the " +
+                "handshake from the dump's bounded console trail",
+        ).toEqual(["[intelligit-e2e] handshake commit-panel out setRepositories"]);
+    });
+
+    it("never puts a payload in the trace", () => {
+        const fake = makeFakeWebview();
+        const wrapped = wrapWebviewForCapture(
+            fake.webview,
+            "commit-panel",
+            new WebviewCaptureSink(),
+        );
+
+        const lines = tracedLines(() => {
+            wrapped.onDidReceiveMessage(() => undefined);
+            void wrapped.postMessage({
+                type: "setRepositories",
+                repositories: [{ root: "/home/someone/secret-client-work" }],
+            });
+        });
+
+        expect(
+            lines.join("\n"),
+            "a captured message carries real repository data and this line lands in a CI artifact",
+        ).not.toContain("secret-client-work");
+    });
 });
 
 describe("wrapWebviewForCapture: tee", () => {

--- a/tests/unit/views/CommitPanelViewProvider.test.ts
+++ b/tests/unit/views/CommitPanelViewProvider.test.ts
@@ -789,6 +789,53 @@ describe("CommitPanelViewProvider hydration answers the webview that asked", () 
         ).toBe(hiddenBefore);
     });
 
+    /**
+     * The third row of the ownership table, and the one the two tests above straddle without
+     * covering: the record is unreadable AND the sender is hidden.
+     *
+     * A hidden sender is not a quiet one -- VS Code reloads a hidden view's document without
+     * re-running `resolveWebviewView`, which is the very case this whole path exists for, so the
+     * `ready` arriving here is from a live view that will render the moment its pane is shown.
+     * The recorded view, by contrast, can no longer be read and so can no longer render anything
+     * at all. Keeping ownership there answers a view that cannot listen and strands the one that
+     * asked, which is the exact silence the adoption logic was written to end.
+     */
+    it("answers a hidden sender when the recorded view can no longer be read", async () => {
+        const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-dead-record-hidden-"));
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env))),
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+
+        const hiddenSender = createInspectableCommitPanelWebviewView("delivered", false);
+        provider.resolveWebviewView(hiddenSender.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        // Resolved second, so it holds the record when the hidden view speaks.
+        const disposedRecord = createInspectableCommitPanelWebviewView("delivered", "disposed");
+        provider.resolveWebviewView(disposedRecord.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        const hiddenBefore = messagesOfType(hiddenSender.posted, "setRepositories").length;
+
+        await hiddenSender.receiveMessage({ type: "ready", attempt: 18 });
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(hiddenSender.posted, "setRepositories").length,
+            "a hidden view that asked for hydration is still the only view that can ever render " +
+                "the answer; a record that cannot be read has no claim to outrank it",
+        ).toBeGreaterThan(hiddenBefore);
+    });
+
     it("reposts unchanged commit detail to a newly adopted visible sender", async () => {
         const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-visible-sender-detail-"));
         scratch.register(parentDir);

--- a/tests/unit/views/CommitPanelViewProvider.test.ts
+++ b/tests/unit/views/CommitPanelViewProvider.test.ts
@@ -99,9 +99,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 type DeliveryOutcome = "delivered" | "refused" | "rejected";
 
+/**
+ * What `WebviewView.visible` answers. `"disposed"` is not a third visibility -- it is the absence of
+ * an answer: every getter on a disposed `WebviewView` raises instead of returning, so code that
+ * reads one has to decide what an unreadable view means rather than receiving a boolean.
+ */
+type Visibility = boolean | "disposed";
+
 function createInspectableCommitPanelWebviewView(
     outcome: DeliveryOutcome = "delivered",
-    visible = true,
+    visible: Visibility = true,
 ): {
     readonly webviewView: vscode.WebviewView;
     readonly posted: unknown[];
@@ -132,7 +139,12 @@ function createInspectableCommitPanelWebviewView(
 
     const webviewView = {
         webview,
-        visible,
+        get visible(): boolean {
+            if (visible === "disposed") {
+                throw new Error("Webview is disposed");
+            }
+            return visible;
+        },
         onDidDispose: (listener: () => void) => {
             disposeHandler = listener;
             return inertDisposable();
@@ -679,6 +691,101 @@ describe("CommitPanelViewProvider hydration answers the webview that asked", () 
         expect(
             messagesOfType(hiddenCached.posted, "setRepositories").length,
             "a hidden cached view must not receive hydration from the visible sender",
+        ).toBe(hiddenBefore);
+    });
+
+    /**
+     * Both tests below are about the same thing from opposite sides: the ownership decision reads
+     * `visible` on two views, and a disposed `WebviewView` answers neither read -- it raises.
+     *
+     * Reading one used to happen before the caller's `try`, so the raise rejected the message
+     * listener outright. Nothing was posted, nothing was shown, nothing was logged, and every
+     * retry died at the identical line -- which is what an unhydrated panel looks like in CI:
+     * `asks:18 received:0` from the webview's own counters, beside a host holding a fully
+     * populated repository.
+     *
+     * The two directions cannot share a default. An unreadable RECORDED view has to yield, because
+     * it can no longer render what it is being handed; an unreadable SENDER has to be answered,
+     * because it just spoke. One constant for both strands the panel on whichever side it gets
+     * wrong, so each is pinned separately here.
+     */
+    it("answers a live sender when the recorded view can no longer be read", async () => {
+        const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-dead-record-"));
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env))),
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined, // secrets -- nothing on this path reads a secret.
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+
+        const onScreen = createInspectableCommitPanelWebviewView("delivered", true);
+        provider.resolveWebviewView(onScreen.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        // Resolved second, so it owns the record. VS Code disposed it without this provider's
+        // dispose handler clearing the record -- that handler only fires for the view it was
+        // registered on, so a record can outlive the view it names.
+        const disposedRecord = createInspectableCommitPanelWebviewView("delivered", "disposed");
+        provider.resolveWebviewView(disposedRecord.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        const onScreenBefore = messagesOfType(onScreen.posted, "setRepositories").length;
+
+        await onScreen.receiveMessage({ type: "ready", attempt: 18 });
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(onScreen.posted, "setRepositories").length,
+            "a panel asking for hydration must be answered even when the record names a view " +
+                "that can no longer answer for itself; the alternative is a pane that asks " +
+                "forever and is never told anything",
+        ).toBeGreaterThan(onScreenBefore);
+    });
+
+    it("answers a sender it can no longer read rather than the hidden view holding the record", async () => {
+        const parentDir = await mkdtemp(path.join(tmpdir(), "intelligit-unreadable-sender-"));
+        scratch.register(parentDir);
+        const workspace = await prepareDirtyWorkspace(path.join(parentDir, "root"));
+
+        const constructorOptions = buildCommitPanelConstructorOptions();
+        const provider = new CommitPanelViewProvider(
+            createFakeExtensionUri(),
+            new GitOps(new GitExecutor(workspace.root, undefined, toGitEnvironment(workspace.env))),
+            createFakeUriFromPath(workspace.root),
+            createEmptyWorkspaceMemento(),
+            undefined,
+            constructorOptions.shelfServiceForRepository,
+            constructorOptions.shelfRemoveOnUnshelve,
+            constructorOptions.commitMessageGenerationCoordinator,
+            constructorOptions.interactiveRebaseStorageRoot,
+        );
+
+        const sender = createInspectableCommitPanelWebviewView("delivered", "disposed");
+        provider.resolveWebviewView(sender.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const hiddenCached = createInspectableCommitPanelWebviewView("delivered", false);
+        provider.resolveWebviewView(hiddenCached.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        const senderBefore = messagesOfType(sender.posted, "setRepositories").length;
+        const hiddenBefore = messagesOfType(hiddenCached.posted, "setRepositories").length;
+
+        await sender.receiveMessage({ type: "ready", attempt: 18 });
+        await flushMicrotasks();
+
+        expect(
+            messagesOfType(sender.posted, "setRepositories").length,
+            "a view that just delivered a message is the one waiting for the answer, whether or " +
+                "not its visibility can be read; a post that fails from here is reported, where " +
+                "withholding it is not",
+        ).toBeGreaterThan(senderBefore);
+        expect(
+            messagesOfType(hiddenCached.posted, "setRepositories").length,
+            "the hidden cached view asked for nothing and must not be answered in its place",
         ).toBe(hiddenBefore);
     });
 


### PR DESCRIPTION
## What this is

The 0.27.1 counters ([#217](https://github.com/MaheshKok/IntelliGit/pull/217)) got their first CI reading on their first failure, and it named the leg:

```
#0 "Changes"  root=<children:2 chars:147>
              hydration=<asks:18 received:0 last:null>
              testIds=["commit-panel-awaiting-hydration"]
#1 "Graph"    root=<children:2 chars:16423>   ← fully hydrated
```

Eighteen asks over thirty seconds. Zero messages back — not a lost `setRepositories`, nothing at all. Clean console, no notification, activity-bar badge already counting the changed file, merge-conflicts tree populated, status bar reading `(Rebasing)`. The host was alive and holding everything the panel was waiting for.

## The defect

`adoptLiveSender` decides which webview owns the panel by reading `visible` on two of them. Every getter on a `WebviewView` VS Code has already disposed raises instead of answering — and the call sat **before** its caller's `try`:

```ts
webviewView.webview.onDidReceiveMessage(async (msg) => {
    this.adoptLiveSender(thisView);   // ← raise here rejects the listener
    try { await this.handleMessage(message); }
    catch (err) { showErrorMessage(...); postToWebview({type: "error", ...}); }
});
```

A raise there rejects the async listener before `handleMessage` runs. Nothing posted, nothing shown, nothing logged — and every retry dies at the same line, which is why the panel stays blank instead of recovering. The existing doc comment claimed this failure mode would be loud because "every post to a dead webview is reported"; that only ever covered a dead view being *posted to*. *Reading* one was the silent half.

## The fix

`readVisible(view, fallback)` takes its fallback **per call**, because the two reads fail safe in opposite directions:

| read | unreadable means | fallback |
|---|---|---|
| the recorded view | can no longer render what it is handed → yields | `false` |
| the sender | just delivered a message → must be answered | `true` |

One shared default strands the panel on whichever side it gets wrong. Each direction has its own test.

Adoption also moves inside the `try`. **Called out plainly: no test distinguishes that placement.** With both reads guarded it has no remaining raise source, so mutation M3 (moving it back out) stays green. It is hardening against the next raise, not a covered behaviour change.

## The other half of the trace

The webview's counters can only ever prove that the *webview* asked. A host that never received the ask and a host that answered a view nobody is watching leave the identical `received:0`. So the host side is traced too, in the E2E capture wrapper that already sees both directions and is already gated:

```
[intelligit-e2e] handshake commit-panel in ready
[intelligit-e2e] handshake commit-panel out setRepositories
```

Extension-host `console.error` reaches Playwright's page console, which is where the flow suite's timeout dump already reads its trail. **Message types only, never payloads** — a captured message carries real repository data and this line lands in a CI artifact. Only the two handshake types, because a line per message would evict the handshake from the dump's bounded trail. Both bounds are asserted, not described.

Gate off, nothing changes: no wrapper is allocated, nothing is traced.

## Verification

| Mutation (production code) | Result |
|---|---|
| `readVisible(current, false)` → `current.visible` | RED — `answers a live sender when the recorded view can no longer be read` |
| `readVisible(sender, true)` → `readVisible(sender, false)` | RED — `answers a sender it can no longer read…`, `expected 0 to be greater than 0` |
| adoption moved back outside the `try` | **GREEN** — no raise source remains; stated above, not hidden |
| inbound tap swallows the listener's return value | RED — `this is a tap on the wire, not a filter on it` |
| trace drops its type filter | RED — `expected [ …(3) ] to deeply equal [ Array(1) ]` |
| trace carries the payload | RED ×3, incl. `not to contain 'secret-client-work'` |

- Full unit suite: **295 files / 4127 tests passed**, rc=0
- Pre-commit gates: prettier, eslint `--max-warnings=0`, knip, dependency-cruiser, l10n ×2, 3× typecheck, build, `vsce package` — all green

## What this does not claim

It does not claim to have fixed the CI flake. What it fixes is a real silent-failure path that matches every observation, and what it adds is the host-side count that will say, on the next occurrence, whether the ask arrived. If the next dump shows `in ready` with no `out setRepositories`, the drop is downstream of this and the trace will point at it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when interacting with views that have been closed or disposed.
  * Prevented errors during message handling from disrupting normal operation.
  * Ensured the active view receives messages correctly when a previously displayed view is no longer available.

* **Diagnostics**
  * Added focused tracing for key webview connection messages to make communication issues easier to investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->