### PR TITLE
fix(ci): compare Insiders theme tokens one at a time, not as one string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.3] - 2026-08-22
+
+### Changed
+
+- The nightly comparison between the pinned VS Code build and Insiders now reads the workbench's theme tokens one at a time instead of as a single string, and reports only the tokens the newer build dropped or gave a different value. Upstream adds theme tokens continuously — one night's run added twenty-five and changed two — and comparing the block as one string called every addition a difference, so the check stood red for a week over tokens this extension never reads, which is the same as having no check at all. A token that disappears or changes value underneath a webview can still break it, so those are still reported, and the failure now names just those tokens rather than printing nine hundred identical ones on either side of a truncation limit. The separate staleness check is deliberately unchanged and still compares byte for byte: both of its sides come from the same pinned build, so there an added token does mean the committed fixture needs recapturing. This is test infrastructure only — nothing an installed extension does changes.
+
 ## [0.27.2] - 2026-08-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.27.2",
+    "version": "0.27.3",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/tests/e2e/hostFixtures/canonicalizeHostFixture.ts
+++ b/tests/e2e/hostFixtures/canonicalizeHostFixture.ts
@@ -7,19 +7,19 @@
 // a `dataset`) can never make two otherwise-identical captures differ.
 
 /**
- * Canonicalizes a raw `element.style.cssText` string: keeps only `--*`
- * custom properties (the `--vscode-*` theme tokens), sorts them by name, and
- * renders each as `name: value;` joined by a single space.
+ * Parses a raw `element.style.cssText` string into its `--*` custom properties
+ * (the `--vscode-*` theme tokens), keyed by name. Non-custom declarations are
+ * dropped, and a repeated name keeps its last value the way the browser
+ * resolves a declaration block -- a real `cssText` read back out of a
+ * `CSSStyleDeclaration` never carries one twice, because `setProperty`
+ * overwrites in place.
  *
- * Raw `cssText` order reflects `Object.entries()` iteration order over VS
- * Code's internal theme-token map when it wrote the properties
- * (`documentStyle.setProperty` in a `for...of` loop, see
- * `out/vs/workbench/contrib/webview/browser/pre/index.html`'s
- * `applyStyles`) -- an implementation detail, not a contract. Sorting here is
- * what turns "recapture and byte-compare" from order-flaky into meaningful.
+ * Split out of `canonicalizeStyleCssText` so the comparator can reason about
+ * individual tokens rather than re-implementing this loop against the same
+ * string it already canonicalized.
  */
-export function canonicalizeStyleCssText(cssText: string): string {
-    const properties: Array<{ readonly name: string; readonly value: string }> = [];
+export function parseStyleCustomProperties(cssText: string): ReadonlyMap<string, string> {
+    const properties = new Map<string, string>();
 
     for (const rawDeclaration of cssText.split(";")) {
         const declaration = rawDeclaration.trim();
@@ -32,11 +32,31 @@ export function canonicalizeStyleCssText(cssText: string): string {
         const value = declaration.slice(colonIndex + 1).trim();
         if (!name.startsWith("--")) continue;
 
-        properties.push({ name, value });
+        properties.set(name, value);
     }
 
-    properties.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-    return properties.map(({ name, value }) => `${name}: ${value};`).join(" ");
+    return properties;
+}
+
+/**
+ * Canonicalizes a raw `element.style.cssText` string: keeps only `--*`
+ * custom properties (the `--vscode-*` theme tokens), sorts them by name, and
+ * renders each as `name: value;` joined by a single space.
+ *
+ * Raw `cssText` order reflects `Object.entries()` iteration order over VS
+ * Code's internal theme-token map when it wrote the properties
+ * (`documentStyle.setProperty` in a `for...of` loop, see
+ * `out/vs/workbench/contrib/webview/browser/pre/index.html`'s
+ * `applyStyles`) -- an implementation detail, not a contract. Sorting here is
+ * what turns "recapture and byte-compare" from order-flaky into meaningful.
+ */
+export function canonicalizeStyleCssText(cssText: string): string {
+    return [...parseStyleCustomProperties(cssText)]
+        .sort(([leftName], [rightName]) =>
+            leftName < rightName ? -1 : leftName > rightName ? 1 : 0,
+        )
+        .map(([name, value]) => `${name}: ${value};`)
+        .join(" ");
 }
 
 /** Sorts a `classList` snapshot for stable output. `classList` entries are already unique, so sorting alone canonicalizes it. */

--- a/tests/e2e/hostFixtures/hostFixtureComparator.ts
+++ b/tests/e2e/hostFixtures/hostFixtureComparator.ts
@@ -1,4 +1,5 @@
 import type { HostFixture } from "./types";
+import { parseStyleCustomProperties } from "./canonicalizeHostFixture";
 import { serializeHostFixture } from "./hostFixtureFile";
 
 type ComparableValue = string | number | readonly string[] | Readonly<Record<string, string>>;
@@ -113,6 +114,52 @@ function recordDifference(
     }
 }
 
+/**
+ * Records a `documentElement.styleCssText` difference for tokens the pinned build declares and the
+ * second capture either DROPPED or REDEFINED. A token present only in the second capture is
+ * ignored.
+ *
+ * Upstream adds theme tokens continuously -- one Insiders run added 25 (`--vscode-modernTab-*`,
+ * `--vscode-modernEditorTab-*`, `--vscode-chat-findMatch*`) against two it actually changed. A
+ * token nothing in this extension reads cannot change how the extension renders, so an addition is
+ * not an early warning; it is what kept this canary red every night until stable caught up, which
+ * is the same as having no canary. A token that disappears or changes value underneath a webview
+ * can break it, so those are what get reported.
+ *
+ * Only the offending tokens travel into the difference. Carrying both full blocks put ~900
+ * identical tokens on either side of the formatter's truncation limit, so the failure named the
+ * field and then printed the same prefix twice.
+ */
+function recordStyleCustomPropertyDifference(
+    differences: HostFixtureDifference[],
+    committedCssText: string,
+    capturedCssText: string,
+): void {
+    const captured = parseStyleCustomProperties(capturedCssText);
+    const committedOffenders: Record<string, string> = {};
+    const capturedOffenders: Record<string, string> = {};
+
+    for (const [name, committedValue] of parseStyleCustomProperties(committedCssText)) {
+        const capturedValue = captured.get(name);
+        if (capturedValue === committedValue) continue;
+
+        committedOffenders[name] = committedValue;
+        // An absent key on the captured side IS the removal: the second build no longer declares
+        // this token at all, which reads differently from a token that merely changed value.
+        if (capturedValue !== undefined) {
+            capturedOffenders[name] = capturedValue;
+        }
+    }
+
+    if (Object.keys(committedOffenders).length > 0) {
+        differences.push({
+            field: "documentElement.styleCssText",
+            committedValue: committedOffenders,
+            capturedValue: capturedOffenders,
+        });
+    }
+}
+
 function formatDifferenceValue(value: ComparableValue, maxValueLength: number): string {
     const serialized = JSON.stringify(value);
     if (serialized.length <= maxValueLength) {
@@ -175,9 +222,12 @@ export function compareHostFixtures(
         committedFixture.documentElement.dataset,
         capturedFixture.documentElement.dataset,
     );
-    recordDifference(
+    // Token-wise, not string-wise: this comparison is the cross-build canary, where the two
+    // captures come from DIFFERENT VS Code builds and upstream additions are expected. The
+    // staleness comparison below stays an exact string match on purpose -- there both sides come
+    // from the SAME pinned build, so any drift at all means the committed fixture needs recapture.
+    recordStyleCustomPropertyDifference(
         differences,
-        "documentElement.styleCssText",
         committedFixture.documentElement.styleCssText,
         capturedFixture.documentElement.styleCssText,
     );

--- a/tests/unit/e2e/hostFixtureComparator.test.ts
+++ b/tests/unit/e2e/hostFixtureComparator.test.ts
@@ -51,8 +51,16 @@ function asRecord(fixture: HostFixture): Record<string, unknown> {
     return fixture as unknown as Record<string, unknown>;
 }
 
-/** Produces a value that differs from `value` while keeping its shape. */
-function mutateValue(value: unknown): unknown {
+/**
+ * Produces a value that differs from `value` while keeping its shape.
+ *
+ * `styleCssText` is mutated by rewriting every token's VALUE rather than by appending, because the
+ * comparator deliberately ignores tokens the second capture adds. Appended text is a mutation the
+ * comparator is supposed to survive, so using it here would make the executable-inventory ratchet
+ * below report "this field is never compared" about a field that is.
+ */
+function mutateValue(value: unknown, field: string): unknown {
+    if (field === "styleCssText") return (value as string).replace(/:[^;]*/g, ": mutated");
     if (typeof value === "number") return value + 1;
     if (typeof value === "string") return `${value}-mutated`;
     if (Array.isArray(value)) return [...value, "mutated"];
@@ -67,8 +75,16 @@ function withMutatedField(
     const sectionValue = asRecord(fixture)[section] as Record<string, unknown>;
     return {
         ...asRecord(fixture),
-        [section]: { ...sectionValue, [field]: mutateValue(sectionValue[field]) },
+        [section]: { ...sectionValue, [field]: mutateValue(sectionValue[field], field) },
     } as unknown as HostFixture;
+}
+
+/** Replaces only the theme-token block, leaving every other field of the fixture identical. */
+function withStyleCssText(fixture: HostFixture, styleCssText: string): HostFixture {
+    return {
+        ...fixture,
+        documentElement: { ...fixture.documentElement, styleCssText },
+    };
 }
 
 describe("compareHostFixtures", () => {
@@ -115,23 +131,88 @@ describe("compareHostFixtures", () => {
         ]);
     });
 
-    it("reports a changed custom-property block with both values", () => {
-        const committed = createFixture();
-        const captured: HostFixture = {
-            ...committed,
-            documentElement: {
-                ...committed.documentElement,
-                styleCssText: "--vscode-editor-background: #ffffff;",
-            },
-        };
+    it("reports a redefined theme token, naming only that token", () => {
+        const committed = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-surface-border: rgba(204, 204, 204, 0.15);",
+        );
+        const captured = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-surface-border: #252526;",
+        );
 
         expect(compareHostFixtures(committed, captured)).toEqual([
             {
                 field: "documentElement.styleCssText",
-                committedValue: "--vscode-editor-background: #000000;",
-                capturedValue: "--vscode-editor-background: #ffffff;",
+                committedValue: { "--vscode-surface-border": "rgba(204, 204, 204, 0.15)" },
+                capturedValue: { "--vscode-surface-border": "#252526" },
             },
         ]);
+    });
+
+    it("reports a theme token the second build dropped", () => {
+        const committed = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-surface-border: #252526;",
+        );
+        const captured = withStyleCssText(createFixture(), "--vscode-editor-background: #000000;");
+
+        // The captured side carries no key for the dropped token -- that absence is the removal,
+        // and it is what distinguishes this from a token that merely changed value.
+        expect(compareHostFixtures(committed, captured)).toEqual([
+            {
+                field: "documentElement.styleCssText",
+                committedValue: { "--vscode-surface-border": "#252526" },
+                capturedValue: {},
+            },
+        ]);
+    });
+
+    // The failure this whole comparison exists to stop reading as noise: VS Code Insiders added 25
+    // theme tokens IntelliGit reads none of, and the exact-string comparison called it a
+    // difference every night for a week.
+    it("ignores theme tokens the second build added", () => {
+        const committed = createFixture();
+        const captured = withStyleCssText(
+            committed,
+            "--vscode-editor-background: #000000; " +
+                "--vscode-modernTab-hoverBackground: #2a2d2e; " +
+                "--vscode-chat-findMatchBackground: rgba(234, 92, 0, 0.67);",
+        );
+
+        expect(compareHostFixtures(committed, captured)).toEqual([]);
+    });
+
+    it("still reports a dropped token when additions arrive in the same block", () => {
+        const committed = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-surface-border: #252526;",
+        );
+        const captured = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-modernTab-hoverBackground: #2a2d2e;",
+        );
+
+        expect(compareHostFixtures(committed, captured)).toEqual([
+            {
+                field: "documentElement.styleCssText",
+                committedValue: { "--vscode-surface-border": "#252526" },
+                capturedValue: {},
+            },
+        ]);
+    });
+
+    it("compares tokens by name rather than by block order", () => {
+        const committed = withStyleCssText(
+            createFixture(),
+            "--vscode-editor-background: #000000; --vscode-surface-border: #252526;",
+        );
+        const captured = withStyleCssText(
+            createFixture(),
+            "--vscode-surface-border: #252526; --vscode-editor-background: #000000;",
+        );
+
+        expect(compareHostFixtures(committed, captured)).toEqual([]);
     });
 
     it("reports a changed dataset value with both values", () => {


### PR DESCRIPTION
## Why

The nightly [E2E Flow Suite - VS Code Insiders](https://github.com/MaheshKok/IntelliGit/actions/workflows/e2e-insiders.yml) `host-fixture-compare` job has been red every night for a week. [Run 32548387264](https://github.com/MaheshKok/IntelliGit/actions/runs/32548387264) failed all four themes on a single field, `documentElement.styleCssText`, while all four flow shards passed.

The job launches the pinned VS Code build and Insiders in the same container and compares the theme tokens each writes onto `documentElement`. That comparison was exact string equality over the whole block, so every token upstream **adds** counted as a difference.

Extracted from that run's payloads — 891 pinned tokens against 916:

- **25 additions**: `--vscode-modernActivityBar-*` (6), `--vscode-modernEditorTab-*` (10), `--vscode-modernTab-*` (4), `--vscode-chat-findMatch*` (2), `--vscode-agentsBottomPanel-border`, `--vscode-agentsCard-border`, `--vscode-editor-border`
- **2 real value changes**: `--vscode-agents-layout-floatingPanelGap` `5px` → `4px`, `--vscode-surface-border` `rgba(204, 204, 204, 0.15)` → `#252526`
- **0 removals**

None of the 25 added tokens appear anywhere in `src/` or `media/`. The workflow gates nothing by design, so a canary that is red every night for tokens this extension never reads is the same as having no canary.

## What changed

- **`compareHostFixtures`** walks the pinned build's tokens and records a difference only for tokens Insiders **dropped** or **redefined**. A token only Insiders declares is ignored. Those two are the ones that can break a webview underneath us.
- The reported difference carries **only the offending tokens**. Both full blocks put ~900 identical tokens on either side of the formatter's 512-character limit, so the old failure named the field and then printed the same truncated prefix twice.
- **`compareHostFixtureStaleness` is deliberately untouched** and still compares byte for byte. Both of its sides come from the *same* pinned build, so there an added token does mean the committed fixture needs recapturing.
- The parse loop moved out of `canonicalizeStyleCssText` into an exported `parseStyleCustomProperties`, so the comparator reasons about the same tokens the canonicalizer writes instead of re-implementing the split.

Test infrastructure only — no shipped code is touched. `detect_changes` against `main`: 9 symbols, 3 files, **0 affected processes**, risk `low`.

**This does not make tonight's run green.** The two value changes are real drift and are still reported — now as one readable line instead of a truncated 900-token blob.

## Replay against the real failing payloads

```
pinned tokens: 891 | insiders tokens: 916
differences: 1
documentElement.styleCssText: committed={"--vscode-agents-layout-floatingPanelGap":"5px","--vscode-surface-border":"rgba(204, 204, 204, 0.15)"}, captured={"--vscode-agents-layout-floatingPanelGap":"4px","--vscode-surface-border":"#252526"}
```

## Test plan

- [x] `bun run test` — 295 files / 4134 tests passed
- [x] `bun run typecheck` (ext + webview + tests) — clean
- [x] `bun run lint:strict` (`--max-warnings=0`) — clean
- [x] `prettier --check .` — clean
- [x] Replayed the real captured payloads from the failing run through the new comparator (above)
- [x] Mutation-proved in three directions, each red naming its own assertion:
  - revert to the exact string compare → `ignores theme tokens the second build added`
  - skip absent tokens → `reports a theme token the second build dropped`, `still reports a dropped token when additions arrive in the same block`
  - skip value changes → `reports a redefined theme token, naming only that token`, `reports a change to documentElement.styleCssText`
- [ ] Next scheduled Insiders run reports the two value changes as one line and nothing else

The generic inventory ratchet mutated `styleCssText` by appending `-mutated`, which the new comparison correctly ignores as a non-token; it now rewrites every token's value instead, so the ratchet keeps proving the field is actually compared. The third mutation above is what holds that honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of CSS custom properties during style comparisons.
  - Prevented false differences caused by property ordering or newly added style tokens.
  - Improved detection of removed or changed theme values.

- **Chores**
  - Updated the IntelliGit extension version to 0.27.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->