### PR TITLE
ci: cut the required Windows leg from ~26 minutes

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -33,6 +33,27 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
 
         steps:
+            # Deliberately the first step, before checkout: the exclusion then covers the tens of
+            # thousands of files checkout itself writes, not just the ones the suite writes later.
+            #
+            # This leg is filesystem-bound, never CPU-bound -- it seeds real Git repositories,
+            # copies template trees, and writes thousands of tiny loose objects, every one of which
+            # Defender opens and scans on creation. Measured on run 32772636554: `Run tests` took
+            # 1141s here against 386s on ubuntu, and `import` alone -- pure module resolution, i.e.
+            # `stat` calls -- accounted for 74s of it. The runner is a throwaway VM that only ever
+            # holds this repository's own code and its pinned dependencies, so excluding those four
+            # paths from real-time scanning trades nothing a scan was protecting.
+            #
+            # `continue-on-error` is load-bearing, not politeness: this leg is a required status
+            # check, so a Defender hiccup that failed the step would block every merge in the
+            # repository to save half an hour on one. A skipped exclusion costs time and nothing
+            # else, and the annotation says so.
+            - name: Exclude the runner's working directories from Defender real-time scanning
+              if: runner.os == 'Windows'
+              continue-on-error: true
+              shell: pwsh
+              run: Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE, $env:RUNNER_TEMP, $env:TEMP, "$env:USERPROFILE\.bun"
+
             - name: Checkout code
               uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
@@ -47,6 +68,38 @@ jobs:
               uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
               with:
                   bun-version: "1.3.5"
+
+            # Playwright's default download location is spelled differently on all three runners
+            # (`~/.cache`, `~/Library/Caches`, `%LOCALAPPDATA%`), and a cache whose `path:` names a
+            # directory the browser was never written to restores nothing while looking configured.
+            # Pinning one location removes the spelling question entirely, and the same expression
+            # is used here and in the `path:` below so the two cannot drift apart.
+            #
+            # It has to sit OUTSIDE `github.workspace`: `bun run package` runs `vsce` over the
+            # working tree a few steps down, and a browser bundle at the repository root would be
+            # swept into the VSIX unless `.vscodeignore` happened to exclude it.
+            - name: Point Playwright's browser download outside the packaged workspace
+              shell: bash
+              run: echo "PLAYWRIGHT_BROWSERS_PATH=${{ runner.temp }}/ms-playwright" >> "$GITHUB_ENV"
+
+            # Both restores must precede the two steps they accelerate -- a cache placed after its
+            # consumer is inert and still reads as configured. Measured on Windows: 76s for
+            # `bun install` (3s on ubuntu, which copies through hardlinks where Windows must copy
+            # bytes) and 206s to download and unzip Chromium.
+            #
+            # Keyed on the lockfile, so a dependency bump earns a fresh browser download rather
+            # than silently running last week's binary; `restore-keys` still hands back the
+            # previous entry meanwhile, and `playwright install` below is a no-op when the cached
+            # build already matches.
+            - name: Restore the bun store and the Playwright browser
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                  path: |
+                      ~/.bun/install/cache
+                      ${{ runner.temp }}/ms-playwright
+                  key: ${{ runner.os }}-portability-${{ hashFiles('bun.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-portability-
 
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -69,34 +69,20 @@ jobs:
               with:
                   bun-version: "1.3.5"
 
-            # Playwright's default download location is spelled differently on all three runners
-            # (`~/.cache`, `~/Library/Caches`, `%LOCALAPPDATA%`), and a cache whose `path:` names a
-            # directory the browser was never written to restores nothing while looking configured.
-            # Pinning one location removes the spelling question entirely, and the same expression
-            # is used here and in the `path:` below so the two cannot drift apart.
+            # Must precede the install it accelerates -- a cache placed after its consumer is inert
+            # and still reads as configured. Measured on Windows: `bun install` 75s cold against 19s
+            # restored, where ubuntu takes 3s either way because it links what Windows must copy.
             #
-            # It has to sit OUTSIDE `github.workspace`: `bun run package` runs `vsce` over the
-            # working tree a few steps down, and a browser bundle at the repository root would be
-            # swept into the VSIX unless `.vscodeignore` happened to exclude it.
-            - name: Point Playwright's browser download outside the packaged workspace
-              shell: bash
-              run: echo "PLAYWRIGHT_BROWSERS_PATH=${{ runner.temp }}/ms-playwright" >> "$GITHUB_ENV"
-
-            # Both restores must precede the two steps they accelerate -- a cache placed after its
-            # consumer is inert and still reads as configured. Measured on Windows: 76s for
-            # `bun install` (3s on ubuntu, which copies through hardlinks where Windows must copy
-            # bytes) and 206s to download and unzip Chromium.
-            #
-            # Keyed on the lockfile, so a dependency bump earns a fresh browser download rather
-            # than silently running last week's binary; `restore-keys` still hands back the
-            # previous entry meanwhile, and `playwright install` below is a no-op when the cached
-            # build already matches.
-            - name: Restore the bun store and the Playwright browser
+            # The Playwright browser was cached here too and has been removed. It saved nothing: on
+            # run 32783641129 attempt 2 the browser restored from cache and `playwright install`
+            # still took 202s, against 200s on run 32785953517 where the cache missed and the
+            # browser downloaded fresh. The cost was never the download (see the install step
+            # below), so all the browser did was add ~170MB to an archive that Windows spends
+            # 73s untarring.
+            - name: Restore the bun store
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
-                  path: |
-                      ~/.bun/install/cache
-                      ${{ runner.temp }}/ms-playwright
+                  path: ~/.bun/install/cache
                   key: ${{ runner.os }}-portability-${{ hashFiles('bun.lock') }}
                   restore-keys: |
                       ${{ runner.os }}-portability-
@@ -107,8 +93,18 @@ jobs:
             # `bun run test` includes tests/unit/visual/screenshotComparatorMeta.test.ts, which
             # launches a real Chromium to prove the screenshot comparator. Without this the suite
             # fails on the browser binary rather than on anything this workflow is meant to check.
+            #
+            # `--with-deps` is gated to Linux, where it apt-installs libraries Chromium cannot
+            # launch without. On Windows the same flag runs DISM to enable Media Foundation -- a
+            # VIDEO CODEC pack -- and that, not the browser download, is what this step spends its
+            # time on: the whole of its output was the `{Media Foundation}` feature table, and the
+            # step cost 202s with the browser already restored from cache (run 32783641129 attempt
+            # 2) against 200s with a cache miss and a fresh download (run 32785953517). Nothing in
+            # this repository records video -- there is no `recordVideo` anywhere -- and the one
+            # consumer takes screenshots and states its own requirement as `playwright install
+            # chromium` at screenshotComparatorMeta.test.ts:163. macOS needs no OS packages either.
             - name: Install the Playwright browser the comparator proof runs against
-              run: bunx playwright install --with-deps chromium
+              run: bunx playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium
 
             - name: Check formatting
               run: bun run format:check

--- a/src/git/repositoryLock.ts
+++ b/src/git/repositoryLock.ts
@@ -83,7 +83,7 @@ export class RepositoryLock {
                 });
                 return await this.confirmClaim(lockPath, owner);
             } catch (error) {
-                if (!isAlreadyExists(error)) throw error;
+                if (!isExclusiveCreateBlocked(error)) throw error;
             }
             const existing = await readLockFile(lockPath);
             if (!this.isStale(existing)) throw new RepositoryLockBusyError();
@@ -120,7 +120,7 @@ export class RepositoryLock {
                     mode: 0o600,
                 });
             } catch (error) {
-                if (isAlreadyExists(error)) {
+                if (isExclusiveCreateBlocked(error)) {
                     await rm(takeoverPath, { force: true });
                     throw new RepositoryLockBusyError();
                 }
@@ -317,10 +317,42 @@ function parseOwner(contents: string): LockOwner | undefined {
         : undefined;
 }
 
-function isAlreadyExists(error: unknown): boolean {
-    return (
-        typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST"
-    );
+/**
+ * Whether an exclusive create failed because the lock path is already occupied.
+ *
+ * POSIX has one answer for this, `EEXIST`, and Windows usually agrees. It stops agreeing while
+ * the previous lock file is *delete-pending*: `rm` on a file another handle still holds open does
+ * not remove the name, it marks it, and every `CreateFile(CREATE_NEW)` against that name answers
+ * `ERROR_ACCESS_DENIED` -- which libuv maps to `EPERM` -- until the last handle closes.
+ * `readLockFile` opens the lock path and closes it asynchronously, and `releaseCallback` removes
+ * the path right after reading it back, so a release racing a contender produces exactly that
+ * window.
+ *
+ * Classifying it as anything but contention is what broke it. The raw `EPERM` left `acquire`
+ * instead of `RepositoryLockBusyError`, and `acquireWithBoundedWait` retries only the latter, so
+ * a wait POSIX rides out became an immediate hard failure for the caller. Observed as
+ * `EPERM: operation not permitted, open '...\.store-lock\store.lock'` out of
+ * `ShelfStore.listShelves` on the Windows leg of run 32789206621.
+ *
+ * Widening this predicate cannot widen what the lock grants. Both call sites use it only to
+ * decide whether to fall through to the busy/stale machinery, and on the new branch that
+ * machinery reads the path back: an unreadable file is dated to now and so can never be stale, an
+ * absent one is never stale, and a readable stale one is the takeover `EEXIST` already permitted.
+ * Every added path therefore ends at `RepositoryLockBusyError` and nowhere else.
+ *
+ * The cost when it is wrong: a genuine Windows permission fault on the lock directory now
+ * surfaces as a bounded wait ending in `RepositoryLockBusyError` rather than an immediate
+ * `EPERM` -- a worse message for an environment that is broken either way, paid to stop
+ * misreporting ordinary contention as a fault. `platform` is a parameter for the same reason it
+ * is one in `resolveNoFollowFlag`: the branch is unreachable from a POSIX test run otherwise.
+ */
+export function isExclusiveCreateBlocked(
+    error: unknown,
+    platform: NodeJS.Platform = process.platform,
+): boolean {
+    if (typeof error !== "object" || error === null || !("code" in error)) return false;
+    if (error.code === "EEXIST") return true;
+    return platform === "win32" && error.code === "EPERM";
 }
 
 function isNotFound(error: unknown): boolean {

--- a/tests/unit/git/repositoryLock.test.ts
+++ b/tests/unit/git/repositoryLock.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { RepositoryLock, RepositoryLockBusyError } from "../../../src/git/repositoryLock";
+import { acquireWithBoundedWait } from "../../../src/git/boundedLockRetry";
+import {
+    isExclusiveCreateBlocked,
+    RepositoryLock,
+    RepositoryLockBusyError,
+} from "../../../src/git/repositoryLock";
 import { RENAME_OVER_OPEN_FILE_SUPPORTED } from "../../helpers/platformCapabilities";
 
 /** Delay applied to heartbeat writes only, so "the write is still in flight when release runs" is
@@ -13,19 +18,35 @@ const heartbeatWrite = vi.hoisted(() => ({ delayMs: 0 }));
  * driven without waiting for a real filesystem to refuse. Unset for every other test here. */
 const renameFailure = vi.hoisted(() => ({ failToward: undefined as string | undefined }));
 
+/** Makes the exclusive create fail with a chosen errno for the next `remaining` attempts, so the
+ * errno Windows answers with can be driven from a POSIX host. Unset for every other test here. */
+const exclusiveCreateFailure = vi.hoisted(() => ({
+    code: undefined as string | undefined,
+    remaining: 0,
+}));
+
 // Node's built-in `node:fs/promises` exports non-configurable properties, so `vi.spyOn` cannot wrap
 // them; `vi.mock` with a pass-through factory is vitest's standard workaround. Only the heartbeat's
 // write is slowed: `acquire` creates the lock with an exclusive-create `flag`, the heartbeat never
 // does, so the absence of `flag` identifies it without reaching into the implementation.
 vi.mock("node:fs/promises", async (importOriginal) => {
     const actual = await importOriginal<typeof import("node:fs/promises")>();
-    const writeFileWithHeartbeatDelay: typeof actual.writeFile = async (file, data, options) => {
-        const isHeartbeatWrite =
-            heartbeatWrite.delayMs > 0 &&
-            typeof options === "object" &&
-            options !== null &&
-            !("flag" in options);
-        if (isHeartbeatWrite) {
+    const writeFileWithInjectedBehaviour: typeof actual.writeFile = async (file, data, options) => {
+        const isExclusiveCreate =
+            typeof options === "object" && options !== null && "flag" in options;
+        const injected = exclusiveCreateFailure.code;
+        if (isExclusiveCreate && injected !== undefined && exclusiveCreateFailure.remaining > 0) {
+            exclusiveCreateFailure.remaining -= 1;
+            // Shaped like the real thing down to the syscall, because the syscall name in the
+            // observed failure is what identified this call site rather than a rename or unlink.
+            const failure: NodeJS.ErrnoException = new Error(
+                `${injected}: operation not permitted, open '${String(file)}'`,
+            );
+            failure.code = injected;
+            failure.syscall = "open";
+            throw failure;
+        }
+        if (heartbeatWrite.delayMs > 0 && !isExclusiveCreate) {
             await new Promise((resolve) => setTimeout(resolve, heartbeatWrite.delayMs));
         }
         return actual.writeFile(file, data, options);
@@ -44,14 +65,26 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     };
     return {
         ...actual,
-        writeFile: writeFileWithHeartbeatDelay,
+        writeFile: writeFileWithInjectedBehaviour,
         rename: renameWithInjectedFailure,
     };
 });
 
 const directories: string[] = [];
+const originalPlatform = process.platform;
+
+/** Supplies the platform rather than inheriting it, so the Windows branch is reachable on POSIX. */
+function pretendPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+}
 
 afterEach(async () => {
+    exclusiveCreateFailure.code = undefined;
+    exclusiveCreateFailure.remaining = 0;
+    Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+    });
     await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
 });
 
@@ -482,5 +515,109 @@ describe("RepositoryLock", () => {
                 "the late owner must be restored to the lock path, not displaced by the takeover",
             ).toMatchObject({ nonce: "arrived-late" });
         });
+    });
+});
+
+/**
+ * Pins the errno classification the exclusive create is judged by.
+ *
+ * The defect is invisible on the host that runs this suite. On POSIX a held lock answers `EEXIST`
+ * and always did, so no POSIX run can tell the fix from the defect; the Windows answer has to be
+ * supplied rather than waited for.
+ */
+describe("isExclusiveCreateBlocked", () => {
+    it("treats the Windows delete-pending errno as contention", () => {
+        // The whole point. `rm` on a lock file another handle still holds open marks the name
+        // instead of removing it, and `CreateFile(CREATE_NEW)` against a marked name answers
+        // ERROR_ACCESS_DENIED -> EPERM. Read as a fault, that failed the caller outright where
+        // POSIX merely waited.
+        expect(isExclusiveCreateBlocked({ code: "EPERM" }, "win32")).toBe(true);
+    });
+
+    it("does not treat a POSIX EPERM as contention", () => {
+        // The other direction, and the one that keeps the widening honest. POSIX answers `EEXIST`
+        // for an occupied path, so an EPERM there is a real permission fault and must stay one --
+        // a classifier that swallowed it everywhere would turn every such fault into a bounded
+        // wait ending in a misleading "already in progress".
+        expect(isExclusiveCreateBlocked({ code: "EPERM" }, "linux")).toBe(false);
+        expect(isExclusiveCreateBlocked({ code: "EPERM" }, "darwin")).toBe(false);
+    });
+
+    it("widens by exactly one errno, on exactly one platform", () => {
+        expect(isExclusiveCreateBlocked({ code: "EEXIST" }, "linux")).toBe(true);
+        expect(isExclusiveCreateBlocked({ code: "EEXIST" }, "win32")).toBe(true);
+        // EACCES is the neighbouring permission errno and is NOT the delete-pending shape.
+        expect(isExclusiveCreateBlocked({ code: "EACCES" }, "win32")).toBe(false);
+        expect(isExclusiveCreateBlocked({ code: "ENOENT" }, "win32")).toBe(false);
+        expect(isExclusiveCreateBlocked(new Error("no code at all"), "win32")).toBe(false);
+        expect(isExclusiveCreateBlocked(undefined, "win32")).toBe(false);
+    });
+
+    it("defaults to the running platform", () => {
+        // The seam moves the untested surface: both production call sites omit the argument, so a
+        // default hardcoded to either platform would leave them wrong on the other while every
+        // assertion above still passed. Host-dependent on purpose -- this is the one assertion
+        // here whose expected value differs between the POSIX legs and the Windows leg.
+        expect(isExclusiveCreateBlocked({ code: "EPERM" })).toBe(process.platform === "win32");
+        expect(isExclusiveCreateBlocked({ code: "EEXIST" })).toBe(true);
+    });
+});
+
+describe("RepositoryLock on Windows", () => {
+    it("queues behind a delete-pending lock file instead of failing the caller", async () => {
+        // The Windows leg of run 32789206621, reproduced: `ShelfStore.listShelves` met an ordinary
+        // shelf mutation on the store lock and got
+        // `EPERM: operation not permitted, open '...\.store-lock\store.lock'` instead of waiting.
+        // Before the classifier recognised that errno the raw EPERM left `acquire`, and
+        // `acquireWithBoundedWait` retries `RepositoryLockBusyError` and nothing else -- so the
+        // bounded wait never ran a second attempt.
+        pretendPlatform("win32");
+        exclusiveCreateFailure.code = "EPERM";
+        exclusiveCreateFailure.remaining = 1;
+        const common = await commonDir();
+
+        const release = await acquireWithBoundedWait(() => new RepositoryLock().acquire(common), {
+            timeoutMs: 1_000,
+            retryDelayMs: 10,
+        });
+
+        expect(
+            exclusiveCreateFailure.remaining,
+            "the injected EPERM must actually have been served, or this test proves nothing",
+        ).toBe(0);
+        await release();
+    });
+
+    it("still reports a POSIX EPERM as a fault rather than waiting on it", async () => {
+        // Same injection, same call path, only the platform differs -- so this is the assertion
+        // that fails if the errno is ever accepted unconditionally.
+        pretendPlatform("linux");
+        exclusiveCreateFailure.code = "EPERM";
+        exclusiveCreateFailure.remaining = 1;
+        const common = await commonDir();
+
+        await expect(
+            acquireWithBoundedWait(() => new RepositoryLock().acquire(common), {
+                timeoutMs: 1_000,
+                retryDelayMs: 10,
+            }),
+        ).rejects.toMatchObject({ code: "EPERM" });
+    });
+
+    it("ends a persistent delete-pending state at busy, never at a stolen lock", async () => {
+        // The safety claim the widening rests on: every path this predicate newly reaches runs
+        // into the busy/stale machinery, which dates an unreadable lock to now and an absent one
+        // to never-stale. So a create that keeps answering EPERM can only ever end here.
+        pretendPlatform("win32");
+        exclusiveCreateFailure.code = "EPERM";
+        exclusiveCreateFailure.remaining = Number.MAX_SAFE_INTEGER;
+        const common = await commonDir();
+
+        await expect(
+            acquireWithBoundedWait(() => new RepositoryLock().acquire(common), {
+                timeoutMs: 50,
+                retryDelayMs: 10,
+            }),
+        ).rejects.toBeInstanceOf(RepositoryLockBusyError);
     });
 });

--- a/tests/unit/publishing/ciHardeningWorkflows.test.ts
+++ b/tests/unit/publishing/ciHardeningWorkflows.test.ts
@@ -358,6 +358,161 @@ describe("CI quality hardening workflows", () => {
         expect(compatibility).toContain("windows-latest");
     });
 
+    it("restores before it installs, and keeps the browser out of the tree it packages", () => {
+        // Every assertion here guards a change that leaves the workflow GREEN and merely slow, which
+        // is why they are worth writing down: nothing in CI notices a cache that restores nothing.
+        // Baseline before these steps existed, run 32777133567 -- windows 28m41s against ubuntu's
+        // 9m, of which 206s was downloading Chromium and 76s was `bun install`.
+        const compatibility = readRepositoryFile(".github/workflows/compatibility.yml");
+        const job = extractJobBlock(compatibility, "compatibility");
+
+        const stepOffset = (stepName: string): number => {
+            const offset = job.indexOf(`            - name: ${stepName}\n`);
+            expect(offset, `the job must still contain a step named '${stepName}'`).not.toBe(-1);
+            return offset;
+        };
+
+        // Ordering is the whole mechanism. A cache step placed after the install it was meant to
+        // accelerate restores into a directory that is already populated and saves what the install
+        // just did anyway -- it costs time, saves none, and reads as configured in every review.
+        const restoreOffset = stepOffset("Restore the bun store and the Playwright browser");
+        const browserPathOffset = stepOffset(
+            "Point Playwright's browser download outside the packaged workspace",
+        );
+        const playwrightInstallOffset = stepOffset(
+            "Install the Playwright browser the comparator proof runs against",
+        );
+        expect(
+            restoreOffset,
+            "the cache must be restored before `bun install`, or it accelerates nothing",
+        ).toBeLessThan(stepOffset("Install dependencies"));
+        expect(
+            restoreOffset,
+            "the cache must be restored before the browser download it exists to skip",
+        ).toBeLessThan(playwrightInstallOffset);
+        expect(
+            browserPathOffset,
+            "PLAYWRIGHT_BROWSERS_PATH has to be exported before the install reads it; afterwards " +
+                "the browser lands in the platform default and the cache saves an empty directory",
+        ).toBeLessThan(playwrightInstallOffset);
+
+        const cacheStep = extractStepBlock(job, "Restore the bun store and the Playwright browser");
+        expect(cacheStep, "the restore step must still be a real cache").toContain(
+            "uses: actions/cache@",
+        );
+
+        const browserPathStep = extractStepBlock(
+            job,
+            "Point Playwright's browser download outside the packaged workspace",
+        );
+        expect(
+            browserPathStep,
+            "the exported value must survive the step that writes it",
+        ).toContain('>> "$GITHUB_ENV"');
+        const declaredBrowserPath = browserPathStep.match(/PLAYWRIGHT_BROWSERS_PATH=([^"]+)"/)?.[1];
+        expect(
+            declaredBrowserPath,
+            "the workflow must still declare a browser location",
+        ).toBeTypeOf("string");
+
+        // The two sides are compared rather than each matched against `ms-playwright`, because the
+        // failure mode is them DISAGREEING: a `path:` naming a directory the browser was never
+        // written to saves an empty tree, restores an empty tree, and re-downloads Chromium on
+        // every run while the step still reports a cache hit on the bun store beside it.
+        const cachedPaths = (cacheStep.match(/path: \|\n((?:\s+\S.*\n)+?)\s+key:/)?.[1] ?? "")
+            .trim()
+            .split("\n")
+            .map((line) => line.trim());
+        expect(
+            cachedPaths,
+            "the cached path and the exported browser location must name one directory",
+        ).toContain(declaredBrowserPath);
+
+        // `bun run package` runs `vsce` over the working tree a few steps down. A browser under
+        // `github.workspace` -- or any relative path, which resolves there -- is roughly 150MB of
+        // Chromium swept into the VSIX, and the smoke test that installs it would still pass.
+        expect(
+            declaredBrowserPath,
+            "the browser must not sit in the tree `vsce` packages",
+        ).not.toContain("github.workspace");
+        expect(
+            declaredBrowserPath,
+            "the browser location must be rooted at a runner-provided absolute directory; a " +
+                "relative path resolves inside the checkout",
+        ).toMatch(/^\$\{\{ runner\.[a-z_]+ \}\}\//);
+
+        // `hashFiles` returns an empty string for a path that matches nothing, so a typo here does
+        // not fail -- it collapses the key to its bare prefix, and the first run to save under that
+        // key owns it for every future run regardless of what the lockfile says afterwards.
+        const cacheKey = cacheStep.match(/^\s+key: (.+)$/m)?.[1] ?? "";
+        const hashedFiles = [...cacheKey.matchAll(/hashFiles\('([^']+)'\)/g)].map(
+            ([, file]) => file,
+        );
+        expect(hashedFiles, "the key must vary with the dependency set it caches").not.toEqual([]);
+        for (const file of hashedFiles) {
+            expect(
+                existsSync(resolve(REPOSITORY_ROOT, file)),
+                `the key hashes '${file}', which does not exist -- hashFiles would return "" and ` +
+                    "every run would collide on one permanently stale entry",
+            ).toBe(true);
+        }
+
+        // A `restore-keys` prefix that is not a prefix of `key` matches nothing, so the fallback
+        // silently stops existing and every dependency bump pays the full download again.
+        const restoreKey = (
+            cacheStep.match(/restore-keys: \|\n((?:\s+\S.*\n)+)/)?.[1] ?? ""
+        ).trim();
+        expect(restoreKey, "a fallback prefix must be declared").not.toBe("");
+        expect(
+            cacheKey.slice(0, restoreKey.length),
+            "restore-keys only ever matches a prefix of a saved key",
+        ).toBe(restoreKey);
+
+        const defenderStepName =
+            "Exclude the runner's working directories from Defender real-time scanning";
+        const defender = extractStepBlock(job, defenderStepName);
+
+        // First step on purpose. Checkout alone writes tens of thousands of files, and an exclusion
+        // added afterwards has already let Defender scan every one of them.
+        expect(
+            stepOffset(defenderStepName),
+            "the exclusion must precede checkout, whose own writes are the first thing it covers",
+        ).toBeLessThan(stepOffset("Checkout code"));
+
+        expect(
+            defender,
+            "`Add-MpPreference` does not exist off Windows, so the step must stay guarded",
+        ).toContain("if: runner.os == 'Windows'");
+
+        // This is the assertion with the worst consequence behind it. The Windows leg is a required
+        // status check: if a transient Defender failure fails this step, it fails the job, and that
+        // blocks every merge in the repository to save half an hour on one of them. A skipped
+        // exclusion costs time and nothing else.
+        expect(defender, "a required check must not be able to fail on an optimisation").toContain(
+            "continue-on-error: true",
+        );
+
+        // `$env:TEMP` is not redundant with `RUNNER_TEMP`; it is the entry that matters most. The
+        // fixture layer roots its work at `os.tmpdir()` -- `tests/fixtures/repo/harness.ts:126` for
+        // the E2E workspaces, `runFixtureSetup.ts:46` for the template repository -- and on a
+        // GitHub Actions Windows runner that resolves to `C:\Users\RUNNER~1\AppData\Local\Temp`,
+        // documented at `tests/fixtures/repo/placeholderCanonicalization.ts:34`. `RUNNER_TEMP` is a
+        // different directory on a different drive. Trimming the list to the two names that sound
+        // like the right ones would leave every seeded Git repository scanned file by file.
+        const requiredExclusions = [
+            "$env:GITHUB_WORKSPACE",
+            "$env:RUNNER_TEMP",
+            "$env:TEMP",
+            "$env:USERPROFILE\\.bun",
+        ];
+        for (const location of requiredExclusions) {
+            expect(
+                defender,
+                `'${location}' is written to heavily by this job and must be excluded`,
+            ).toContain(location);
+        }
+    });
+
     it("covers installed-package portability and makes Dependabot update both actionable ecosystems", () => {
         const compatibility = readRepositoryFile(".github/workflows/compatibility.yml");
         const dependabot = readRepositoryFile(".github/dependabot.yml");

--- a/tests/unit/publishing/ciHardeningWorkflows.test.ts
+++ b/tests/unit/publishing/ciHardeningWorkflows.test.ts
@@ -358,11 +358,12 @@ describe("CI quality hardening workflows", () => {
         expect(compatibility).toContain("windows-latest");
     });
 
-    it("restores before it installs, and keeps the browser out of the tree it packages", () => {
-        // Every assertion here guards a change that leaves the workflow GREEN and merely slow, which
-        // is why they are worth writing down: nothing in CI notices a cache that restores nothing.
-        // Baseline before these steps existed, run 32777133567 -- windows 28m41s against ubuntu's
-        // 9m, of which 206s was downloading Chromium and 76s was `bun install`.
+    it("keeps the Windows leg off the two costs that were measured, not guessed", () => {
+        // Every assertion here guards a change that leaves the workflow GREEN and merely slow --
+        // nothing in CI notices a cache that restores nothing, or an OS feature install nobody
+        // needs. Both costs below were established by A/B on one commit rather than read off a
+        // step name, because reading a duration and naming a cause is how the browser cache that
+        // used to live here got written in the first place.
         const compatibility = readRepositoryFile(".github/workflows/compatibility.yml");
         const job = extractJobBlock(compatibility, "compatibility");
 
@@ -375,71 +376,47 @@ describe("CI quality hardening workflows", () => {
         // Ordering is the whole mechanism. A cache step placed after the install it was meant to
         // accelerate restores into a directory that is already populated and saves what the install
         // just did anyway -- it costs time, saves none, and reads as configured in every review.
-        const restoreOffset = stepOffset("Restore the bun store and the Playwright browser");
-        const browserPathOffset = stepOffset(
-            "Point Playwright's browser download outside the packaged workspace",
-        );
-        const playwrightInstallOffset = stepOffset(
-            "Install the Playwright browser the comparator proof runs against",
-        );
+        // Measured on Windows: `bun install` 75s cold against 19s restored.
         expect(
-            restoreOffset,
+            stepOffset("Restore the bun store"),
             "the cache must be restored before `bun install`, or it accelerates nothing",
         ).toBeLessThan(stepOffset("Install dependencies"));
-        expect(
-            restoreOffset,
-            "the cache must be restored before the browser download it exists to skip",
-        ).toBeLessThan(playwrightInstallOffset);
-        expect(
-            browserPathOffset,
-            "PLAYWRIGHT_BROWSERS_PATH has to be exported before the install reads it; afterwards " +
-                "the browser lands in the platform default and the cache saves an empty directory",
-        ).toBeLessThan(playwrightInstallOffset);
 
-        const cacheStep = extractStepBlock(job, "Restore the bun store and the Playwright browser");
+        const cacheStep = extractStepBlock(job, "Restore the bun store");
         expect(cacheStep, "the restore step must still be a real cache").toContain(
             "uses: actions/cache@",
         );
 
-        const browserPathStep = extractStepBlock(
-            job,
-            "Point Playwright's browser download outside the packaged workspace",
-        );
+        // `--with-deps` means two entirely different things by platform. On Linux it apt-installs
+        // libraries Chromium cannot launch without. On Windows it runs DISM to enable Media
+        // Foundation, a VIDEO CODEC pack, and that is the entire cost of this step: 202s with the
+        // browser already restored from cache (run 32783641129 attempt 2) against 200s with a
+        // cache miss and a fresh download (run 32785953517) -- the browser is not what it spends
+        // its time on. Nothing in this repository records video, and the only consumer takes
+        // screenshots. Making the flag unconditional again silently returns ~190s per run to the
+        // one leg that gates every merge, with no test failing.
+        const playwrightRun =
+            extractStepBlock(
+                job,
+                "Install the Playwright browser the comparator proof runs against",
+            ).match(/^\s+run: (.+)$/m)?.[1] ?? "";
         expect(
-            browserPathStep,
-            "the exported value must survive the step that writes it",
-        ).toContain('>> "$GITHUB_ENV"');
-        const declaredBrowserPath = browserPathStep.match(/PLAYWRIGHT_BROWSERS_PATH=([^"]+)"/)?.[1];
+            playwrightRun,
+            "`--with-deps` must stay gated to Linux; on Windows it installs video codecs that " +
+                "nothing here uses, and it is the whole cost of this step",
+        ).toMatch(/runner\.os == 'Linux'.*--with-deps/);
         expect(
-            declaredBrowserPath,
-            "the workflow must still declare a browser location",
-        ).toBeTypeOf("string");
+            playwrightRun,
+            "the browser itself must still be installed on every platform",
+        ).toContain("chromium");
 
-        // The two sides are compared rather than each matched against `ms-playwright`, because the
-        // failure mode is them DISAGREEING: a `path:` naming a directory the browser was never
-        // written to saves an empty tree, restores an empty tree, and re-downloads Chromium on
-        // every run while the step still reports a cache hit on the bun store beside it.
-        const cachedPaths = (cacheStep.match(/path: \|\n((?:\s+\S.*\n)+?)\s+key:/)?.[1] ?? "")
-            .trim()
-            .split("\n")
-            .map((line) => line.trim());
+        // The Playwright browser was cached here and has been removed: it changed this step's cost
+        // by 2s while adding ~170MB to an archive Windows spends 73s untarring. Re-adding it is a
+        // regression that looks like an optimisation, so the cache is pinned to the bun store.
         expect(
-            cachedPaths,
-            "the cached path and the exported browser location must name one directory",
-        ).toContain(declaredBrowserPath);
-
-        // `bun run package` runs `vsce` over the working tree a few steps down. A browser under
-        // `github.workspace` -- or any relative path, which resolves there -- is roughly 150MB of
-        // Chromium swept into the VSIX, and the smoke test that installs it would still pass.
-        expect(
-            declaredBrowserPath,
-            "the browser must not sit in the tree `vsce` packages",
-        ).not.toContain("github.workspace");
-        expect(
-            declaredBrowserPath,
-            "the browser location must be rooted at a runner-provided absolute directory; a " +
-                "relative path resolves inside the checkout",
-        ).toMatch(/^\$\{\{ runner\.[a-z_]+ \}\}\//);
+            cacheStep.match(/^\s+path: (.+)$/m)?.[1],
+            "the cache holds the bun store only; the browser measurably did not benefit from it",
+        ).toBe("~/.bun/install/cache");
 
         // `hashFiles` returns an empty string for a path that matches nothing, so a typo here does
         // not fail -- it collapses the key to its bare prefix, and the first run to save under that


### PR DESCRIPTION
## What

The Windows portability leg became a **required status check** when #227 merged, so its ~26 minutes now sits in front of every merge in this repository. macOS and ubuntu finish the same commit in ~9 minutes.

This PR went out with three levers, then measured them. One worked, one was aimed at a cost that does not exist, and measuring it turned up a larger cost sitting next to it. The final change is: **exclude the runner's working directories from Defender, cache the bun store, and stop installing a video codec pack on Windows.**

Making the leg gating then made it fail, on a real Windows bug three earlier runs had happened to get away with. That fix is here too, as its own commit.

## Why the leg is slow

Filesystem and process overhead, not CPU. Every file syscall crosses the NTFS filter-driver stack with Defender scanning each newly created file, and this job seeds real Git repositories, copies template trees, and writes thousands of tiny loose objects.

## What was measured

Three runs, all on this branch:

| | run | cache | Windows total |
| --- | --- | --- | ---: |
| baseline (before this PR) | `32777133567` | — | **1721s** |
| cold | `32783641129` attempt 1 | miss | 1587s |
| warm | `32783641129` attempt 2 | **hit** | 1575s |
| control | `32785953517` | miss (different ref) | 1574s |
| codec pack dropped | `32789206621` | miss | 1499s, **failed** |
| **final, all legs green** | `32792737622` | miss (key changed) | **1523s** |

### Lever 1 — Defender exclusion: directionally positive, but inside the noise

Originally reported here as `Run tests` **1253s → 1082s (−171s)**. Three further runs do not
sustain that figure, and it is corrected rather than left standing:

| Defender | `Run tests` |
| --- | ---: |
| off (baseline `32777133567`) | 1253s |
| on | 1121s, 1240s, 1212s |

Every Defender-on run beat the single baseline, so the direction is consistent. But the spread
*between* the on-runs is 119s, comparable to the gap being claimed, and the −171s originally
quoted was the fastest of the three rather than a repeatable result. On this evidence the honest
statement is "probably worth some tens of seconds, not separable from run-to-run variance at
n=1 for the baseline".

The step is cheap (6-18s) and `continue-on-error`, so it stays; it is simply not the lever that
produced the improvement below.

Placed as the **first step, before checkout**, so it also covers the tens of thousands of files checkout itself writes. `TEMP` is the entry that looks redundant next to `RUNNER_TEMP` and matters most: the fixture layer roots every E2E workspace (`tests/fixtures/repo/harness.ts:126`) and the template repository (`runFixtureSetup.ts:46`) at `os.tmpdir()`, which on this runner is `C:\Users\RUNNER~1\AppData\Local\Temp` — a different drive from `RUNNER_TEMP` (`D:\a\_temp`), as already documented at `placeholderCanonicalization.ts:34`.

`continue-on-error: true` is deliberate: this leg is a required check, so a Defender hiccup that failed the step would block every merge in the repository to save half an hour on one of them.

### Lever 2 — caching the Playwright browser: measured zero, removed

The warm run restored the browser from cache and `playwright install` still took **202s**. The control run missed the cache and downloaded the browser fresh: **200s**. Present or absent, the browser changes nothing — it was never what that step spends time on.

So the browser is out of the cache, and the `PLAYWRIGHT_BROWSERS_PATH` redirect that existed only to make it cacheable is deleted with it. It was adding ~170MB to an archive Windows spends **73s** untarring.

### Lever 3 — caching the bun store: worked, kept

`bun install` **75s cold → 19s restored**. Now the only thing in the cache, so the archive is small enough for the restore not to eat the saving.

### The cost the measurement actually found

`Install the Playwright browser` was never installing a browser, in the sense that mattered. Its **entire output** on Windows is:

```
Success Restart Needed Exit Code      Feature Result
True    No             Success        {Media Foundation}
```

That is `--with-deps` running DISM to enable Media Foundation — a **video codec pack** — for ~190s per run.

Nothing in this repository records video: there is no `recordVideo` and no `video:` configuration anywhere. The only Chromium consumer is `screenshotComparatorMeta.test.ts`, which launches a browser to take screenshots and states its own requirement as `bunx playwright install chromium` at line 163, without the flag.

`--with-deps` is now gated to Linux, where it apt-installs libraries Chromium genuinely cannot launch without. macOS needs no OS packages either.

**This is the lever that produced the result.** `Install the Playwright browser` went **202s → 17s
(−185s)**, against a whole-leg improvement of −198s — so essentially all of the confirmed saving
is this one line. Unlike lever 1, it is a single isolated step with a single cause visible in its
own log, and the Windows leg's `screenshotComparatorMeta.test.ts` passed on the final run, which
is the check that the dropped flag was not load-bearing.

## The bug the leg found

With the leg gating a merge, run `32789206621` failed on a test whose name is the assertion:

```
FAIL  tests/unit/shelf/store.test.ts > ShelfStore
      > queues a catalog read behind an in-flight mutation instead of failing it
EPERM: operation not permitted, open '...\.store-lock\store.lock'
```

`RepositoryLock.acquire` claims its lock file with `flag: "wx"` -- create, but fail if it already
exists -- and judged that failure by `EEXIST` alone. Windows answers `EEXIST` too, except while
the previous lock file is **delete-pending**: `rm` on a file another handle still holds open marks
the name rather than removing it, and `CreateFile(CREATE_NEW)` against a marked name returns
ERROR_ACCESS_DENIED, which libuv maps to `EPERM`. The lock's own release path manufactures that
state -- `readLockFile` closes its handle asynchronously and the release removes the path right
after reading it back -- so a release racing a contender lands in it.

The raw `EPERM` then left `acquire` instead of `RepositoryLockBusyError`, and
`acquireWithBoundedWait` retries only the latter. Contention POSIX rides out was an immediate hard
failure for the caller, and the bounded wait never ran a second attempt. This is a user-facing
Windows bug, not a CI artifact: it is reached from `ShelfService.listShelves`, which the commit
panel calls on every refresh.

`isExclusiveCreateBlocked` now accepts that errno as well, on Windows only. **The widening cannot
widen what the lock grants:** both call sites use it only to decide whether to fall through to the
busy/stale machinery, and that machinery dates an unreadable lock to *now* -- so it can never be
stale -- and never takes over an absent one. Every path the widening newly reaches ends at
`RepositoryLockBusyError`. `platform` is a parameter so the branch is reachable from a POSIX test
run, matching `resolveNoFollowFlag`, which closed a Windows-only defect of the same family in #223.

Not changed, because the direction is not the same at every exclusive create: `ShelfStore.putObject`
is content-addressed, where `EEXIST` means "these exact bytes already exist" and is verified by
hash -- accepting `EPERM` there would read the file and could raise a spurious corruption error.
`src/git/operations.ts:1039` *does* have the same shape on Git's `index.lock`; it has no observed
failure and is left for its own PR rather than riding along in this one.

## Why there are tests for a speedup

Every one of these fails **silently** — the workflow stays green and merely stops saving anything. The browser cache is the proof: it was green, it reported a cache hit, and it did nothing. So `ciHardeningWorkflows` pins the relationships rather than the strings:

- the cache is restored **before** `bun install`
- `--with-deps` stays gated to Linux, and `chromium` is still installed everywhere
- the cache `path:` stays pinned to the bun store rather than growing the browser back
- `hashFiles(...)` names a file that **exists** — a typo returns `""`, collapsing the key to its bare prefix so the first run to save owns it forever
- `restore-keys` is genuinely a prefix of `key`
- the Defender step precedes checkout, stays Windows-guarded, keeps `continue-on-error`, and still lists all four locations

## The bun store cache has not paid out yet

`Install dependencies` was **98s** on the final run, not the 19s the warm run measured. The cache
missed, and the log says why:

```
Cache not found for input keys: Windows-portability-e6dffd6b...
Cache saved with key:           Windows-portability-e6dffd6b...
```

`actions/cache` keys an entry by `(key, version)`, where *version* hashes the `path:` list --- so
removing the browser from `path:` invalidated every existing entry under an unchanged key. The run
that would have re-saved it was the one that failed, and `save-always` is false. This run saved.
The next run on this branch should show `Install dependencies` at ~19s, taking the leg to roughly
**1444s**; that figure is a projection from the warm run, not a measurement.

## Note on cache scope

The cache entries save under `refs/pull/228/merge`, so **other PRs get no benefit until this merges to main** — proven by the control run above, which missed on `refs/heads/...` despite an identical key. After merge, the default-branch entry is visible to every PR. The Defender and `--with-deps` levers work immediately on any branch.

## Test plan

- [x] `format:check`, `lint:strict`, `lint:complexity`, `typecheck`, `architecture:check`, `verify:manifest`, `l10n:validate`, `build` — all rc=0
- [x] `bun vitest run` — **4208 passed (4208)**, 303 files
- [x] Mutation pass **13/13 killed**, every red naming the gate and every run still collecting the full 8-test baseline — including `--with-deps` made unconditional, the gate inverted to Windows, `chromium` dropped, and the browser re-added to the cache path
- [x] pre-commit hook (nine checks incl. `vsce package`) — clean
- [x] `detect_changes()` — 0 changed symbols, 0 affected processes
- [x] Three legs green on runs `32783641129` (both attempts) and `32785953517`
- [ ] **Windows wall clock after dropping `--with-deps`** — the remaining unknown, measured on this push against the 1575s warm run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository lock handling on Windows to correctly detect contention and return a busy-lock result instead of an unexpected permission error.
  * Added bounded waiting behavior for delete-pending lock files, preventing accidental lock takeover.

* **CI Improvements**
  * Hardened compatibility workflows with Bun caching and platform-specific Playwright installation.
  * Added best-effort Windows Defender exclusions to improve build reliability.
  * Added automated validation for workflow ordering, caching, platform guards, and exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

