### PR TITLE
ci: report the portability legs on pull requests so the Windows leg can gate a merge

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,12 +1,26 @@
 name: Installed-package portability
 
 on:
+    # No `paths:` filter, deliberately. This workflow's Windows leg is a required status check, and
+    # a required check that never reports blocks a pull request forever rather than passing it -- so
+    # a documentation-only change has to get a verdict here too, not silence. `ciHardeningWorkflows`
+    # asserts the absence rather than trusting a comment.
+    pull_request:
+        branches:
+            - main
     schedule:
         - cron: "43 3 * * 0"
     workflow_dispatch:
 
 permissions:
     contents: read
+
+# The Windows leg runs about thirty minutes, so a superseded pull-request run spends half an hour of
+# a runner on a commit nobody will merge. Scheduled runs are exempt on purpose: only one is ever in
+# flight, and cancelling it would drop that week's result rather than replace it.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     compatibility:

--- a/tests/fixtures/repo/copyInodeGuard.ts
+++ b/tests/fixtures/repo/copyInodeGuard.ts
@@ -11,15 +11,45 @@
  */
 
 import { lstat } from "node:fs/promises";
+import type { Stats } from "node:fs";
 import path from "node:path";
 import type { FsEntry } from "./snapshotTypes";
 
+/** The three `lstat` fields that decide whether two paths name one underlying file. */
+export type FileIdentity = Pick<Stats, "dev" | "ino" | "nlink">;
+
+/** One file whose template and copy sides could not be told apart, with the evidence. */
+interface SharedStorageOffender {
+    readonly relativePath: string;
+    readonly source: FileIdentity;
+    readonly destination: FileIdentity;
+}
+
+/**
+ * Whether `source` and `destination` name the same underlying file.
+ *
+ * Extracted from the walk so the decision is assertable on its own: the values a filesystem
+ * reports for a pair that is *not* linked cannot be produced on demand by creating files, and a
+ * predicate that only runs against whatever the host happens to hand it is a predicate no test
+ * can pin.
+ */
+export function sharesStorage(source: FileIdentity, destination: FileIdentity): boolean {
+    // A hardlink is one file wearing two names, so both sides must report at least two. `dev` and
+    // `ino` alone were enough until this ran on Windows, where they matched for a pair `fs.cp` had
+    // just written separately -- `fs.cp` copies through the platform's file-copy call and has no
+    // mechanism that could link them. `nlink` is reported independently of the ids, so it survives
+    // whatever made them agree, and it is the property the guard actually cares about: a file with
+    // one name cannot be corrupted through another.
+    if (source.nlink < 2 || destination.nlink < 2) return false;
+    return source.dev === destination.dev && source.ino === destination.ino;
+}
+
 /**
  * Asserts that no `"file"` entry in `entries` (relative paths, resolved against both
- * `sourceRoot` and `destinationRoot`) shares an inode -- same device *and* same inode number,
- * which is what actually identifies a hardlink -- between the template and the copy. Throws once,
- * listing every offending relative path, rather than on the first match, so a failing test's
- * message is self-explanatory (mirrors `assertAlternatesContained`'s error style).
+ * `sourceRoot` and `destinationRoot`) shares storage between the template and the copy. Throws
+ * once, listing every offending relative path together with the `lstat` fields that condemned it,
+ * rather than on the first match, so a failing test's message is self-explanatory (mirrors
+ * `assertAlternatesContained`'s error style).
  */
 export async function assertNoSharedInodes(
     sourceRoot: string,
@@ -29,31 +59,45 @@ export async function assertNoSharedInodes(
     const fileEntries = entries.filter((entry) => entry.type === "file");
     const offending = (
         await Promise.all(
-            fileEntries.map(async (entry) => {
-                const shared = await sharesInode(sourceRoot, destinationRoot, entry.relativePath);
-                return shared ? entry.relativePath : null;
-            }),
+            fileEntries.map((entry) =>
+                inspectPair(sourceRoot, destinationRoot, entry.relativePath),
+            ),
         )
-    ).filter((relativePath): relativePath is string => relativePath !== null);
+    ).filter((offender): offender is SharedStorageOffender => offender !== null);
 
     if (offending.length > 0) {
         throw new Error(
             `copyTemplate: copy shares an inode with the template for ${offending.length} file(s) ` +
-                `(a hardlinked copy lets one test's mutation corrupt every other): ${offending.join(", ")}`,
+                `(a hardlinked copy lets one test's mutation corrupt every other): ` +
+                offending.map(describeOffender).join(", "),
         );
     }
 }
 
+/** The numbers are in the message because they are the only way to tell a real hardlink from a
+ * platform that declined to identify the file -- and reading them off a CI log costs nothing,
+ * where reproducing the run costs half an hour. */
+function describeOffender(offender: SharedStorageOffender): string {
+    return (
+        `${offender.relativePath} ` +
+        `(template ${describeIdentity(offender.source)}; copy ${describeIdentity(offender.destination)})`
+    );
+}
+
+function describeIdentity(identity: FileIdentity): string {
+    return `dev=${identity.dev} ino=${identity.ino} nlink=${identity.nlink}`;
+}
+
 /** `dev` scopes the inode-number comparison: inode numbers are only unique per device, so two
  * files on different filesystems could coincidentally share a raw `ino` without being linked. */
-async function sharesInode(
+async function inspectPair(
     sourceRoot: string,
     destinationRoot: string,
     relativePath: string,
-): Promise<boolean> {
-    const [sourceStats, destinationStats] = await Promise.all([
+): Promise<SharedStorageOffender | null> {
+    const [source, destination] = await Promise.all([
         lstat(path.join(sourceRoot, relativePath)),
         lstat(path.join(destinationRoot, relativePath)),
     ]);
-    return sourceStats.dev === destinationStats.dev && sourceStats.ino === destinationStats.ino;
+    return sharesStorage(source, destination) ? { relativePath, source, destination } : null;
 }

--- a/tests/unit/e2e/controlChannelClient.test.ts
+++ b/tests/unit/e2e/controlChannelClient.test.ts
@@ -151,11 +151,27 @@ describe("E2eControlChannelClient response polling", () => {
             pollIntervalMs: 5,
         });
 
-        const responsePromise = client.request(REQUEST_PAYLOAD);
+        // The handler is attached where the promise is created, not at the assertion. This is the
+        // one case in the file whose promise is expected to REJECT, and `responseTimeoutMs` is 25ms
+        // -- less than the `waitForRequest` directory poll below costs on a slow filesystem. So the
+        // rejection lands while nothing is watching it, Node reports an unhandled rejection, and
+        // that fails the RUN while this test still passes: `.rejects` is satisfied by a promise
+        // that rejected earlier, so the assertion never notices it was late. Measured on
+        // windows-latest at 10a7e3a9 -- `Tests 4160 passed | 46 skipped (4206)`, `Errors 1 error`,
+        // exit code 1, no test red anywhere. Reproducible on any platform by sleeping 80ms in the
+        // gap this line closes.
+        const outcome = client.request(REQUEST_PAYLOAD).catch((error: unknown) => error);
         const request = await waitForRequest();
+        const rejection = await outcome;
 
-        await expect(responsePromise).rejects.toThrow(
-            new RegExp(`did not arrive within 25ms.*${request.nonce}\\.request\\.json`),
-        );
+        expect(
+            rejection,
+            "the bounded poll must reject rather than resolve; a resolved value here would mean " +
+                "the deadline was never enforced",
+        ).toBeInstanceOf(Error);
+        expect(
+            (rejection as Error).message,
+            "the timeout must name both the bound it exceeded and the request left unanswered",
+        ).toMatch(new RegExp(`did not arrive within 25ms.*${request.nonce}\\.request\\.json`));
     });
 });

--- a/tests/unit/fixtures/copyTemplate.test.ts
+++ b/tests/unit/fixtures/copyTemplate.test.ts
@@ -29,7 +29,11 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { assertNoSharedInodes } from "../../fixtures/repo/copyInodeGuard";
+import {
+    assertNoSharedInodes,
+    sharesStorage,
+    type FileIdentity,
+} from "../../fixtures/repo/copyInodeGuard";
 import { copyTemplate } from "../../fixtures/repo/copyTemplate";
 import { inventoryDirectory } from "../../fixtures/repo/fsInventory";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
@@ -206,6 +210,69 @@ describe("copyTemplate", () => {
             await expect(assertNoSharedInodes(source, destination, entries)).rejects.toThrow(
                 /shares an inode with the template/,
             );
+        });
+
+        // `fs.cp` has no mechanism that can produce a hardlink -- it copies through the platform's
+        // own file-copy call -- so when this guard fired on `windows-latest` for exactly one loose
+        // Git object (`origin.git/objects/72/44a2...`, run 32772636554), the pair it condemned
+        // could not have been linked. Four earlier Windows runs of the same test were green: what
+        // `lstat` reports for `dev`/`ino` there is not, on its own, stable enough to identify a
+        // file, and the guard read a match into it.
+        //
+        // A second name is what a hardlink IS, and `nlink` is reported independently of the ids.
+        // The failing values cannot be manufactured by creating files -- an unlinked pair on a
+        // healthy filesystem never reports matching ids -- so the decision is asserted directly
+        // rather than through a copy the host would have to cooperate in breaking.
+        it("needs a second name, not just matching ids, before calling a pair linked", () => {
+            const cases: readonly {
+                readonly what: string;
+                readonly source: FileIdentity;
+                readonly destination: FileIdentity;
+                readonly shared: boolean;
+            }[] = [
+                {
+                    what: "a real hardlink: matching ids, and both sides admit a second name",
+                    source: { dev: 16_777_232, ino: 4_211_009, nlink: 2 },
+                    destination: { dev: 16_777_232, ino: 4_211_009, nlink: 2 },
+                    shared: true,
+                },
+                {
+                    what: "ids the platform declined to fill in -- two separate files, both zero",
+                    source: { dev: 0, ino: 0, nlink: 1 },
+                    destination: { dev: 0, ino: 0, nlink: 1 },
+                    shared: false,
+                },
+                {
+                    what: "plausible matching ids, but each file has exactly one name",
+                    source: { dev: 16_777_232, ino: 4_211_009, nlink: 1 },
+                    destination: { dev: 16_777_232, ino: 4_211_009, nlink: 1 },
+                    shared: false,
+                },
+                {
+                    what: "link counts that disagree cannot both describe one file",
+                    source: { dev: 16_777_232, ino: 4_211_009, nlink: 2 },
+                    destination: { dev: 16_777_232, ino: 4_211_009, nlink: 1 },
+                    shared: false,
+                },
+                {
+                    what: "distinct inodes on one device are distinct files",
+                    source: { dev: 16_777_232, ino: 4_211_009, nlink: 2 },
+                    destination: { dev: 16_777_232, ino: 4_211_010, nlink: 2 },
+                    shared: false,
+                },
+                {
+                    what: "one inode number on two devices is a coincidence, not a link",
+                    source: { dev: 16_777_232, ino: 4_211_009, nlink: 2 },
+                    destination: { dev: 16_777_233, ino: 4_211_009, nlink: 2 },
+                    shared: false,
+                },
+            ];
+
+            for (const testCase of cases) {
+                expect(sharesStorage(testCase.source, testCase.destination), testCase.what).toBe(
+                    testCase.shared,
+                );
+            }
         });
     });
 

--- a/tests/unit/publishing/ciHardeningWorkflows.test.ts
+++ b/tests/unit/publishing/ciHardeningWorkflows.test.ts
@@ -59,6 +59,23 @@ function pinnedRefsFor(workflow: string, actionPath: string): readonly string[] 
     return [...workflow.matchAll(pattern)].map((match) => match[1]);
 }
 
+/**
+ * Extracts a top-level workflow mapping -- `on:`, `concurrency:` -- so an assertion about a trigger
+ * cannot be satisfied by an identical string sitting inside a job.
+ */
+function extractTopLevelBlock(workflow: string, key: string): string {
+    const header = `\n${key}:\n`;
+    const start = workflow.indexOf(header);
+    if (start === -1) return "";
+
+    const bodyStart = start + header.length;
+    const nextTopLevelOffset = workflow.slice(bodyStart).search(/^[a-z]/m);
+    return workflow.slice(
+        bodyStart,
+        nextTopLevelOffset === -1 ? workflow.length : bodyStart + nextTopLevelOffset,
+    );
+}
+
 /** Returns the complete job-local permission map as rendered in a workflow. */
 function jobPermissionEntries(job: string): readonly string[] {
     const permissions = job.match(
@@ -294,6 +311,51 @@ describe("CI quality hardening workflows", () => {
             "dependency-review.yml must run dependency-review-action, SHA-pinned",
         ).toBe(1);
         expect(dependencyReview).toContain("fail-on-severity: high");
+    });
+
+    it("reports the portability legs on every pull request, so one of them can gate a merge", () => {
+        const compatibility = readRepositoryFile(".github/workflows/compatibility.yml");
+        const triggers = extractTopLevelBlock(compatibility, "on");
+
+        // The reason the Windows leg was not a required status check was never a policy choice: the
+        // workflow ran on a weekly schedule and on manual dispatch only, so it produced no check run
+        // on a pull request at all. Requiring a context that never reports does not fail a merge, it
+        // blocks one indefinitely, which is why the trigger has to land before the ruleset does.
+        expect(
+            triggers,
+            "the portability workflow must run on pull requests, or its check cannot gate a merge",
+        ).toMatch(/^ {4}pull_request:\n {8}branches:\n {12}- main\n/m);
+
+        // Exact set equality, not an absence check per filter key. `paths:` is the one that bites
+        // today, but `paths-ignore:` and `branches-ignore:` deadlock a required check in precisely
+        // the same way, and an enumerated ban only ever covers the cases someone remembered. Any
+        // new key under this trigger has to be justified against the deadlock before it is added.
+        const pullRequestBlock =
+            triggers.match(/^ {4}pull_request:\n((?: {8}.*\n| *\n)*)/m)?.[1] ?? "";
+        expect(
+            [...pullRequestBlock.matchAll(/^ {8}([a-z-]+):/gm)].map(([, key]) => key),
+            "a filter here silences the workflow on the pull requests it excludes, and a required " +
+                "check that stays silent blocks the merge instead of passing it",
+        ).toEqual(["branches"]);
+
+        // Windows takes about thirty minutes of the ninety-minute budget, so an uncancelled
+        // superseded run holds a runner for a commit nobody will merge. The scheduled run is exempt
+        // by the same reasoning inverted: exactly one is ever in flight, so cancelling it discards
+        // that week's only result. Asserting the guard rather than a bare `true` is the point --
+        // `cancel-in-progress: true` would typecheck as YAML and silently drop weekly results.
+        expect(extractTopLevelBlock(compatibility, "concurrency")).toMatch(
+            /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/,
+        );
+
+        // The check that gets required is named after the matrix entry, so dropping the entry
+        // renames the context out of existence -- and a required context with no check run is the
+        // same deadlock as no trigger at all, arriving by a different route.
+        expect(
+            compatibility,
+            "the required context is 'Installed package smoke (windows-latest)', which only exists " +
+                "while the runner stays in the matrix and the job name keeps interpolating it",
+        ).toContain("name: Installed package smoke (${{ matrix.os }})");
+        expect(compatibility).toContain("windows-latest");
     });
 
     it("covers installed-package portability and makes Dependabot update both actionable ecosystems", () => {


### PR DESCRIPTION
## Why the Windows leg is not required — it was never a settings oversight

Adding `Installed package smoke (windows-latest)` to the `main` ruleset today would not have started failing bad merges. It would have blocked **every** merge, permanently.

`compatibility.yml` is the only workflow in this repository with a Windows runner, and its triggers were:

```yaml
on:
    schedule:
        - cron: "43 3 * * 0"
    workflow_dispatch:
```

No `pull_request`. It never produced a check run on a pull request, and GitHub does not pass a required context that never reports — it waits for it. So the ruleset entry could not be added until the trigger existed. That ordering is the whole reason this is a PR and not a settings change.

Worth stating plainly, because it is the actual hole: **no PR-triggered workflow in this repository has ever used a Windows runner.** Every job in `publish.yml` — `build`, `visual`, `e2e-full`, `package-smoke` — is `ubuntu-latest`, as are `codeql.yml`, `e2e.yml` and `dependency-review.yml`. That is how the Windows leg accumulated 206 failures without anyone seeing one.

## What changed

`.github/workflows/compatibility.yml`

- `pull_request` on `main` added, so all three legs report on every PR.
- `concurrency` added, cancelling superseded **pull-request** runs only.

`tests/unit/publishing/ciHardeningWorkflows.test.ts` — one new case, `reports the portability legs on every pull request, so one of them can gate a merge`.

### Three decisions and why

**The matrix stays whole rather than narrowing to Windows on PRs.** The repository is public, so runner minutes are free, and the legs run concurrently: Windows 30 min, macOS 11, Linux 8. The other two add nothing to wall-clock and gain the same pre-merge verdict, so narrowing the matrix would be a conditional expression buying nothing.

**No `paths:` filter.** A required check that never reports blocks a pull request rather than passing it, so a documentation-only change has to get a verdict here too. The test asserts the **exact key set** under `pull_request:` equals `["branches"]` rather than banning `paths:` by name — `paths-ignore:` and `branches-ignore:` deadlock a required check identically, and an enumerated ban only ever covers the cases someone remembered.

**`concurrency` exempts the scheduled run.** Thirty minutes of a runner spent on a superseded commit is worth reclaiming. The weekly run is the inverse: exactly one is ever in flight, so cancelling it discards that week's only result rather than replacing it. The assertion pins the guard expression, not a bare `true`, because `cancel-in-progress: true` is valid YAML that silently drops weekly results.

## Verification

**This pull request is the end-to-end proof.** If `Installed package smoke (windows-latest)` appears in its own check list, the trigger works; if it does not, nothing else in this PR matters.

**Mutation proof**, baseline holding at 7 under each so no run was a crashed runner in disguise. Every red named the new case:

| mutation | total | failed | red test |
|---|---|---|---|
| remove the `pull_request` trigger | 7 | 1 | `reports the portability legs on every pull request…` |
| add a `paths:` filter under it | 7 | 1 | same |
| cancel scheduled runs too | 7 | 1 | same |
| drop `windows-latest` from the matrix | 7 | 2 | same, plus the existing matrix assertion |

**Local gates**, all eight plus `vsce package` via the pre-commit hook:

```
format:check PASS   lint:strict PASS   deps:check:strict PASS   architecture:check PASS
l10n:validate PASS  l10n:audit PASS    typecheck PASS           build PASS

Test Files  303 passed (303)
Tests  4206 passed (4206)
```

4205 → 4206 is exactly the one case added.

## What the leg caught on its very first pull request

`10a7e3a9` turned the Windows leg on. It went red — with **every one of its 4,206 tests green**:

```
Test Files  303 passed (303)
     Tests  4160 passed | 46 skipped (4206)
    Errors  1 error
exit code 1
```

An unhandled rejection, no test red anywhere. `bounds polling when the response remains missing` is the only test in `controlChannelClient.test.ts` whose promise is expected to reject, and it left that promise floating while awaiting `waitForRequest()` — a directory poll. `responseTimeoutMs` for that case is 25ms, less than the poll costs on a slow filesystem, so the rejection landed with nothing watching it. Node reported it as unhandled and Vitest failed the run. The assertion still passed: `.rejects` is satisfied by a promise that rejected earlier and cannot tell that it was late.

`96a5b645` attaches the handler in the same turn the promise is created. Assertion strength is unchanged — the rejection must be an `Error` and its message must still name both the 25ms bound and the request left unanswered.

**Reproduced on macOS** by sleeping 80ms in the gap the fix closes, which is the timing Windows supplies for free:

| | exit | totals | errors |
|---|---|---|---|
| before the fix | 1 | `Tests 6 passed (6)` | `Errors 1 error`, `Unhandled Rejection` |
| after the fix | 0 | `Tests 6 passed (6)` | none |

**Both assertions still bite**, mutating the shared client:

| mutation | result |
|---|---|
| timeout resolves instead of rejecting | `1 failed \| 5 passed` — `bounds polling…` |
| timeout message loses its wording | `1 failed \| 5 passed` — `bounds polling…` |

**One site, and the audit proves it can see it.** Every test in the tree was scanned for the same shape — a promise assigned to a local, an unrelated `await`, then `await expect(local).rejects`. One hit. The audit asserts it finds this known positive before its count is trusted; its first version returned zero, including for the bug already reproduced by hand, because `\b(promise)\b` cannot match inside `responsePromise`.

This is the argument for the whole PR, made by accident. The bug was live on `main`, reachable by any contributor on Windows, and invisible to every check that runs today.

## …and a second defect on the second run

`96a5b645` closed the unhandled rejection. Windows went red again — a different failure, latent since Phase 6:

```
FAIL tests/unit/fixtures/workspaceIsolation.test.ts > Phase 6 step 35 -- workspace isolation
Error: copyTemplate: copy shares an inode with the template for 1 file(s):
       origin.git/objects/72/44a26dd50e8dbcb785ad974c9af8d3081e402e
```

`copyTemplate`'s guard asks whether a copied file shares storage with the template by comparing `dev` and `ino`. On `windows-latest` those matched for a pair `fs.cp` had just written separately. `fs.cp` copies through the platform's own file-copy call and has no mechanism that could produce a hardlink, so the pair it condemned could not have been linked — the guard read a hardlink into fields that had stopped identifying the file. Four earlier Windows runs of the same test were green, which is what a check resting on unstable identity looks like.

`13213b37` requires a second name on both sides before condemning a pair. A hardlink is one file wearing two names, and `nlink` is reported independently of the ids, so it survives whatever made them agree — and it is the property the guard actually cares about: a file with one name cannot be corrupted through another.

The decision moved into `sharesStorage`, a pure predicate. The failing values cannot be manufactured by creating files — an unlinked pair on a healthy filesystem never reports matching ids — so a test that builds files can only ever assert the case that already worked.

**Mutation-proven in both directions**, against a 10-test baseline that held under every mutation:

| mutation | result | red assertion |
|---|---|---|
| drop the `nlink` condition (the bug, restored) | `1 failed \| 9 passed (10)` | *needs a second name…* |
| demand three names, so a real hardlink slips through | `2 failed \| 8 passed (10)` | *THROWS…the deliberate break* **and** *needs a second name…* |
| drop the `dev`/`ino` comparison | `1 failed \| 9 passed (10)` | *needs a second name…* |

The middle row is the one that matters: it shows a genuine hardlink is still caught, so the fix loosened the guard exactly as far as the platform artifact and no further.

The guard's message now prints `dev`/`ino`/`nlink` for every offender. Diagnosing this cost a half-hour CI round trip spent purely to learn which numbers matched.

## The leg is green

Run [32777133567](https://github.com/MaheshKok/IntelliGit/actions/runs/32777133567) at `13213b37`, all three portability legs:

| leg | result | duration | totals |
|---|---|---|---|
| `windows-latest` | **pass** | 28m41s | `Test Files 303 passed (303)`, `Tests 4161 passed \| 46 skipped (4207)` |
| `macos-latest` | pass | 11m29s | — |
| `ubuntu-latest` | pass | 8m45s | — |

Both defects it found stayed fixed: **0** unhandled rejections (was 1 at `10a7e3a9`), **0** inode-guard fires (was 1 at `96a5b645`).

`e2e-full` failed once on this commit — `flows.spec.ts:8:13 › commit`, `No IntelliGit webview rendered "[data-testid="commit-panel-tab-row"]"`, `1 failed | 11 passed` — and **passed on a re-run of the identical tree**: `12 passed (3.1m)`. Red then green at one commit is the definition of a flake, and it is the known hydration flake named in the section below, not a consequence of this branch: nothing in the diff appears anywhere in its 75KB log, and the guard change can only make a throw *less* likely, which is not a shape a hydration timeout takes. Every check on `13213b37` is now green and the pull request reads `MERGEABLE / CLEAN`.

## The second half is not a file

Merging this does **not** make the leg mandatory. It makes it *possible* to. The ruleset entry is a repository setting:

```
ruleset 12862467 "main" → required_status_checks
  + Installed package smoke (windows-latest)
```

That has to be added **after** this merges, or open pull requests block on a context their base commit cannot produce. It is not in this diff because it cannot be.

## Three things to weigh before requiring it

**It makes a known flake merge-blocking.** The Windows leg runs `test:package-smoke`, which waits on `commit-panel-tab-row` through the same `frameOwning` helper whose hydration timeout fails on `main` at roughly 33%. It hit the macOS leg during #224 and passed on a re-run of the identical commit. Requiring the Windows context gives that flake the power to block a merge. The mitigation is to fix the hydration race, not to add retries — `playwright.e2e.config.ts:34` sets `retries: 0` deliberately, because a retry would mask exactly the flake the suite exists to detect.

**`strict_required_status_checks_policy` is `true`.** Every merge to `main` invalidates open pull requests and forces a re-run. Today the required checks are 1–6 minutes; a 30-minute Windows leg changes how that feels.

**It is a ~26-minute check, and the cost is not evenly spread.** Per-step seconds from run 32772636554:

| step | windows | ubuntu | macos |
|---|---|---|---|
| **Run tests** | **1141s** | 386s | 471s |
| Install the Playwright browser | 206s | 23s | 7s |
| Install dependencies | 76s | 3s | 6s |
| ESLint / format / typecheck | 73s | 51s | 36s |

Tests are 74% of the gap. This suite is filesystem- and subprocess-bound rather than CPU-bound — it seeds real Git repositories, copies template trees, and spawns `git` constantly — and Windows pays for both: `CreateProcess` costs far more than `fork`/`exec`, and every file syscall crosses the NTFS filter-driver stack with Defender scanning each newly created file. The suite writes thousands of tiny loose objects, which is the worst case for that stack. (The 25m19s above is an *incomplete* run — it died at `Run tests`, so packaging and the smoke step never ran.)

Three levers exist, none of them in this PR: a `Add-MpPreference -ExclusionPath` step for `RUNNER_TEMP`/`GITHUB_WORKSPACE`, `actions/cache` on `%LOCALAPPDATA%\ms-playwright` (~200s), and a cache for bun's store (~70s). Worth deciding before the check becomes merge-blocking.

None is an argument against requiring it. All three are things worth knowing before you do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pull requests targeting the main branch now automatically run compatibility checks, including documentation-only updates.
  - Superseded pull-request runs are canceled automatically, while scheduled checks continue uninterrupted.
  - Compatibility validation continues to include Windows coverage.

- **Tests**
  - Improved timeout handling and verification for missing responses.
  - Added automated checks to ensure CI triggers, filtering, concurrency behavior, and platform coverage remain reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



