### PR TITLE
fix(windows): let the index restore recognise a delete-pending lock (v0.27.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.6] - 2026-08-25
+
+### Fixed
+
+- Fixed restoring the Git index after a commit failing outright on Windows instead of degrading as it was built to. Committing part of a file's changes snapshots the index first and puts it back afterwards, and putting it back creates an `<index>.lock` file exclusively, so that a concurrent `git status` never reads a half-written index. A lock that already exists means another Git process is mid-write, so the restore waits briefly and, if the contention outlasts that, falls back to copying the index directly — getting the user's index back matters more than strict atomicity. Whether the lock already existed was decided by one error code, `EEXIST`, which is what POSIX answers. Windows answers `EPERM` instead whenever the name is *delete-pending* — the state left behind every time Git removes the lock while a handle on it is still open, which is to say after every index write it performs. Read as a fault rather than as contention, that code skipped the wait and the fallback both, so the one path written to degrade gracefully failed outright, on the platform where Git holds that lock most often, and left the index with the commit's temporary unstaging still applied. The decision now uses the same shared check the repository lock uses, which accepts the second code on Windows alone.
+- Fixed a repository lock being reported as a permission error rather than waited for, on Windows. The lock is claimed by creating its record exclusively, and a record that already exists means another window holds the lock — which callers recognise in order to wait briefly and retry, since the hold is normally momentary. That condition was recognised by the same POSIX-only error code, so on Windows a lock whose record was delete-pending surfaced as `EPERM: operation not permitted` and every waiting caller was skipped: the operation failed immediately, naming a permission problem that did not exist, instead of retrying and succeeding. Widening the check cannot widen what the lock grants, because every path it opens still ends at the same busy verdict.
+
 ## [0.27.5] - 2026-08-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.27.5",
+    "version": "0.27.6",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/git/operations.ts
+++ b/src/git/operations.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import { readEmptyTreeOid } from "./emptyTree";
 import { GitExecutor } from "./executor";
 import { resolveGitDir } from "./gitDirectory";
+import { isExclusiveCreateBlocked } from "./repositoryLock";
 import {
     WHOLE_INDEX_OPERATION_MARKERS,
     type WholeIndexOperationMarker,
@@ -1023,6 +1024,13 @@ export class GitOps {
      * retried briefly since that window is normally sub-second. If contention persists past the
      * retry budget, restoring the user's index takes priority over strict atomicity, so this
      * falls back to a direct, non-atomic copy rather than failing the restore outright.
+     *
+     * "Existing" is judged by `isExclusiveCreateBlocked` rather than by `EEXIST` alone, because
+     * Windows does not always answer `EEXIST`. Git removes `index.lock` on every write, and a
+     * removal whose handle is still open leaves the name *delete-pending*, where the exclusive
+     * create below returns `EPERM` instead. Read as a fault rather than as contention, that errno
+     * skipped both the retry and the fallback -- so the one path deliberately built to degrade
+     * gracefully failed outright, on the platform where Git contends most.
      */
     private async restoreIndexSnapshot(snapshotPath: string, indexPath: string): Promise<void> {
         const lockPath = `${indexPath}.lock`;
@@ -1036,7 +1044,7 @@ export class GitOps {
                 // react-doctor-disable-next-line react-doctor/async-await-in-loop
                 await writeFile(lockPath, snapshotBytes, { flag: "wx" });
             } catch (error) {
-                if (!isLockAlreadyExistsError(error)) throw error;
+                if (!isExclusiveCreateBlocked(error)) throw error;
                 if (attempt < maxAttempts - 1) {
                     await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
                     continue;
@@ -1844,13 +1852,6 @@ async function pathExists(filePath: string): Promise<boolean> {
     } catch {
         return false;
     }
-}
-
-/** Returns whether an `fs` error indicates the target path already exists (e.g. `EEXIST` from an exclusive create). */
-function isLockAlreadyExistsError(error: unknown): boolean {
-    return (
-        typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST"
-    );
 }
 
 /** Returns whether Git reported a path absent from an otherwise valid treeish. */

--- a/tests/unit/git/operationsIndexLockEperm.test.ts
+++ b/tests/unit/git/operationsIndexLockEperm.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Pins how `restoreIndexSnapshot` judges a contended `index.lock`.
+ *
+ * The defect is invisible on the host that runs this suite. On POSIX an occupied path answers
+ * `EEXIST` and always did, so the sibling test in `operations.test.ts` -- which plants a real
+ * `.lock` file and asserts the copy fallback -- passes identically with and without the fix. Only
+ * the errno Windows substitutes tells them apart, and it has to be supplied rather than waited for.
+ *
+ * Kept out of `operations.test.ts` deliberately: `vi.mock` applies to a whole module for the whole
+ * file, and that file has thirty-odd tests with no interest in a mocked filesystem.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+
+/** Makes the exclusive create of an `index.lock` fail with a chosen errno for the next
+ * `remaining` attempts, so the errno Windows answers with is reachable from a POSIX host, and
+ * records how often the lock was renamed onto the index. That count is the only thing separating
+ * the two restore paths: both end with the original bytes back in place and no `.lock` left
+ * behind, so bytes alone cannot say whether the restore stayed atomic or degraded to a copy. */
+const indexLockProbe = vi.hoisted(() => ({
+    code: undefined as string | undefined,
+    remaining: 0,
+    renamesOntoIndex: 0,
+}));
+
+// Node's built-in `node:fs/promises` exports non-configurable properties, so `vi.spyOn` cannot wrap
+// them; `vi.mock` with a pass-through factory is vitest's standard workaround. Keyed on the `.lock`
+// suffix so the snapshot copy, the index read and this file's own fixture writes are untouched.
+vi.mock("node:fs/promises", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:fs/promises")>();
+    const writeFileWithInjectedLockFailure: typeof actual.writeFile = async (
+        file,
+        data,
+        options,
+    ) => {
+        const injected = indexLockProbe.code;
+        if (
+            injected !== undefined &&
+            indexLockProbe.remaining > 0 &&
+            String(file).endsWith(".lock")
+        ) {
+            indexLockProbe.remaining -= 1;
+            // Shaped like the real thing down to the syscall: the syscall name is what identifies
+            // an exclusive create rather than a rename or an unlink in a captured failure.
+            const failure: NodeJS.ErrnoException = new Error(
+                `${injected}: operation not permitted, open '${String(file)}'`,
+            );
+            failure.code = injected;
+            failure.syscall = "open";
+            throw failure;
+        }
+        return actual.writeFile(file, data, options);
+    };
+    // `restoreIndexSnapshot` holds the only `rename` in the module under test and its source is
+    // always the lock, so a `.lock` source identifies the atomic path with no ambiguity.
+    const renameCountingLockRenames: typeof actual.rename = async (from, to) => {
+        if (String(from).endsWith(".lock")) indexLockProbe.renamesOntoIndex += 1;
+        return actual.rename(from, to);
+    };
+    return {
+        ...actual,
+        writeFile: writeFileWithInjectedLockFailure,
+        rename: renameCountingLockRenames,
+    };
+});
+
+const execFileAsync = promisify(execFile);
+const directories: string[] = [];
+const originalPlatform = process.platform;
+
+/** Supplies the platform rather than inheriting it, so the Windows branch is reachable on POSIX. */
+function pretendPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+afterEach(async () => {
+    indexLockProbe.code = undefined;
+    indexLockProbe.remaining = 0;
+    indexLockProbe.renamesOntoIndex = 0;
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+async function git(directory: string, args: string[]): Promise<string> {
+    const { stdout } = await execFileAsync("git", args, { cwd: directory });
+    return stdout;
+}
+
+/** A staged repository plus the absolute path of its live index, resolved as production does. */
+async function stagedRepository(): Promise<{ root: string; indexPath: string }> {
+    const root = await mkdtemp(path.join(tmpdir(), "intelligit-index-lock-"));
+    directories.push(root);
+    await git(root, ["init"]);
+    await writeFile(path.join(root, "a.txt"), "a\n");
+    await git(root, ["add", "a.txt"]);
+    const reported = (await git(root, ["rev-parse", "--git-path", "index"])).trim();
+    return {
+        root,
+        indexPath: path.isAbsolute(reported) ? reported : path.resolve(root, reported),
+    };
+}
+
+describe("GitOps.withIndexSnapshot against a delete-pending index.lock", () => {
+    it("restores through the copy fallback when the lock keeps answering the Windows errno", async () => {
+        // The whole point. Git removes `index.lock` on every write, and a removal whose handle is
+        // still open leaves the name delete-pending -- where the exclusive create answers `EPERM`,
+        // not `EEXIST`. Judged a fault rather than contention, that errno skipped the retry AND
+        // the deliberate copy fallback, so the one path built to degrade gracefully failed
+        // outright and left the index "with the commit's temporary unstaging applied".
+        pretendPlatform("win32");
+        indexLockProbe.code = "EPERM";
+        indexLockProbe.remaining = Number.MAX_SAFE_INTEGER;
+        const { root, indexPath } = await stagedRepository();
+        const originalIndexBytes = await readFile(indexPath);
+
+        const result = await new GitOps(new GitExecutor(root)).withIndexSnapshot(async () => {
+            // A real `git` write would contend for the same lock, so the index bytes are mutated
+            // directly to isolate this test to the restore.
+            await writeFile(indexPath, "mutated-index-bytes-outside-git");
+            return "operation-result";
+        });
+
+        expect(result).toBe("operation-result");
+        await expect(readFile(indexPath)).resolves.toEqual(originalIndexBytes);
+        expect(
+            indexLockProbe.remaining,
+            "the injected EPERM must actually have been served, or this test proves nothing",
+        ).toBeLessThan(Number.MAX_SAFE_INTEGER);
+        expect(
+            indexLockProbe.renamesOntoIndex,
+            "the lock never opened, so the restore must have come from the copy fallback",
+        ).toBe(0);
+    });
+
+    it("retries onto the atomic path when the delete-pending window closes", async () => {
+        // The fallback above is the degraded outcome. This is the one that should normally happen:
+        // the window is sub-second, so the second attempt creates the lock for real and the
+        // restore stays atomic. A fix that only reached the fallback would pass the test above
+        // and still have given up the atomicity the method exists to provide.
+        pretendPlatform("win32");
+        indexLockProbe.code = "EPERM";
+        indexLockProbe.remaining = 1;
+        const { root, indexPath } = await stagedRepository();
+        const originalIndexBytes = await readFile(indexPath);
+
+        await new GitOps(new GitExecutor(root)).withIndexSnapshot(async () => {
+            await writeFile(indexPath, "mutated-index-bytes-outside-git");
+        });
+
+        expect(indexLockProbe.remaining, "the injected EPERM must have been served").toBe(0);
+        expect(
+            indexLockProbe.renamesOntoIndex,
+            "the second attempt must rename the lock onto the index; a copy would restore the same bytes and leave no lock behind, so only this count tells the two apart",
+        ).toBe(1);
+        await expect(readFile(indexPath)).resolves.toEqual(originalIndexBytes);
+        await expect(
+            readFile(`${indexPath}.lock`),
+            "the lock must be renamed onto the index, never left behind",
+        ).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("still reports a POSIX EPERM as a fault rather than degrading quietly", async () => {
+        // The other direction, and the one that keeps the widening honest. POSIX answers `EEXIST`
+        // for an occupied path, so an `EPERM` there is a real permission fault. Swallowing it
+        // everywhere would turn a broken `.git` directory into a silent non-atomic copy -- or,
+        // once the copy failed too, into a message about lock contention that never happened.
+        pretendPlatform("linux");
+        indexLockProbe.code = "EPERM";
+        indexLockProbe.remaining = 1;
+        const { root, indexPath } = await stagedRepository();
+
+        await expect(
+            new GitOps(new GitExecutor(root)).withIndexSnapshot(async () => {
+                await writeFile(indexPath, "mutated-index-bytes-outside-git");
+            }),
+        ).rejects.toThrow(/EPERM/);
+    });
+});


### PR DESCRIPTION
`restoreIndexSnapshot` puts the index back after a commit that staged only part of a file. It writes the snapshot to `<index>.lock` with an exclusive create, then renames it onto the index, so a concurrent `git status` never reads a half-written file. A lock that already exists means another Git process is mid-write, so it waits briefly and — if the contention outlasts the budget — falls back to a direct copy rather than fail. That fallback is deliberate: getting the user's index back matters more than strict atomicity.

Whether the lock already existed was judged by `EEXIST` alone.

Windows answers `EPERM` instead whenever the name is *delete-pending*: `DeleteFile` against a name another handle still holds open marks the name rather than removing it, and every `CreateFile(CREATE_NEW)` against a marked name returns `ERROR_ACCESS_DENIED` until the last handle closes. libuv maps that to `EPERM`. Git produces exactly that state after every index write, because it removes `index.lock` while still holding it.

Read as a fault rather than as contention, that errno skipped the retry **and** the fallback. The one path built to degrade gracefully failed outright — on the platform where Git holds that lock most often — and `withIndexSnapshot` surfaced *"The commit succeeded, but restoring the Git index snapshot failed"*, leaving the index with the commit's temporary unstaging still applied.

## The change

One call site. `isLockAlreadyExistsError` had exactly one caller and is deleted; the site now calls `isExclusiveCreateBlocked`, which `repositoryLock.ts` already adopted for the identical defect. Net −7 lines of code, +7 of comment.

Two sibling exclusive creates were checked and **deliberately left alone**:

| Site | Verdict |
|---|---|
| `ShelfStore.putObject` (`src/shelf/store.ts:210`) | Content-addressed. `EEXIST` means the identical bytes are already stored, verified by hash. Accepting `EPERM` would read a file that may not be readable and could raise a spurious `ShelfStoreCorruptionError`. |
| review-prompt latch (`src/services/reviewPrompt.ts:633`) | Once-only. The errno is not a contention signal there at all. |

Direction was checked adversarially before the edit. If an `EPERM` here were a genuine ACL fault, the fix costs 150ms of retry and then a `copyFile` that fails the same way — same error class, no regression. If it is delete-pending contention, the current code throws and corrupts the user's staging. Asymmetric in favour of widening.

## Reproduction

The defect is invisible on the host that runs this suite. The existing sibling test in `operations.test.ts` plants a real `.lock` file and asserts the copy fallback — on POSIX that yields `EEXIST`, so it passes **identically with and without this fix**. The errno has to be injected rather than waited for.

`tests/unit/git/operationsIndexLockEperm.test.ts` (new, 3 tests) mocks `node:fs/promises` with a pass-through factory keyed on the `.lock` suffix, and supplies the platform via `Object.defineProperty`. Kept out of `operations.test.ts` because `vi.mock` applies to a whole module for a whole file, and that file has 51 tests with no interest in a mocked filesystem — verified still 51/51.

The factory also **counts renames onto the index**. That count is load-bearing: both restore paths end with the original bytes back in place and no `.lock` left behind, so bytes alone cannot say whether the restore stayed atomic or degraded to a copy. Without it the retry test was blind — the first mutation run proved it by surviving `maxAttempts 3 → 1`.

## Mutation proof — KILLED 5/5

Both directions the fix has to hold, plus three that test the tests. 27 collected under every mutation (a crashed runner counterfeits a kill), sources restored byte-identical, verified by SHA-256.

| Mutation | Verdict | The red it names |
|---|---|---|
| revert to the `EEXIST`-only classifier | KILLED | `restores through the copy fallback…` + `retries onto the atomic path…` |
| drop the `win32` gate in the shared helper | KILLED | `still reports a POSIX EPERM as a fault…` + 3 in `repositoryLock` |
| accept every errno | KILLED | same, + 4 in `repositoryLock` |
| `maxAttempts 3 → 1` | KILLED | `retries onto the atomic path…` (`renamesOntoIndex` 1 → 0) |
| skip the copy fallback | KILLED | `restores through the copy fallback…` |

Mutations 2 and 3 going red in `repositoryLock.test.ts` as well is the proof that the helper is genuinely shared rather than copied.

## Gates

`format:check`, `lint:strict`, `lint:complexity`, `typecheck`, `architecture:check`, `verify:manifest`, `l10n:validate`, `build` — all rc=0. `architecture:check` matters specifically here: `operations.ts → repositoryLock.ts` is a new module edge.

Full suite: **4218 passed, 0 failed** (304 files, 422s). Main was 4215; +3 is exactly this PR's tests.

`impact({target: "restoreIndexSnapshot"})` → **LOW** (1 direct caller, 0 processes). `detect_changes` → medium, 5 processes, all attached to the `GitOps` class rather than to this private method — fan-in, not blast radius.

## Also in this PR

`isExclusiveCreateBlocked` landed in #228 under a `ci:` title with no version bump and **no changelog entry**, so that half of the same defect would have shipped unrecorded. 0.27.6 logs both.

## Not fixed here — a separate Windows exposure in the same method

`rename(lockPath, indexPath)` (`src/git/operations.ts:1059`) is the atomic step *after* the lock is won. Windows refuses a rename onto a file another process holds open — and `git status` holds the index open. That path has no fallback: it `rm`s the lock and rethrows, bypassing the `copyFile` the exclusive-create path is careful to reach. Reported rather than fixed to keep this PR to the classifier; it needs its own reproduction and proof.
