### PR TITLE
test(windows): route every recursive scratch removal through the retrying delete

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -202,8 +202,14 @@ export default defineConfig([
                     // import, because 29 removals in tests/ are single files (`rm(file)`,
                     // `rm(x, { force: true })`) that have no readdir/rmdir window to lose and
                     // must stay legal. A recursive removal is the only shape at risk.
+                    //
+                    // Exempting `recursive: false` specifically -- rather than requiring
+                    // `recursive: true` -- is the fail-safe direction. A flag this rule cannot
+                    // read statically (`{ recursive: deep }`) still reports, because a false
+                    // positive costs one word and a missed one puts the flake back. Only the
+                    // provably non-recursive spelling is let through.
                     selector:
-                        'CallExpression:matches([callee.name=/^rm(Sync)?$/], [callee.property.name=/^rm(Sync)?$/]) > ObjectExpression:has(Property[key.name="recursive"]):not(:has(Property[key.name="maxRetries"]))',
+                        'CallExpression:matches([callee.name=/^rm(Sync)?$/], [callee.property.name=/^rm(Sync)?$/]) > ObjectExpression:has(Property[key.name="recursive"]):not(:has(Property[key.name="recursive"][value.raw="false"])):not(:has(Property[key.name="maxRetries"]))',
                     message:
                         "Recursive removals in tests must retry: use removeScratchDirectories / removeScratchDirectoriesSync from tests/helpers/scratchDirectories. Git keeps writing into .git/objects/pack after its command returns, so a bare recursive rm loses the rmdir race and fails whichever row is executing -- it took the Windows leg red repeatedly.",
                 },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -186,6 +186,31 @@ export default defineConfig([
         },
     },
     {
+        // Its OWN block on purpose, with no `ignores`. The `tests/**/*.ts` block above carries an
+        // ignore list that exists for the oracle-import rule, and `tests/unit/e2e/oracles.test.ts`
+        // alone holds seven recursive removals -- hanging this rule there would exempt exactly the
+        // files nobody would think to re-check, and it would lint clean while doing it.
+        files: ["tests/**/*.ts"],
+        languageOptions: {
+            parser: tseslint.parser,
+        },
+        rules: {
+            "no-restricted-syntax": [
+                "error",
+                {
+                    // Keyed on `recursive` present and `maxRetries` absent rather than on the
+                    // import, because 29 removals in tests/ are single files (`rm(file)`,
+                    // `rm(x, { force: true })`) that have no readdir/rmdir window to lose and
+                    // must stay legal. A recursive removal is the only shape at risk.
+                    selector:
+                        'CallExpression:matches([callee.name=/^rm(Sync)?$/], [callee.property.name=/^rm(Sync)?$/]) > ObjectExpression:has(Property[key.name="recursive"]):not(:has(Property[key.name="maxRetries"]))',
+                    message:
+                        "Recursive removals in tests must retry: use removeScratchDirectories / removeScratchDirectoriesSync from tests/helpers/scratchDirectories. Git keeps writing into .git/objects/pack after its command returns, so a bare recursive rm loses the rmdir race and fails whichever row is executing -- it took the Windows leg red repeatedly.",
+                },
+            ],
+        },
+    },
+    {
         files: SCRIPT_FILES,
         ...js.configs.recommended,
         languageOptions: {

--- a/tests/fixtures/repo/harness.ts
+++ b/tests/fixtures/repo/harness.ts
@@ -47,6 +47,7 @@ import { DEFAULT_MANIFEST_PATH, readFixtureManifest } from "./manifest";
 import { rehydrateCopy } from "./rehydrate";
 import { REPOSITORY_SCENARIOS, type RepositoryScenarioId } from "./scenarios";
 import { createSanitizedGitEnv } from "./seed";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** What `createFixtureWorkspace()` returns -- matches PLAN.md line 60's stated shape
  * (`{ root, originRoot, profileDir, dispose }`) plus `env`, which every caller needs in order to
@@ -172,7 +173,7 @@ export async function createFixtureWorkspace(
             // Best-effort, and deliberately not allowed to replace the diagnosis: the caller needs
             // to know WHY construction failed, and a cleanup error raised in its place would bury
             // that. `force: true` already absorbs the case where nothing was created yet.
-            await rm(ownRoot, { recursive: true, force: true }).catch(() => undefined);
+            await removeScratchDirectories(ownRoot).catch(() => undefined);
             throw error;
         }
     }
@@ -194,7 +195,7 @@ export async function createFixtureWorkspace(
         // Best-effort, and deliberately not allowed to replace the diagnosis: the caller needs
         // to know WHY construction failed, and a cleanup error raised in its place would bury
         // that. `force: true` already absorbs the case where nothing was created yet.
-        await rm(ownRoot, { recursive: true, force: true }).catch(() => undefined);
+        await removeScratchDirectories(ownRoot).catch(() => undefined);
         throw error;
     }
 }
@@ -367,9 +368,7 @@ async function removeLinkedWorktrees(root: string, env: NodeJS.ProcessEnv): Prom
         .filter((worktreePath): worktreePath is string => worktreePath !== null);
 
     await Promise.all(
-        linkedWorktreePaths.map((worktreePath) =>
-            rm(worktreePath, { recursive: true, force: true }),
-        ),
+        linkedWorktreePaths.map((worktreePath) => removeScratchDirectories(worktreePath)),
     );
 }
 

--- a/tests/fixtures/repo/runFixtureTeardown.ts
+++ b/tests/fixtures/repo/runFixtureTeardown.ts
@@ -19,6 +19,7 @@ import { rm } from "node:fs/promises";
 
 import { DEFAULT_MANIFEST_PATH } from "./manifest";
 import { DEFAULT_TEMPLATE_ROOT } from "./runFixtureSetup";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 export interface RunFixtureTeardownOptions {
     /** The template directory to remove. Defaults to {@link DEFAULT_TEMPLATE_ROOT}. */
@@ -39,7 +40,7 @@ export async function runFixtureTeardown(options?: RunFixtureTeardownOptions): P
     const manifestPath = options?.manifestPath ?? DEFAULT_MANIFEST_PATH;
 
     await Promise.all([
-        rm(templateRoot, { recursive: true, force: true }),
-        rm(manifestPath, { recursive: true, force: true }),
+        removeScratchDirectories(templateRoot),
+        removeScratchDirectories(manifestPath),
     ]);
 }

--- a/tests/fixtures/repo/scenarios.ts
+++ b/tests/fixtures/repo/scenarios.ts
@@ -25,7 +25,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { GitExecutor } from "../../../src/git/executor";
@@ -44,6 +44,7 @@ import {
     seedFixtureTemplate,
     type FixtureTemplate,
 } from "./seed";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 export { DIRTY_FIXTURE };
 
@@ -679,7 +680,7 @@ async function prepareAheadBehind(
         env,
     );
     await runGit(advanceClone, ["push", "--quiet", "origin", FIXTURE_REFS.main], env);
-    await rm(advanceClone, { recursive: true, force: true });
+    await removeScratchDirectories(advanceClone);
 
     // Fetches (never merges) origin's new commit: local `main` stays put, so it becomes "behind".
     await runGit(root, ["fetch", "--quiet", FIXTURE_REFS.remote, FIXTURE_REFS.main], env);
@@ -772,7 +773,7 @@ async function prepareRewrittenHistory(
         ["push", "--quiet", "--force", FIXTURE_REFS.remote, FIXTURE_REFS.main],
         env,
     );
-    await rm(collaboratorClone, { recursive: true, force: true });
+    await removeScratchDirectories(collaboratorClone);
 
     await assertCleanPostcondition(root, env);
     await assertRewrittenHistoryPostcondition(root, originRoot, env);
@@ -812,7 +813,7 @@ async function prepareStaleLease(
         ["push", "--quiet", FIXTURE_REFS.remote, FIXTURE_REFS.main],
         env,
     );
-    await rm(collaboratorClone, { recursive: true, force: true });
+    await removeScratchDirectories(collaboratorClone);
 
     await assertCleanPostcondition(root, env);
     await assertStaleLeasePostcondition(root, originRoot, env);

--- a/tests/fixtures/repo/seed.ts
+++ b/tests/fixtures/repo/seed.ts
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -201,7 +202,7 @@ export async function createSanitizedGitEnv(options?: {
  */
 export async function cleanUpThenRethrow(scratchPath: string, error: unknown): Promise<never> {
     try {
-        await rm(scratchPath, { recursive: true, force: true });
+        await removeScratchDirectories(scratchPath);
     } catch (cleanupError) {
         // Reported, not swallowed: a leaked scratch directory is worth knowing about, but not at
         // the cost of the error below, which is the one that explains the failure.

--- a/tests/helpers/scratchDirectories.ts
+++ b/tests/helpers/scratchDirectories.ts
@@ -1,3 +1,4 @@
+import { rmSync } from "node:fs";
 import { rm } from "node:fs/promises";
 
 /**
@@ -21,4 +22,19 @@ export async function removeScratchDirectories(...directories: readonly string[]
             rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 }),
         ),
     );
+}
+
+/**
+ * Synchronous sibling of {@link removeScratchDirectories}, for teardown that cannot await.
+ *
+ * The retry contract is identical because the hazard is: `rmSync` fails on the same
+ * EBUSY/EMFILE/ENFILE/ENOTEMPTY/EPERM class and accepts the same `maxRetries`/`retryDelay`. The
+ * options stay spelled out at both call sites rather than hoisted to a shared constant so the
+ * `no-restricted-syntax` guard in `eslint.config.mjs`, which matches an inline options object,
+ * demonstrably covers this file too instead of being evaded by the one module that defines it.
+ */
+export function removeScratchDirectoriesSync(...directories: readonly string[]): void {
+    for (const directory of directories) {
+        rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    }
 }

--- a/tests/integration/shelf/shelf-recovery-contention.integration.test.ts
+++ b/tests/integration/shelf/shelf-recovery-contention.integration.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readFile, rm, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { describeAbruptTermination } from "../../helpers/abruptTermination";
@@ -22,6 +22,7 @@ import {
     gitDirectory,
     indexSnapshot,
 } from "./shelfTestHarness";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 afterEach(cleanTemporaryRepositories);
 
@@ -229,7 +230,7 @@ describe("ShelfService recovery and real lock contention", () => {
         );
         await writeFile(path.join(fixture.root, "tracked.txt"), "one\nfresh local\nthree\n");
         const recoveryRoot = path.join(await gitDirectory(fixture.root), "intelligit", "recovery");
-        await rm(recoveryRoot, { recursive: true, force: true });
+        await removeScratchDirectories(recoveryRoot);
         await writeFile(recoveryRoot, "not a directory");
 
         await expect(

--- a/tests/oracleSelfTests.ts
+++ b/tests/oracleSelfTests.ts
@@ -1,12 +1,4 @@
-import {
-    mkdirSync,
-    mkdtempSync,
-    readFileSync,
-    renameSync,
-    rmSync,
-    statSync,
-    writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +9,7 @@ import { FIXTURE_REFS } from "./fixtures/repo/seed";
 import { oracles, type OracleId } from "./oracles";
 import type { EnvironmentVerdict } from "./visual/playwright/visualEnvironmentGuard";
 import type { VisualEnvironment } from "./visual/oracles/visualEnvironment";
+import { removeScratchDirectoriesSync } from "./helpers/scratchDirectories";
 
 export interface OracleSelfTest {
     /** What defect this oracle exists to catch, in one line. */
@@ -122,7 +115,7 @@ export async function disposeSelfTestWorkspaces(): Promise<void> {
         if (rejected !== undefined) throw rejected.reason;
     } finally {
         selfTestWorkspaces.clear();
-        rmSync(selfTestWorkspacesRoot, { recursive: true, force: true });
+        removeScratchDirectoriesSync(selfTestWorkspacesRoot);
     }
 }
 
@@ -395,7 +388,7 @@ export const oracleSelfTests: Record<OracleId, OracleSelfTest> = {
                     return [error];
                 }
             } finally {
-                rmSync(directory, { recursive: true, force: true });
+                removeScratchDirectoriesSync(directory);
             }
         },
         knownGood: () => {
@@ -410,7 +403,7 @@ export const oracleSelfTests: Record<OracleId, OracleSelfTest> = {
             } catch (error) {
                 return [error];
             } finally {
-                rmSync(directory, { recursive: true, force: true });
+                removeScratchDirectoriesSync(directory);
             }
         },
     },
@@ -547,7 +540,7 @@ export const oracleSelfTests: Record<OracleId, OracleSelfTest> = {
                     ? [snapshot.shelfStoreFiles, listedFiles, defaulted.globalStoragePath]
                     : [];
             } finally {
-                rmSync(nestedRoot, { recursive: true, force: true });
+                removeScratchDirectoriesSync(nestedRoot);
             }
         },
         knownGood: async () => {
@@ -619,9 +612,9 @@ export const oracleSelfTests: Record<OracleId, OracleSelfTest> = {
                 );
                 nestedStatus = await localGit.statusPorcelain(workspace);
             } finally {
-                rmSync(untrackedFile, { recursive: true, force: true });
+                removeScratchDirectoriesSync(untrackedFile);
                 renameSync(untrackedBackup, untrackedFile);
-                rmSync(nestedProbeRoot, { recursive: true, force: true });
+                removeScratchDirectoriesSync(nestedProbeRoot);
             }
             const nestedStatusReportsFile = nestedStatus.some(
                 ({ path }) => path === nestedUntrackedPath,

--- a/tests/unit/ai/commitMessageGenerator.test.ts
+++ b/tests/unit/ai/commitMessageGenerator.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -41,6 +41,7 @@ import {
     PromptTooLargeError,
     prepareCommitMessageGeneration,
 } from "../../../src/ai/commitMessageGenerator";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -49,7 +50,7 @@ const itPosix = process.platform === "win32" ? it.skip : it;
 afterEach(async () => {
     await Promise.all(
         directories.splice(0).map(async (directory) => {
-            await rm(directory, { recursive: true, force: true });
+            await removeScratchDirectories(directory);
         }),
     );
 });

--- a/tests/unit/core/fileIconTheme.test.ts
+++ b/tests/unit/core/fileIconTheme.test.ts
@@ -2,6 +2,7 @@ import * as os from "os";
 import * as path from "path";
 import { promises as fsp } from "fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 interface VscodeState {
     themeId?: string;
@@ -236,7 +237,7 @@ describe("FileIconThemeResolver", () => {
             resolver.dispose();
             expect(state.extensionDisposeCount).toBe(1);
         } finally {
-            await fsp.rm(extensionPath, { recursive: true, force: true });
+            await removeScratchDirectories(extensionPath);
         }
     });
 

--- a/tests/unit/e2e/controlChannel.test.ts
+++ b/tests/unit/e2e/controlChannel.test.ts
@@ -12,7 +12,6 @@ import {
     mkdtempSync,
     readdirSync,
     readFileSync,
-    rmSync,
     unlinkSync,
     writeFileSync,
 } from "node:fs";
@@ -29,6 +28,7 @@ import * as vscodeMock from "vscode";
 import { activateE2eControlChannel } from "../../../src/e2e/controlChannel";
 import { isE2eControlChannelActive } from "../../../src/e2e/activationState";
 import { E2E_CHANNEL_READY_MARKER } from "../../../src/e2e/transportFs";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 const ALLOWED_WORKSPACE_KEY = "intelligit.selectedRepositoryRoot";
 
@@ -108,7 +108,7 @@ describe("activateE2eControlChannel: the watcher does not start outside Developm
     afterEach(() => {
         delete process.env.INTELLIGIT_E2E;
         delete process.env.INTELLIGIT_E2E_CHANNEL_DIR;
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("does not activate, and never answers a request, under Production even with INTELLIGIT_E2E=1 and the directory present and writable", async () => {
@@ -191,7 +191,7 @@ describe("activateE2eControlChannel: the watcher does not start outside Developm
             handle.dispose();
             delete process.env.INTELLIGIT_E2E;
             delete process.env.INTELLIGIT_E2E_CHANNEL_DIR;
-            rmSync(matrixChannelDir, { recursive: true, force: true });
+            removeScratchDirectoriesSync(matrixChannelDir);
         }
     });
 });
@@ -208,7 +208,7 @@ describe("activateE2eControlChannel: end-to-end request/response over the real t
     afterEach(() => {
         delete process.env.INTELLIGIT_E2E;
         delete process.env.INTELLIGIT_E2E_CHANNEL_DIR;
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it(
@@ -429,7 +429,7 @@ describe("activateE2eControlChannel: end-to-end request/response over the real t
 
                 // Unblocking alone must be enough -- no new request file is written here, so only
                 // reconciliation retrying the surviving one can produce a response.
-                rmSync(responsePath, { recursive: true, force: true });
+                removeScratchDirectoriesSync(responsePath);
                 await waitFor(() => existsSync(responsePath));
                 expect(JSON.parse(readFileSync(responsePath, "utf8")).ok).toBe(true);
                 expect(existsSync(requestPath)).toBe(false);

--- a/tests/unit/e2e/controlChannelClient.test.ts
+++ b/tests/unit/e2e/controlChannelClient.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import {
     type E2eRequestInput,
     writeE2eRequestAtomic,
 } from "../../e2e/controlChannelClient";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const REQUEST_PAYLOAD: E2eRequestInput = {
     store: "memento",
@@ -25,7 +26,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-    await rm(channelDir, { recursive: true, force: true });
+    await removeScratchDirectories(channelDir);
 });
 
 /** Waits for the client to publish one complete request file and returns its parsed envelope. */

--- a/tests/unit/e2e/controlChannelDelivery.test.ts
+++ b/tests/unit/e2e/controlChannelDelivery.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type * as vscode from "vscode";
@@ -46,6 +46,7 @@ vi.mock("../../../src/e2e/transportFs", async () => {
 
 import * as vscodeMock from "vscode";
 import { activateE2eControlChannel } from "../../../src/e2e/controlChannel";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 /**
  * The handler's side effect, counted directly. A retry that re-runs the handler seeds the
@@ -97,7 +98,7 @@ describe("activateE2eControlChannel response delivery", () => {
     afterEach(() => {
         delete process.env.INTELLIGIT_E2E;
         delete process.env.INTELLIGIT_E2E_CHANNEL_DIR;
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
         vi.restoreAllMocks();
     });
 

--- a/tests/unit/e2e/controlChannelDrain.test.ts
+++ b/tests/unit/e2e/controlChannelDrain.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type * as vscode from "vscode";
@@ -45,6 +45,7 @@ vi.mock("../../../src/e2e/transportFs", async () => {
 
 import * as vscodeMock from "vscode";
 import { activateE2eControlChannel } from "../../../src/e2e/controlChannel";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 function makeContext(workspaceUpdate: ReturnType<typeof vi.fn>): vscode.ExtensionContext {
     const workspaceMap = new Map<string, unknown>();
@@ -77,7 +78,7 @@ describe("activateE2eControlChannel drain/watcher overlap", () => {
     afterEach(() => {
         delete process.env.INTELLIGIT_E2E;
         delete process.env.INTELLIGIT_E2E_CHANNEL_DIR;
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("dispatches once when the drain and live watcher both observe one nonce", async () => {

--- a/tests/unit/e2e/controlChannelReconciliation.test.ts
+++ b/tests/unit/e2e/controlChannelReconciliation.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +14,7 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 import { removeRequestFile, watchChannelDir } from "../../../src/e2e/transportFs";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("watchChannelDir reconciliation", () => {
     let channelDir: string;
@@ -24,7 +25,7 @@ describe("watchChannelDir reconciliation", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("answers a later request after an earlier request when fs.watch sends no notification", async () => {

--- a/tests/unit/e2e/electronLaunchHelpers.test.ts
+++ b/tests/unit/e2e/electronLaunchHelpers.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -8,6 +8,7 @@ import {
     seedProfileSettings,
     toElectronLaunchEnv,
 } from "../../e2e/hostFixtures/electronLaunchHelpers";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("toElectronLaunchEnv", () => {
     it("drops undefined-valued keys instead of forwarding them to Electron", () => {
@@ -34,7 +35,7 @@ describe("seedProfileSettings", () => {
             // fails if the custom workbench confirmation renderer is ever dropped from the harness.
             expect(settings["window.dialogStyle"]).toBe("custom");
         } finally {
-            await rm(userDataDir, { recursive: true, force: true });
+            await removeScratchDirectories(userDataDir);
         }
     });
 });

--- a/tests/unit/e2e/gate.test.ts
+++ b/tests/unit/e2e/gate.test.ts
@@ -6,7 +6,7 @@
 // directory present -- so this suite drives `evaluateE2eGate` directly with real temp
 // directories rather than stubbing filesystem calls.
 
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +20,7 @@ vi.mock("vscode", () => ({
 
 import * as vscode from "vscode";
 import { evaluateE2eGate } from "../../../src/e2e/gate";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("evaluateE2eGate: gating truth table", () => {
     let channelDir: string;
@@ -29,7 +30,7 @@ describe("evaluateE2eGate: gating truth table", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     // All four cells of {Development, Production} x {INTELLIGIT_E2E=1, unset}. Exactly one
@@ -101,7 +102,7 @@ describe("evaluateE2eGate: channel directory gate", () => {
             expect(result.active).toBe(false);
             expect(result.reason).toMatch(/not an existing directory/);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            removeScratchDirectoriesSync(dir);
         }
     });
 
@@ -119,7 +120,7 @@ describe("evaluateE2eGate: channel directory gate", () => {
                 expect(result.reason).toMatch(/not writable/);
             } finally {
                 chmodSync(dir, 0o700);
-                rmSync(dir, { recursive: true, force: true });
+                removeScratchDirectoriesSync(dir);
             }
         },
     );
@@ -133,7 +134,7 @@ describe("evaluateE2eGate: channel directory gate", () => {
             });
             expect(result.active).toBe(false);
         } finally {
-            rmSync(dir, { recursive: true, force: true });
+            removeScratchDirectoriesSync(dir);
         }
     });
 });

--- a/tests/unit/e2e/oracles.test.ts
+++ b/tests/unit/e2e/oracles.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,6 +11,7 @@ import { headOid, headSubject, parseStatusPorcelain, refOid } from "../../e2e/or
 import { listFilesUnder, readDurableState } from "../../e2e/oracles/durableState";
 import { getRebaseStoragePaths } from "../../../src/git/interactiveRebase/storage";
 import { resolveShelfPaths } from "../../../src/shelf/paths";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -68,7 +69,7 @@ describe("localGit oracle parsing", () => {
             expect(currentHead).toMatch(/^[0-9a-f]{40}$/);
             expect(await refOid(workspace, "HEAD")).toBe(currentHead);
         } finally {
-            await rm(root, { recursive: true, force: true });
+            await removeScratchDirectories(root);
         }
     });
 
@@ -93,8 +94,8 @@ describe("localGit oracle parsing", () => {
             } else {
                 process.env.GIT_DIR = previousGitDir;
             }
-            await rm(root, { recursive: true, force: true });
-            await rm(decoy, { recursive: true, force: true });
+            await removeScratchDirectories(root);
+            await removeScratchDirectories(decoy);
         }
     });
 });
@@ -163,7 +164,7 @@ describe("origin oracle", () => {
             expect(origin.didRefMove(before, after)).toBe(true);
             await expect(origin.refOid(workspace, "refs/heads/missing")).rejects.toThrow();
         } finally {
-            await rm(root, { recursive: true, force: true });
+            await removeScratchDirectories(root);
         }
     });
 });
@@ -193,7 +194,7 @@ describe("durable state oracle", () => {
                 path.join(root, "a", "z.txt"),
             ]);
         } finally {
-            await rm(root, { recursive: true, force: true });
+            await removeScratchDirectories(root);
         }
     });
 
@@ -216,7 +217,7 @@ describe("durable state oracle", () => {
             expect(snapshot.repoLockPresent).toBe(false);
             expect(snapshot.takeoverPaths).toEqual([]);
         } finally {
-            await rm(root, { recursive: true, force: true });
+            await removeScratchDirectories(root);
         }
     });
 
@@ -266,7 +267,7 @@ describe("durable state oracle", () => {
                 true,
             );
         } finally {
-            await rm(root, { recursive: true, force: true });
+            await removeScratchDirectories(root);
         }
     });
 });

--- a/tests/unit/e2e/transportFs.test.ts
+++ b/tests/unit/e2e/transportFs.test.ts
@@ -6,7 +6,7 @@
 // mechanism sufficient; a unit test cannot itself race a reader against a writer
 // deterministically, so it verifies the code takes the only path that guarantee covers.
 
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +20,7 @@ import {
     watchChannelDir,
     writeResponseFileAtomic,
 } from "../../../src/e2e/transportFs";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 /**
  * `describeReadFailure` is tested here as a pure function rather than through `watchChannelDir`,
@@ -123,7 +124,7 @@ describe("writeResponseFileAtomic: partial-write safety", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("leaves the final response path readable with the exact written payload, and no leftover temp file", () => {
@@ -156,7 +157,7 @@ describe("readRequestFile / removeRequestFile", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("reads and JSON-parses an existing request file", () => {
@@ -200,7 +201,7 @@ describe("removeChannelReadyMarker", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("removes the marker and tolerates a missing marker", () => {
@@ -221,7 +222,7 @@ describe("watchChannelDir", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     // Exercises a real fs.watch delivery, not a mock. A confirmed run showed this can

--- a/tests/unit/e2e/transportFsAtomicWrite.test.ts
+++ b/tests/unit/e2e/transportFsAtomicWrite.test.ts
@@ -13,7 +13,7 @@
 // Mixing that with other tests in the same file that need the real filesystem risks the two
 // interfering with each other.
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -36,6 +36,7 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 import { writeResponseFileAtomic } from "../../../src/e2e/transportFs";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("writeResponseFileAtomic: temp-file-plus-rename mechanism", () => {
     let channelDir: string;
@@ -46,7 +47,7 @@ describe("writeResponseFileAtomic: temp-file-plus-rename mechanism", () => {
     });
 
     afterEach(() => {
-        rmSync(channelDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(channelDir);
     });
 
     it("writes the full payload to a temp file, then moves it into place with exactly one rename", () => {

--- a/tests/unit/fixtures/copyTemplate.test.ts
+++ b/tests/unit/fixtures/copyTemplate.test.ts
@@ -20,7 +20,6 @@ import {
     readlink,
     realpath,
     rename,
-    rm,
     symlink,
     writeFile,
 } from "node:fs/promises";
@@ -38,12 +37,13 @@ import { copyTemplate } from "../../fixtures/repo/copyTemplate";
 import { inventoryDirectory } from "../../fixtures/repo/fsInventory";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
 import type { FsEntry } from "../../fixtures/repo/snapshotTypes";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("copyTemplate", () => {
     let cleanupDirs: string[] = [];
 
     afterEach(async () => {
-        await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+        await Promise.all(cleanupDirs.map((dir) => removeScratchDirectories(dir)));
         cleanupDirs = [];
     });
 

--- a/tests/unit/fixtures/gitTestHelpers.ts
+++ b/tests/unit/fixtures/gitTestHelpers.ts
@@ -15,12 +15,13 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
 import { createSanitizedGitEnv, type SanitizedGitEnv } from "../../fixtures/repo/seed";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -58,10 +59,7 @@ export async function createScratchRepo(namePrefix: string): Promise<ScratchRepo
         env,
         home,
         dispose: async () => {
-            await Promise.all([
-                rm(root, { recursive: true, force: true }),
-                rm(home, { recursive: true, force: true }),
-            ]);
+            await Promise.all([removeScratchDirectories(root), removeScratchDirectories(home)]);
         },
     };
 }

--- a/tests/unit/fixtures/harness.test.ts
+++ b/tests/unit/fixtures/harness.test.ts
@@ -7,7 +7,7 @@
  * module's own internal `runGit` seam), mirroring `rehydrate.test.ts`'s own discipline.
  */
 
-import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -24,6 +24,7 @@ import {
 import { MANIFEST_SCHEMA_VERSION, writeFixtureManifest } from "../../fixtures/repo/manifest";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const FIXTURE_TIMEOUT_MS = 30_000;
 
@@ -34,7 +35,7 @@ describe("createFixtureWorkspace", () => {
     afterEach(async () => {
         await Promise.all(workspacesToDispose.map((workspace) => workspace.dispose()));
         workspacesToDispose = [];
-        await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+        await Promise.all(cleanupDirs.map((dir) => removeScratchDirectories(dir)));
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);
 

--- a/tests/unit/fixtures/manifest.test.ts
+++ b/tests/unit/fixtures/manifest.test.ts
@@ -8,7 +8,7 @@
  * `readFixtureManifest`'s own implementation.
  */
 
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -37,6 +37,7 @@ import {
     writeFixtureManifest,
     type FixtureManifest,
 } from "../../fixtures/repo/manifest";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -46,7 +47,7 @@ describe("manifest", () => {
     let cleanupDirs: string[] = [];
 
     afterEach(async () => {
-        await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+        await Promise.all(cleanupDirs.map((dir) => removeScratchDirectories(dir)));
         cleanupDirs = [];
     });
 

--- a/tests/unit/fixtures/placeholderCanonicalization.test.ts
+++ b/tests/unit/fixtures/placeholderCanonicalization.test.ts
@@ -10,7 +10,7 @@
  * consumers by construction -- there is exactly one implementation for both tests to exercise.
  */
 
-import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, symlink } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -23,6 +23,7 @@ import {
     normalizeString,
     type PlaceholderRoots,
 } from "../../fixtures/repo/placeholderCanonicalization";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /**
  * Every webview fixture recorder passes `profileDir: ""` -- those slices never allocate a VS Code
@@ -106,7 +107,7 @@ describe("normalizeUnknownDeep -- realpath duality", () => {
     let scratch: string | undefined;
 
     afterEach(async () => {
-        if (scratch) await rm(scratch, { recursive: true, force: true });
+        if (scratch) await removeScratchDirectories(scratch);
         scratch = undefined;
     });
 
@@ -294,7 +295,7 @@ describe("buildPlaceholderReplacements -- the native resolver's canonical spelli
     let scratch: string | undefined;
 
     afterEach(async () => {
-        if (scratch) await rm(scratch, { recursive: true, force: true });
+        if (scratch) await removeScratchDirectories(scratch);
         scratch = undefined;
     });
 
@@ -393,7 +394,7 @@ describe("buildPlaceholderReplacements -- a root whose directory is already gone
     let scratch: string | undefined;
 
     afterEach(async () => {
-        if (scratch) await rm(scratch, { recursive: true, force: true });
+        if (scratch) await removeScratchDirectories(scratch);
         scratch = undefined;
     });
 

--- a/tests/unit/fixtures/rehydrate.test.ts
+++ b/tests/unit/fixtures/rehydrate.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -32,6 +32,7 @@ import {
 import { DECLARED_REWRITES, rehydrateCopy } from "../../fixtures/repo/rehydrate";
 import { snapshotWorkspace, type PlaceholderRoots } from "../../fixtures/repo/snapshot";
 import { git } from "./gitTestHelpers";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const FIXTURE_TIMEOUT_MS = 30_000;
@@ -53,7 +54,7 @@ describe("rehydrateCopy / assertWorkspaceEquivalentToTemplate", () => {
     let cleanupDirs: string[] = [];
 
     afterEach(async () => {
-        await Promise.all(cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+        await Promise.all(cleanupDirs.map((dir) => removeScratchDirectories(dir)));
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);
 

--- a/tests/unit/fixtures/resourceCleanup.test.ts
+++ b/tests/unit/fixtures/resourceCleanup.test.ts
@@ -36,7 +36,18 @@ describe("FixtureWorkspace resource cleanup", () => {
         await Promise.all(workspacesToDispose.map((workspace) => workspace.dispose()));
         workspacesToDispose = [];
         await Promise.all(
-            cleanupDirs.map((directory) => actual.rm(directory, { recursive: true, force: true })),
+            // Deliberately the un-mocked binding, and deliberately NOT `removeScratchDirectories`:
+            // that helper imports `rm` from `node:fs/promises`, which this suite mocks, so routing
+            // teardown through it would add to the very `rmMock` call count these assertions read.
+            // The retry contract is copied rather than shared, for that one reason.
+            cleanupDirs.map((directory) =>
+                actual.rm(directory, {
+                    recursive: true,
+                    force: true,
+                    maxRetries: 10,
+                    retryDelay: 50,
+                }),
+            ),
         );
         cleanupDirs = [];
         rmMock.mockClear();

--- a/tests/unit/fixtures/runFixtureSetup.test.ts
+++ b/tests/unit/fixtures/runFixtureSetup.test.ts
@@ -8,7 +8,7 @@
  * would produce), so these tests prove the actual ordering rather than a stand-in for it.
  */
 
-import { chmod, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -27,6 +27,7 @@ import {
     publishTemplate,
     runFixtureSetup,
 } from "../../fixtures/repo/runFixtureSetup";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const FIXTURE_TIMEOUT_MS = 30_000;
 
@@ -79,8 +80,8 @@ describe("runFixtureSetup", () => {
         await Promise.all(workspacesToDispose.map((workspace) => workspace.dispose()));
         workspacesToDispose = [];
         await Promise.all([
-            ...cleanupDirs.map((dir) => rm(dir, { recursive: true, force: true })),
-            ...cleanupHomes.map((home) => rm(home, { recursive: true, force: true })),
+            ...cleanupDirs.map((dir) => removeScratchDirectories(dir)),
+            ...cleanupHomes.map((home) => removeScratchDirectories(home)),
         ]);
         cleanupDirs = [];
         cleanupHomes = [];

--- a/tests/unit/fixtures/scenarios.test.ts
+++ b/tests/unit/fixtures/scenarios.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -509,7 +509,7 @@ describe("rewritten-history", () => {
             workspace.env,
         );
         await git(collaboratorClone, ["push", "--quiet", "origin", "main"], workspace.env);
-        await rm(collaboratorClone, { recursive: true, force: true });
+        await removeScratchDirectories(collaboratorClone);
 
         await expect(
             assertRewrittenHistoryPostcondition(
@@ -603,7 +603,7 @@ describe("stale-lease", () => {
             ["push", "--quiet", "--force", "origin", "main"],
             workspace.env,
         );
-        await rm(collaboratorClone, { recursive: true, force: true });
+        await removeScratchDirectories(collaboratorClone);
 
         await expect(
             assertStaleLeasePostcondition(

--- a/tests/unit/fixtures/scratchWorkspaces.test.ts
+++ b/tests/unit/fixtures/scratchWorkspaces.test.ts
@@ -13,11 +13,12 @@
  */
 
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createScratchWorkspaces } from "./scratchWorkspaces";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 async function exists(target: string): Promise<boolean> {
     try {
@@ -42,9 +43,7 @@ describe("createScratchWorkspaces", () => {
     }
 
     afterEach(async () => {
-        await Promise.all(
-            allocated.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
-        );
+        await Promise.all(allocated.splice(0).map((dir) => removeScratchDirectories(dir)));
     });
 
     it("removes a slow sibling's home when the other seed fails first", async () => {

--- a/tests/unit/fixtures/scratchWorkspaces.ts
+++ b/tests/unit/fixtures/scratchWorkspaces.ts
@@ -22,7 +22,7 @@
  * other four.
  */
 
-import { rm } from "node:fs/promises";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** The one thing this module needs from a seeded workspace: the temp `HOME` it owns. */
 interface ScratchWorkspace {
@@ -83,7 +83,7 @@ export function createScratchWorkspaces(): ScratchWorkspaces {
             // the undocumented part.
             await Promise.all(
                 [...new Set(scratchPaths)].map((scratchPath) =>
-                    rm(scratchPath, { recursive: true, force: true }),
+                    removeScratchDirectories(scratchPath),
                 ),
             );
         },

--- a/tests/unit/fixtures/seed.test.ts
+++ b/tests/unit/fixtures/seed.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../fixtures/repo/seed";
 import { OVERLONG_NAMES_FAIL_REMOVAL } from "../../helpers/platformCapabilities";
 import { createScratchWorkspaces } from "./scratchWorkspaces";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -169,7 +170,7 @@ describe("seedFixtureTemplate", () => {
                     expect(sanitized.env.LC_ALL).toBe("C");
                     expect(sanitized.env.LANG).toBe("C");
                 } finally {
-                    await rm(sanitized.home, { recursive: true, force: true });
+                    await removeScratchDirectories(sanitized.home);
                 }
             } finally {
                 restoreEnvVar("LC_ALL", ambient.LC_ALL);
@@ -422,9 +423,7 @@ describe("seedFixtureTemplate failure cleanup", () => {
     const allocated: string[] = [];
 
     afterAll(async () => {
-        await Promise.all(
-            allocated.map((scratchPath) => rm(scratchPath, { recursive: true, force: true })),
-        );
+        await Promise.all(allocated.map((scratchPath) => removeScratchDirectories(scratchPath)));
     });
 
     it("removes the temporary home it allocated when seeding fails", async () => {
@@ -466,9 +465,7 @@ describe("cleanUpThenRethrow", () => {
 
     afterAll(async () => {
         await Promise.all(
-            allocatedScratchRoots.map((scratchPath) =>
-                rm(scratchPath, { recursive: true, force: true }),
-            ),
+            allocatedScratchRoots.map((scratchPath) => removeScratchDirectories(scratchPath)),
         );
     });
 

--- a/tests/unit/fixtures/seedDeterminism.test.ts
+++ b/tests/unit/fixtures/seedDeterminism.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -20,6 +20,7 @@ import {
     normalizeFixtureSnapshot,
     type FixtureSnapshot,
 } from "../../fixtures/repo/phase6Snapshot";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const FIXTURE_TIMEOUT_MS = 60_000;
@@ -74,9 +75,7 @@ describe("Phase 6 step 32 -- canonical snapshot seed determinism", () => {
 
     afterEach(async () => {
         await Promise.all(workspaces.map((workspace) => workspace.dispose()));
-        await Promise.all(
-            cleanupDirs.map((directory) => rm(directory, { recursive: true, force: true })),
-        );
+        await Promise.all(cleanupDirs.map((directory) => removeScratchDirectories(directory)));
         workspaces = [];
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);

--- a/tests/unit/fixtures/snapshotIndex.test.ts
+++ b/tests/unit/fixtures/snapshotIndex.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { snapshotIndex } from "../../fixtures/repo/snapshotIndex";
 import { git, type ScratchRepo } from "./gitTestHelpers";
 import { commitAll, createScratchRepo, writeRepoFile } from "./gitTestHelpers";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("snapshotIndex", () => {
     let repo: ScratchRepo | undefined;
@@ -140,7 +141,7 @@ describe("snapshotIndex", () => {
             expect(section.data).toEqual([]);
 
             const { rm } = await import("node:fs/promises");
-            await rm(bareRoot, { recursive: true, force: true });
+            await removeScratchDirectories(bareRoot);
         });
     });
 });

--- a/tests/unit/fixtures/snapshotNormalize.test.ts
+++ b/tests/unit/fixtures/snapshotNormalize.test.ts
@@ -20,7 +20,7 @@
  * scenario normalization is actually built for and are proven equal, including the index file.
  */
 
-import { cp, mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -33,15 +33,16 @@ import { snapshotWorkspace } from "../../fixtures/repo/snapshot";
 import type { FsEntry } from "../../fixtures/repo/snapshotTypes";
 import { captured, notCaptured } from "../../fixtures/repo/snapshotTypes";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8's real scenario)", () => {
     let scratchDirs: string[] = [];
     let template: FixtureTemplate | undefined;
 
     afterEach(async () => {
-        await Promise.all(scratchDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+        await Promise.all(scratchDirs.map((dir) => removeScratchDirectories(dir)));
         scratchDirs = [];
-        if (template) await rm(template.home, { recursive: true, force: true });
+        if (template) await removeScratchDirectories(template.home);
         template = undefined;
     }, 30_000);
 
@@ -52,8 +53,8 @@ describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8'
 
         const copy1Dest = await mkdtemp(path.join(tmpdir(), "intelligit-normalize-copy1-"));
         const copy2Dest = await mkdtemp(path.join(tmpdir(), "intelligit-normalize-copy2-"));
-        await rm(copy1Dest, { recursive: true, force: true });
-        await rm(copy2Dest, { recursive: true, force: true });
+        await removeScratchDirectories(copy1Dest);
+        await removeScratchDirectories(copy2Dest);
         scratchDirs.push(copy1Dest, copy2Dest);
         await cp(seedDest, copy1Dest, {
             recursive: true,
@@ -98,8 +99,8 @@ describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8'
 
         const copy1Dest = await mkdtemp(path.join(tmpdir(), "intelligit-normalize-red-copy1-"));
         const copy2Dest = await mkdtemp(path.join(tmpdir(), "intelligit-normalize-red-copy2-"));
-        await rm(copy1Dest, { recursive: true, force: true });
-        await rm(copy2Dest, { recursive: true, force: true });
+        await removeScratchDirectories(copy1Dest);
+        await removeScratchDirectories(copy2Dest);
         scratchDirs.push(copy1Dest, copy2Dest);
         await cp(seedDest, copy1Dest, {
             recursive: true,
@@ -260,7 +261,7 @@ describe("normalizeSnapshot -- realpath duality", () => {
     let scratch: string | undefined;
 
     afterEach(async () => {
-        if (scratch) await rm(scratch, { recursive: true, force: true });
+        if (scratch) await removeScratchDirectories(scratch);
         scratch = undefined;
     });
 

--- a/tests/unit/fixtures/workspaceIsolation.test.ts
+++ b/tests/unit/fixtures/workspaceIsolation.test.ts
@@ -3,7 +3,7 @@
  * boundary into a second copy or the shared seed template.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -18,6 +18,7 @@ import {
 } from "../../fixtures/repo/phase6Snapshot";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const FIXTURE_TIMEOUT_MS = 60_000;
 
@@ -35,9 +36,7 @@ describe("Phase 6 step 35 -- workspace isolation", () => {
                 }
             }),
         );
-        await Promise.all(
-            cleanupDirs.map((directory) => rm(directory, { recursive: true, force: true })),
-        );
+        await Promise.all(cleanupDirs.map((directory) => removeScratchDirectories(directory)));
         workspaces = [];
         cleanupDirs = [];
     }, FIXTURE_TIMEOUT_MS);

--- a/tests/unit/git/editorHelper.test.ts
+++ b/tests/unit/git/editorHelper.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,6 +9,7 @@ import {
     quoteGitEditorArgument,
 } from "../../../src/git/interactiveRebase/editorCommand";
 import { supportsPosixShell } from "../../helpers/platformCapabilities";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const HASH_A = "a".repeat(40);
 const HASH_B = "b".repeat(40);
@@ -19,7 +20,7 @@ const itPosix = supportsPosixShell ? it : it.skip;
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/executor.test.ts
+++ b/tests/unit/git/executor.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, open, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ import {
 import { RepositoryMutationCoordinator } from "../../../src/git/mutationCoordinator";
 import { RepositoryLock } from "../../../src/git/repositoryLock";
 import { RepositoryMutationGate } from "../../../src/git/repositoryMutationGate";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const itPosix = process.platform === "win32" ? it.skip : it;
 
@@ -85,7 +86,7 @@ async function withFakeGit<T>(
         return await run(new GitExecutor(process.cwd(), gate));
     } finally {
         restoreEnv();
-        await rm(directory, { force: true, recursive: true });
+        await removeScratchDirectories(directory);
     }
 }
 
@@ -121,7 +122,7 @@ async function gatedRunCount(args: string[]): Promise<number> {
         return gatedRuns.length;
     } finally {
         restoreEnv();
-        await rm(directory, { force: true, recursive: true });
+        await removeScratchDirectories(directory);
     }
 }
 
@@ -133,7 +134,7 @@ async function runWithStubGit(args: string[], script = "exit 0"): Promise<void> 
         await new GitExecutor(process.cwd()).run(args);
     } finally {
         restoreEnv();
-        await rm(directory, { force: true, recursive: true });
+        await removeScratchDirectories(directory);
     }
 }
 
@@ -355,7 +356,7 @@ describe("GitExecutor", () => {
             expect(output.stdout).toEqual(Buffer.alloc(0));
             expect((await readFile(outputFile)).toString("utf8")).toMatch(/^[a-f0-9]{40}\n$/);
         } finally {
-            await rm(directory, { force: true, recursive: true });
+            await removeScratchDirectories(directory);
         }
     });
 
@@ -370,7 +371,7 @@ describe("GitExecutor", () => {
                 }),
             ).rejects.toMatchObject({ code: "ENOENT" });
         } finally {
-            await rm(directory, { force: true, recursive: true });
+            await removeScratchDirectories(directory);
         }
     });
 
@@ -444,7 +445,7 @@ describe("GitExecutor", () => {
             await writeFile(release, "", "utf8");
             await push.catch(() => undefined);
             restoreEnv();
-            await rm(directory, { force: true, recursive: true });
+            await removeScratchDirectories(directory);
         }
     });
 
@@ -489,7 +490,7 @@ describe("GitExecutor", () => {
                 readFile(join(resultsDir, String(index)), "utf8"),
             ),
         );
-        await rm(directory, { force: true, recursive: true });
+        await removeScratchDirectories(directory);
         const observedMaxConcurrency = Math.max(...counts.map((count) => Number(count.trim())));
 
         expect(observedMaxConcurrency).toBeGreaterThan(1);
@@ -517,7 +518,7 @@ describe("GitExecutor", () => {
         } finally {
             await writer.close();
             restoreEnv();
-            await rm(directory, { force: true, recursive: true });
+            await removeScratchDirectories(directory);
         }
     });
 });

--- a/tests/unit/git/gitHelpers.test.ts
+++ b/tests/unit/git/gitHelpers.test.ts
@@ -1,7 +1,7 @@
 // Tests for pure utility functions in src/services/gitHelpers.ts.
 
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, it, expect, vi } from "vitest";
@@ -58,6 +58,7 @@ import {
 import type { Branch } from "../../../src/types";
 import type { GitOps } from "../../../src/git/operations";
 import type { GitExecutor } from "../../../src/git/executor";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** Builds a branch fixture with safe defaults for checkout helper tests. */
 function makeBranch(overrides: Partial<Branch> = {}): Branch {
@@ -519,7 +520,7 @@ describe("buildCommitFilePatch", () => {
             expect(patch).toContain(":(glob)*");
             expect(patch).not.toContain("victim.txt");
         } finally {
-            await rm(repo, { recursive: true, force: true });
+            await removeScratchDirectories(repo);
         }
     });
 

--- a/tests/unit/git/gitops/branch.test.ts
+++ b/tests/unit/git/gitops/branch.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { GitOps, UpstreamPushDeclinedError } from "../../../../src/git/operations";
 import type { GitExecutor } from "../../../../src/git/executor";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -62,7 +63,7 @@ describe("GitOps", () => {
                 const gitDir = (await git(repo, ["rev-parse", "--git-dir"])).trim();
                 expect(gitDir).toBe(".git");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 

--- a/tests/unit/git/gitops/remotes.test.ts
+++ b/tests/unit/git/gitops/remotes.test.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { GitOps, UpstreamPushDeclinedError } from "../../../../src/git/operations";
 import type { GitExecutor } from "../../../../src/git/executor";
 import { parseStashFiles } from "../../../../src/git/stashFiles";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -723,7 +724,7 @@ describe("GitOps", () => {
                     }
                 }
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 

--- a/tests/unit/git/gitops/status.test.ts
+++ b/tests/unit/git/gitops/status.test.ts
@@ -11,6 +11,7 @@ import {
     type ActiveOperationKind,
 } from "../../../../src/git/operations";
 import type { GitExecutor } from "../../../../src/git/executor";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -405,7 +406,7 @@ describe("GitOps", () => {
                 await ops.stageFiles(["tracked.txt"]);
                 expect(await status(repo)).toBe("D  tracked.txt\n");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -431,7 +432,7 @@ describe("GitOps", () => {
                     ' M nested/tracked.txt\n?? --weird.txt\n?? "space name.txt"\n',
                 );
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -459,7 +460,7 @@ describe("GitOps", () => {
                         .filter(Boolean);
                     expect(remaining).toEqual(["?? victim.txt"]);
                 } finally {
-                    await rm(repo, { recursive: true, force: true });
+                    await removeScratchDirectories(repo);
                 }
             },
         );
@@ -497,7 +498,7 @@ describe("GitOps", () => {
 
                 expect(await status(repo)).toBe(" A new-file.txt\n");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -526,7 +527,7 @@ describe("GitOps", () => {
 
                 expect(await status(repo)).toBe("");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -546,7 +547,7 @@ describe("GitOps", () => {
 
                 expect(await status(repo)).toBe("");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -568,7 +569,7 @@ describe("GitOps", () => {
 
                 expect(await status(repo)).toBe("");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -584,7 +585,7 @@ describe("GitOps", () => {
 
                 expect(await status(repo)).toBe("D  --weird.txt\n");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -601,7 +602,7 @@ describe("GitOps", () => {
                 await ops.rollbackFiles(["renamed.txt"]);
                 expect(await status(repo)).toBe("");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -628,7 +629,7 @@ describe("GitOps", () => {
                 expect(rawStatus).toContain("space file.txt");
                 expect(rawStatus).toContain("nested/tracked.txt");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -647,7 +648,7 @@ describe("GitOps", () => {
                 const lastMsg = await ops.getLastCommitMessage();
                 expect(lastMsg).toContain("feat: update tracked");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -674,7 +675,7 @@ describe("GitOps", () => {
                 expect(lines).toHaveLength(2);
                 expect(lines[0]).toContain("amended message");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -700,7 +701,7 @@ describe("GitOps", () => {
                 );
                 expect(await status(repo)).toBe("D  to-remove.txt\n");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
 
@@ -716,7 +717,7 @@ describe("GitOps", () => {
                 const content = await ops.getFileContentAtRef("--ref-file.txt", "HEAD");
                 expect(content).toBe("ref content\n");
             } finally {
-                await rm(repo, { recursive: true, force: true });
+                await removeScratchDirectories(repo);
             }
         });
     });

--- a/tests/unit/git/interactiveRebase.test.ts
+++ b/tests/unit/git/interactiveRebase.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -19,6 +19,7 @@ import {
     type RebaseSubmissionEntry,
     type RebaseTodoEntry,
 } from "../../../src/git/interactiveRebase";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const HASH_A = "a".repeat(40);
 const HASH_B = "b".repeat(40);
@@ -30,7 +31,7 @@ const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/interactiveRebase/control.test.ts
+++ b/tests/unit/git/interactiveRebase/control.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +15,7 @@ import {
     tryAcquireRebaseReservation,
     writeRebaseManifest,
 } from "../../../../src/git/interactiveRebase/storage";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const terminalManifestWriteFault = vi.hoisted(() => ({ enabled: false }));
 
@@ -44,7 +45,7 @@ const directories: string[] = [];
 afterEach(async () => {
     terminalManifestWriteFault.enabled = false;
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 
@@ -124,7 +125,7 @@ async function fixture(
                 const succeeded = exitCode === 0 && !options.continueThrows;
                 const after = options.afterContinue ?? (succeeded ? "end" : "keep");
                 const mergeDirectory = path.join(gitDir, "rebase-merge");
-                if (after === "end") await rm(mergeDirectory, { recursive: true, force: true });
+                if (after === "end") await removeScratchDirectories(mergeDirectory);
                 if (after === "steal") {
                     await writeFile(
                         path.join(mergeDirectory, REBASE_SESSION_MARKER),
@@ -139,7 +140,7 @@ async function fixture(
             }
             if (command === "rebase --abort") {
                 if (options.abortFails) throw new Error("abort failed");
-                await rm(path.join(gitDir, "rebase-merge"), { recursive: true });
+                await removeScratchDirectories(path.join(gitDir, "rebase-merge"));
                 return binary();
             }
             throw new Error(`Unexpected Git command: ${command}`);

--- a/tests/unit/git/interactiveRebase/guards.test.ts
+++ b/tests/unit/git/interactiveRebase/guards.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ABSENT_GIT_CONFIG_GLOBAL } from "../../../helpers/gitConfigIsolation";
 import { evaluateInteractiveRebaseGuards } from "../../../../src/git/interactiveRebase/guards";
 import type { GitExecutor } from "../../../../src/git/executor";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const HASH = "a".repeat(40);
@@ -16,7 +17,7 @@ const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/interactiveRebase/pushOffer.test.ts
+++ b/tests/unit/git/interactiveRebase/pushOffer.test.ts
@@ -29,6 +29,7 @@ import {
     writeRebaseManifest,
 } from "../../../../src/git/interactiveRebase/storage";
 import type { RebaseSessionManifest } from "../../../../src/git/interactiveRebase/types";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const BRANCH = "refs/heads/main";
 const HEAD = "b".repeat(40);
@@ -37,7 +38,7 @@ const roots: string[] = [];
 
 afterEach(async () => {
     failingRemovals.clear();
-    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+    await Promise.all(roots.splice(0).map((root) => removeScratchDirectories(root)));
 });
 
 async function fixture(

--- a/tests/unit/git/interactiveRebase/range.test.ts
+++ b/tests/unit/git/interactiveRebase/range.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -12,6 +12,7 @@ import {
     MAX_INTERACTIVE_REBASE_RANGE_OUTPUT_BYTES,
 } from "../../../../src/git/interactiveRebase/range";
 import type { GitExecutor } from "../../../../src/git/executor";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const HASH_A = "a".repeat(40);
@@ -24,7 +25,7 @@ const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/interactiveRebase/rebaseControl.test.ts
+++ b/tests/unit/git/interactiveRebase/rebaseControl.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import {
     deriveRebaseControl,
     type LiveRebaseManifest,
 } from "../../../../src/git/interactiveRebase/rebaseControl";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 const canAssertUnreadableDirectory = supportsUnreadableDirectories;
@@ -16,7 +17,7 @@ afterEach(async () => {
     await Promise.all(
         directories.splice(0).map(async (directory) => {
             await chmod(directory, 0o700).catch(() => undefined);
-            await rm(directory, { force: true, recursive: true });
+            await removeScratchDirectories(directory);
         }),
     );
 });

--- a/tests/unit/git/interactiveRebase/reconcile.test.ts
+++ b/tests/unit/git/interactiveRebase/reconcile.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +13,7 @@ import {
     writeRebaseManifest,
 } from "../../../../src/git/interactiveRebase/storage";
 import type { RebaseSessionManifest } from "../../../../src/git/interactiveRebase/types";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const REPO_ROOT = "/fixture-repository";
 const BRANCH = "refs/heads/main";
@@ -22,7 +23,7 @@ const REBASED_HEAD = "c".repeat(40);
 const roots: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+    await Promise.all(roots.splice(0).map((root) => removeScratchDirectories(root)));
 });
 
 /** Creates valid durable state with only the fields reconciliation is allowed to use. */

--- a/tests/unit/git/interactiveRebase/run.test.ts
+++ b/tests/unit/git/interactiveRebase/run.test.ts
@@ -38,6 +38,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 import { runInteractiveRebaseSubmission } from "../../../../src/git/interactiveRebase/run";
 import { getRebaseStoragePaths } from "../../../../src/git/interactiveRebase/storage";
 import type { InteractiveRebaseRunDependencies } from "../../../../src/git/interactiveRebase/run";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const BASE = "a".repeat(40);
 const HEAD = "b".repeat(40);
@@ -50,7 +51,7 @@ afterEach(async () => {
     cleanupFault.manifestRemoval = false;
     terminalManifestWriteFault.enabled = false;
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/interactiveRebase/session.test.ts
+++ b/tests/unit/git/interactiveRebase/session.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,6 +8,7 @@ import type {
     RebaseTodoEntry,
 } from "../../../../src/git/interactiveRebase/types";
 import { writeInteractiveRebaseSession } from "../../../../src/git/interactiveRebase/session";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const HASH_A = "a".repeat(40);
 const HASH_B = "B".repeat(40);
@@ -15,7 +16,7 @@ const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/git/interactiveRebase/storage.test.ts
+++ b/tests/unit/git/interactiveRebase/storage.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -16,13 +16,14 @@ import type {
     RebaseSessionLifecycle,
     RebaseSessionManifest,
 } from "../../../../src/git/interactiveRebase/types";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const REPO_ROOT = "/fixture-repository";
 const SESSION_ID = "session-1";
 const roots: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+    await Promise.all(roots.splice(0).map((root) => removeScratchDirectories(root)));
 });
 
 /** Creates an isolated storage root holding one manifest at the requested lifecycle. */

--- a/tests/unit/git/operations.test.ts
+++ b/tests/unit/git/operations.test.ts
@@ -21,12 +21,15 @@ import {
     type DiffForPathsResult,
 } from "../../../src/git/operations";
 import type { WorkingFile } from "../../../src/types";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 async function git(directory: string, args: string[]): Promise<string> {
@@ -305,7 +308,7 @@ describe("GitOps.withIndexSnapshot", () => {
 
         const caught: unknown = await gitOps
             .withIndexSnapshot(async () => {
-                await rm(path.join(root, ".git"), { recursive: true, force: true });
+                await removeScratchDirectories(path.join(root, ".git"));
                 throw operationError;
             })
             .catch((error: unknown) => error);
@@ -325,7 +328,7 @@ describe("GitOps.withIndexSnapshot", () => {
 
         const caught: unknown = await gitOps
             .withIndexSnapshot(async () => {
-                await rm(path.join(root, ".git"), { recursive: true, force: true });
+                await removeScratchDirectories(path.join(root, ".git"));
                 return "operation-result";
             })
             .catch((error: unknown) => error);

--- a/tests/unit/git/operationsIndexLockEperm.test.ts
+++ b/tests/unit/git/operationsIndexLockEperm.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GitExecutor } from "../../../src/git/executor";
 import { GitOps } from "../../../src/git/operations";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** Makes the exclusive create of an `index.lock` fail with a chosen errno for the next
  * `remaining` attempts, so the errno Windows answers with is reachable from a POSIX host, and
@@ -87,7 +88,9 @@ afterEach(async () => {
     indexLockProbe.remaining = 0;
     indexLockProbe.renamesOntoIndex = 0;
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 async function git(directory: string, args: string[]): Promise<string> {

--- a/tests/unit/git/repositoryDiscovery.test.ts
+++ b/tests/unit/git/repositoryDiscovery.test.ts
@@ -6,6 +6,7 @@ import {
     discoverGitRepositories,
     type ResolveGitRepository,
 } from "../../../src/services/repositoryDiscovery";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const tempRoots: string[] = [];
 
@@ -36,9 +37,7 @@ function resolverFor(roots: string[]): ResolveGitRepository {
 }
 
 afterEach(async () => {
-    await Promise.all(
-        tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-    );
+    await Promise.all(tempRoots.splice(0).map((root) => removeScratchDirectories(root)));
 });
 
 describe("discoverGitRepositories", () => {

--- a/tests/unit/git/repositoryLock.test.ts
+++ b/tests/unit/git/repositoryLock.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,7 @@ import {
     RepositoryLockBusyError,
 } from "../../../src/git/repositoryLock";
 import { RENAME_OVER_OPEN_FILE_SUPPORTED } from "../../helpers/platformCapabilities";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** Delay applied to heartbeat writes only, so "the write is still in flight when release runs" is
  * a controlled fact rather than a race the test hopes to win. Zero for every other test here. */
@@ -85,7 +86,9 @@ afterEach(async () => {
         value: originalPlatform,
         configurable: true,
     });
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 async function commonDir(): Promise<string> {

--- a/tests/unit/git/repositoryMutationGate.test.ts
+++ b/tests/unit/git/repositoryMutationGate.test.ts
@@ -1,15 +1,18 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { RepositoryMutationCoordinator } from "../../../src/git/mutationCoordinator";
 import { RepositoryLock, RepositoryLockBusyError } from "../../../src/git/repositoryLock";
 import { RepositoryMutationGate } from "../../../src/git/repositoryMutationGate";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 async function tempDir(prefix: string): Promise<string> {

--- a/tests/unit/git/wholeIndexOperationWatcher.test.ts
+++ b/tests/unit/git/wholeIndexOperationWatcher.test.ts
@@ -1,10 +1,11 @@
 import type { FSWatcher } from "node:fs";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGitDir } from "../../../src/git/gitDirectory";
 import { watchWholeIndexOperation } from "../../../src/git/wholeIndexOperationWatcher";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const { readFileSyncMock, watchMock } = vi.hoisted(() => ({
     readFileSyncMock: vi.fn(),
@@ -25,7 +26,9 @@ const directories: string[] = [];
 afterEach(async () => {
     readFileSyncMock.mockClear();
     watchMock.mockReset();
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 /** Creates an isolated repository-shaped directory for synchronous Git-dir resolver tests. */

--- a/tests/unit/git/worktrees.test.ts
+++ b/tests/unit/git/worktrees.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -18,6 +18,7 @@ import {
     removeWorktree,
     unlockWorktree,
 } from "../../../src/git/worktrees";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const tempRoots: string[] = [];
@@ -71,9 +72,7 @@ async function createTempGitRepo(): Promise<{ root: string; repo: string }> {
 }
 
 afterEach(async () => {
-    await Promise.all(
-        tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-    );
+    await Promise.all(tempRoots.splice(0).map((root) => removeScratchDirectories(root)));
 });
 
 describe("parseWorktreeList", () => {

--- a/tests/unit/gitEnvironmentIsolation.test.ts
+++ b/tests/unit/gitEnvironmentIsolation.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { removeScratchDirectories } from "../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
@@ -39,7 +40,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/helpers/gitPathSpelling.test.ts
+++ b/tests/unit/helpers/gitPathSpelling.test.ts
@@ -6,7 +6,7 @@
  * Windows one.
  */
 
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp } from "node:fs/promises";
 import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -14,6 +14,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { gitSpellingOf } from "../../helpers/gitPathSpelling";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("gitSpellingOf -- separators", () => {
     it("rewrites Node's separators to the ones git emits when the platform separator is a backslash", () => {
@@ -38,7 +39,7 @@ describe("gitSpellingOf -- the canonical on-disk spelling", () => {
     let scratch: string | undefined;
 
     afterEach(async () => {
-        if (scratch) await rm(scratch, { recursive: true, force: true });
+        if (scratch) await removeScratchDirectories(scratch);
         scratch = undefined;
     });
 

--- a/tests/unit/helpers/scratchRemovalLintRule.test.ts
+++ b/tests/unit/helpers/scratchRemovalLintRule.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Behavioural test for the `no-restricted-syntax` guard that keeps recursive removals in `tests/`
+ * on the retrying helpers.
+ *
+ * The guard exists because git keeps writing into `.git/objects/pack` after the command that
+ * triggered it has returned, so a bare recursive `rm` can lose the race between its `readdir` and
+ * its `rmdir` and fail whichever row happens to be executing. Routing 180 call sites through
+ * `removeScratchDirectories` fixed the ones that existed; this rule is what stops the next one
+ * being written by hand.
+ *
+ * Asserted behaviourally rather than by reading the selector back out of the config, because the
+ * selector is the part that can be wrong. A test that re-derives the selector from the config it
+ * is checking would agree with any selector, including one matching nothing at all -- which is the
+ * exact failure this file exists to catch, since a rule that matches nothing lints green.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+// Deliberately absent from disk. `lintText` resolves configuration by path without reading the
+// file, so this leaves no debris for the repository-wide scans to trip over.
+const probePath = path.join(repositoryRoot, "tests", "unit", "recursiveRemovalProbe.ts");
+
+async function reportedLines(body: string): Promise<readonly number[]> {
+    const source = `async function probe(): Promise<void> {\n${body}\n}\nvoid probe;\n`;
+    const results = await new ESLint({ cwd: repositoryRoot }).lintText(source, {
+        filePath: probePath,
+    });
+    return results
+        .flatMap((result) => result.messages)
+        .filter((message) => message.ruleId === "no-restricted-syntax")
+        .map((message) => message.line);
+}
+
+describe("recursive-removal lint guard", () => {
+    it.each([
+        ["a bare async recursive rm", "    await rm(dir, { recursive: true, force: true });"],
+        ["a bare sync recursive rm", "    rmSync(dir, { recursive: true, force: true });"],
+        [
+            "a recursive rm reached through a namespace",
+            "    await fs.rm(dir, { recursive: true });",
+        ],
+        [
+            "a recursive flag this rule cannot read statically",
+            "    await rm(dir, { recursive: deep, force: true });",
+        ],
+    ])("reports %s", async (_label, body) => {
+        expect(await reportedLines(body)).toEqual([2]);
+    });
+
+    it.each([
+        // The regression case: a non-recursive removal has no readdir step to lose, so requiring
+        // retries of it would be noise -- and noise is what gets silenced with eslint-disable.
+        ["an explicitly non-recursive rm", "    await rm(dir, { recursive: false });"],
+        ["a single-file rm with no options", "    await rm(file);"],
+        ["a single-file rm that only forces", "    await rm(file, { force: true });"],
+        [
+            "a recursive rm that already retries",
+            "    await rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });",
+        ],
+        // `mkdir` carries a `recursive` option too, and shares nothing else with this hazard.
+        ["a recursive mkdir", "    await mkdir(dir, { recursive: true });"],
+    ])("leaves %s alone", async (_label, body) => {
+        expect(await reportedLines(body)).toEqual([]);
+    });
+
+    it("reports every offending call rather than only the first", async () => {
+        // Vacuity guard. Every "leaves alone" row above passes for a rule that matches nothing at
+        // all, so at least one assertion has to pin a count that only a working selector produces.
+        const lines = await reportedLines(
+            [
+                "    await rm(a, { recursive: true, force: true });",
+                "    await rm(b, { recursive: false });",
+                "    rmSync(c, { recursive: true, force: true });",
+            ].join("\n"),
+        );
+        expect(lines).toEqual([2, 4]);
+    });
+});

--- a/tests/unit/publishing/verifyVsixPackage.test.ts
+++ b/tests/unit/publishing/verifyVsixPackage.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -13,6 +13,7 @@ import {
     selectSoleVsix,
     verifyVsixPackage,
 } from "../../../scripts/verifyVsixPackage.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 const REQUIRED_FILES = [
     "package.json",
@@ -47,7 +48,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    rmSync(fixtureRoot, { recursive: true, force: true });
+    removeScratchDirectoriesSync(fixtureRoot);
 });
 
 async function writeArchive(entries: ArchiveEntry[]): Promise<string> {

--- a/tests/unit/scripts/build.test.ts
+++ b/tests/unit/scripts/build.test.ts
@@ -13,13 +13,14 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { runBuild } from "../../../scripts/build.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("runBuild", () => {
     let workDir: string;
@@ -34,7 +35,7 @@ describe("runBuild", () => {
     });
 
     afterEach(() => {
-        rmSync(workDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(workDir);
     });
 
     function writeSource(name: string, contents: string): string {

--- a/tests/unit/scripts/buildManifest.test.ts
+++ b/tests/unit/scripts/buildManifest.test.ts
@@ -7,13 +7,14 @@
  * manifest, run the build" message instead of a loud parse/schema error.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createManifest, hashFileContents, readManifest } from "../../../scripts/buildManifest.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("buildManifest", () => {
     let distDir: string;
@@ -23,7 +24,7 @@ describe("buildManifest", () => {
     });
 
     afterEach(() => {
-        rmSync(distDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(distDir);
     });
 
     it("returns null when no manifest file exists", () => {

--- a/tests/unit/scripts/check-no-skip-ci.test.ts
+++ b/tests/unit/scripts/check-no-skip-ci.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -23,6 +23,7 @@ import {
     findOffenders,
     getCommitMessages,
 } from "../../../scripts/check-no-skip-ci.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("containsSkipDirective: recognized GitHub skip tokens", () => {
     it.each(["[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"])(
@@ -216,7 +217,7 @@ describe("getCommitMessages: integration against a real repository", () => {
     });
 
     afterAll(() => {
-        rmSync(repoDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(repoDir);
     });
 
     it("returns exactly one entry per commit in the exclusive base..head range", () => {

--- a/tests/unit/scripts/verifyBuildProvenance.test.ts
+++ b/tests/unit/scripts/verifyBuildProvenance.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createManifest, writeManifest } from "../../../scripts/buildManifest.js";
 import { verifyBuildProvenance } from "../../../scripts/verifyBuildProvenance.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 describe("verifyBuildProvenance", () => {
     let distDir: string;
@@ -23,7 +24,7 @@ describe("verifyBuildProvenance", () => {
     });
 
     afterEach(() => {
-        rmSync(distDir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(distDir);
     });
 
     function seedOutput(name: string, contents: string): string {

--- a/tests/unit/scripts/verifyNoE2eManifestCommand.test.ts
+++ b/tests/unit/scripts/verifyNoE2eManifestCommand.test.ts
@@ -6,7 +6,7 @@
 // a control command is ever actually added to it, not just against synthetic fixtures.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -15,6 +15,7 @@ import {
     findE2eCommands,
     verifyNoE2eManifestCommand,
 } from "../../../scripts/verifyNoE2eManifestCommand.js";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 const SCRIPT_PATH = resolve(__dirname, "../../../scripts/verifyNoE2eManifestCommand.js");
 
@@ -33,7 +34,7 @@ describe("verifyNoE2eManifestCommand: synthetic fixtures", () => {
     });
 
     afterEach(() => {
-        rmSync(dir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(dir);
     });
 
     function seedPackageJson(contributes: unknown): string {
@@ -183,7 +184,7 @@ describe("verifyNoE2eManifestCommand: a control command with neutral metadata", 
     });
 
     afterEach(() => {
-        rmSync(dir, { recursive: true, force: true });
+        removeScratchDirectoriesSync(dir);
     });
 
     const NEUTRAL_COMMAND = { command: "intelligit.internalDebug", title: "Seed" };

--- a/tests/unit/services/reviewPrompt.test.ts
+++ b/tests/unit/services/reviewPrompt.test.ts
@@ -56,6 +56,7 @@ import {
     getReviewUrl,
     registerReviewPrompt,
 } from "../../../src/services/reviewPrompt";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 /** Well clear of the 14-day install age and the 30-day snooze horizon. */
@@ -129,7 +130,7 @@ describe("reviewPrompt", () => {
     afterEach(async () => {
         setGitSuccessListener(undefined);
         resetReviewPromptHosts();
-        await rm(storageDir, { recursive: true, force: true });
+        await removeScratchDirectories(storageDir);
     });
 
     describe("countsAsSuccess", () => {
@@ -515,7 +516,7 @@ describe("reviewPrompt", () => {
             vscodeMock.window.showInformationMessage.mockResolvedValue(RATE_ACTION);
             const service = makeService();
             await service.init();
-            await rm(path.join(storageDir, "reviewPrompt"), { recursive: true, force: true });
+            await removeScratchDirectories(path.join(storageDir, "reviewPrompt"));
             await writeFile(path.join(storageDir, "reviewPrompt"), "not a directory", "utf8");
 
             service.handleGitSuccess("commit", ["commit"]);
@@ -778,7 +779,7 @@ describe("reviewPrompt", () => {
 
     describe("containment", () => {
         it("disables itself instead of failing activation when storage is unusable", async () => {
-            await rm(storageDir, { recursive: true, force: true });
+            await removeScratchDirectories(storageDir);
             await writeFile(storageDir, "not a directory", "utf8");
             const service = makeService();
 

--- a/tests/unit/services/shelfConflictSession.test.ts
+++ b/tests/unit/services/shelfConflictSession.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,12 +11,13 @@ import {
     extractOursFromConflictMarkers,
     type ShelfConflictSessionDependencies,
 } from "../../../src/services/shelfConflictSession";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/services/shelfService.test.ts
+++ b/tests/unit/services/shelfService.test.ts
@@ -13,13 +13,14 @@ import { resolveShelfPaths } from "../../../src/shelf/paths";
 import { ShelfStore } from "../../../src/shelf/store";
 import { ShelfService } from "../../../src/services/shelfService";
 import { pathFingerprint } from "../../../src/services/shelfServiceOperations";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 
@@ -404,7 +405,7 @@ describe("ShelfService", () => {
         directories.push(outside);
         const outsideTarget = path.join(outside, "tracked.txt");
         await writeFile(outsideTarget, "one\nlocal\nthree\n");
-        await rm(path.join(root, "nested"), { recursive: true, force: true });
+        await removeScratchDirectories(path.join(root, "nested"));
         await symlink(outside, path.join(root, "nested"));
         const originalRunBinary = executor.runBinary.bind(executor);
         let merged = false;

--- a/tests/unit/services/shelfServiceUnicode.test.ts
+++ b/tests/unit/services/shelfServiceUnicode.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,13 +11,14 @@ import { RepositoryMutationGate } from "../../../src/git/repositoryMutationGate"
 import { resolveShelfPaths } from "../../../src/shelf/paths";
 import { ShelfStore } from "../../../src/shelf/store";
 import { ShelfService } from "../../../src/services/shelfService";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/services/worktreeService.test.ts
+++ b/tests/unit/services/worktreeService.test.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fixturePath } from "../../helpers/fixturePaths";
 import type { GitExecutor } from "../../../src/git/executor";
 import { WorktreeService } from "../../../src/services/worktreeService";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const showWarningMessage = vi.hoisted(() => vi.fn());
 const includeFiles = vi.hoisted(() => ({ value: [] as string[] }));
@@ -92,9 +93,7 @@ function createScopedExecutor(statusOutput: string): {
 describe("WorktreeService", () => {
     afterEach(async () => {
         includeFiles.value = [];
-        await Promise.all(
-            tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-        );
+        await Promise.all(tempRoots.splice(0).map((root) => removeScratchDirectories(root)));
     });
 
     it("caches worktree lists until refresh repulls and emits", async () => {

--- a/tests/unit/shelf/capture.test.ts
+++ b/tests/unit/shelf/capture.test.ts
@@ -11,12 +11,13 @@ import {
 import { ShelfUnsupportedStateError, type ShelfFileEntry } from "../../../src/shelf/model";
 import { resolveShelfPaths } from "../../../src/shelf/paths";
 import { ShelfStore } from "../../../src/shelf/store";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/shelf/importValidation.test.ts
+++ b/tests/unit/shelf/importValidation.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,14 +10,13 @@ import {
     validateImportedPatchStream,
     validateShelfManifestPath,
 } from "../../../src/shelf/importValidation";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        temporaryDirectories
-            .splice(0)
-            .map((directory) => rm(directory, { recursive: true, force: true })),
+        temporaryDirectories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/shelf/patchIO.test.ts
+++ b/tests/unit/shelf/patchIO.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -13,6 +13,7 @@ import {
     materializeLayerPatches,
     selectPatchBlocks,
 } from "../../../src/shelf/patchIO";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -146,7 +147,7 @@ describe("shelf patch primitives", () => {
             ]);
             expect(executor.runCalls.flat()).not.toContain("--3way");
         } finally {
-            await rm(directory, { recursive: true, force: true });
+            await removeScratchDirectories(directory);
         }
     });
 
@@ -173,7 +174,7 @@ describe("shelf patch primitives", () => {
             await expect(access(sourcePath)).rejects.toThrow();
             await expect(readFile(destinationPath, "utf8")).resolves.toBe("before\n");
         } finally {
-            await rm(directory, { recursive: true, force: true });
+            await removeScratchDirectories(directory);
         }
     });
 

--- a/tests/unit/shelf/patchRoundTrip.test.ts
+++ b/tests/unit/shelf/patchRoundTrip.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,13 +11,14 @@ import {
     generateUntrackedPatch,
     materializeLayerPatches,
 } from "../../../src/shelf/patchIO";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/shelf/paths.test.ts
+++ b/tests/unit/shelf/paths.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, realpath, rm, stat, symlink } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, realpath, stat, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,12 +10,13 @@ import {
     ShelfPathError,
     writePrivateShelfFile,
 } from "../../../src/shelf/paths";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/shelf/recovery.test.ts
+++ b/tests/unit/shelf/recovery.test.ts
@@ -468,7 +468,7 @@ describe("ShelfReverter", () => {
         const primary = await createReverter();
         const linkedWorktree = await mkdtemp(path.join(tmpdir(), "intelligit-shelf-linked-"));
         directories.push(linkedWorktree);
-        await rm(linkedWorktree, { recursive: true, force: true });
+        await removeScratchDirectories(linkedWorktree);
         await git(primary.repositoryRoot, [
             "worktree",
             "add",

--- a/tests/unit/shelf/recoveryRollback.test.ts
+++ b/tests/unit/shelf/recoveryRollback.test.ts
@@ -1,15 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import {
-    mkdir,
-    mkdtemp,
-    readFile,
-    readdir,
-    rename,
-    rm,
-    symlink,
-    writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -27,13 +18,14 @@ import {
     type RevertCheckpoint,
 } from "../../../src/shelf/recovery";
 import { ShelfStore } from "../../../src/shelf/store";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 
@@ -390,7 +382,7 @@ describe("ShelfReverter per-path rollback index guards", () => {
         await writeFile(path.join(repositoryRoot, "gone", "nested.txt"), "nested base\n");
         await git(repositoryRoot, ["add", "gone/nested.txt"]);
         await git(repositoryRoot, ["commit", "-m", "nested base"]);
-        await rm(path.join(repositoryRoot, "gone"), { recursive: true, force: true });
+        await removeScratchDirectories(path.join(repositoryRoot, "gone"));
         await git(repositoryRoot, ["add", "-u"]);
 
         await reverter.revert({

--- a/tests/unit/shelf/safeWorktreeWrite.test.ts
+++ b/tests/unit/shelf/safeWorktreeWrite.test.ts
@@ -24,7 +24,7 @@
  * tail behind" is the defect that matters, whatever mechanism is underneath.
  */
 
-import { chmod, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -32,12 +32,13 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { POSIX_PERMISSIONS_ENFORCED } from "../../helpers/platformCapabilities";
 import { replaceRegularWorktreeFile } from "../../../src/shelf/safeWorktreeWrite";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 describe("replaceRegularWorktreeFile", () => {
     let root: string | undefined;
 
     afterEach(async () => {
-        if (root) await rm(root, { recursive: true, force: true });
+        if (root) await removeScratchDirectories(root);
         root = undefined;
     });
 

--- a/tests/unit/shelf/store.test.ts
+++ b/tests/unit/shelf/store.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -11,12 +11,13 @@ import {
     ShelfStore,
     ShelfStoreCorruptionError,
 } from "../../../src/shelf/store";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const directories: string[] = [];
 
 afterEach(async () => {
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 
@@ -163,7 +164,7 @@ describe("ShelfStore", () => {
         const garbageOutside = await mkdtemp(path.join(tmpdir(), "intelligit-shelf-outside-"));
         directories.push(garbageOutside);
         const objects = path.join(garbage.paths.root, "shelves", "shelf-one", "objects");
-        await rm(objects, { recursive: true, force: true });
+        await removeScratchDirectories(objects);
         await symlink(garbageOutside, objects);
         await expect(garbage.store.collectGarbage("shelf-one")).rejects.toBeInstanceOf(
             ShelfPathError,

--- a/tests/unit/shelf/storeDirectoryFsync.test.ts
+++ b/tests/unit/shelf/storeDirectoryFsync.test.ts
@@ -7,13 +7,14 @@
 // the suite on Windows: 206 failures, every one `EPERM: operation not permitted, fsync` raised from
 // `fsyncDirectory`, because Windows lets a directory handle be OPENED and then refuses to flush it.
 import { statSync } from "node:fs";
-import { mkdir, mkdtemp, open, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, open, realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ensureShelfRoot, resolveShelfPaths } from "../../../src/shelf/paths";
 import { ShelfStore } from "../../../src/shelf/store";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 // Everything except `open` stays real: the point is to watch one call, not to simulate a store.
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -32,7 +33,7 @@ afterEach(async () => {
     setPlatform(originalPlatform);
     vi.mocked(open).mockClear();
     await Promise.all(
-        directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/views/UndockedViewProvider.test.ts
+++ b/tests/unit/views/UndockedViewProvider.test.ts
@@ -48,7 +48,7 @@ import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVs
 // the `vi.mock` call it feeds.
 vi.mock("vscode", () => createCommitInfoVscodeDouble());
 
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -71,6 +71,7 @@ import {
     resetFakeWorkspaceConfigurationForTests,
     setFakeWorkspaceConfiguration,
 } from "../../visual/recorder/workspaceConfigurationDouble";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === "object" && value !== null;
@@ -200,7 +201,7 @@ describe("UndockedViewProvider commit-detail re-post on webview reload", () => {
                 for (const createdPanel of getCreatedWebviewPanels()) createdPanel.dispose();
                 resetCreatedWebviewPanelsForTests();
                 resetFakeWorkspaceConfigurationForTests();
-                await rm(parentDir, { recursive: true, force: true });
+                await removeScratchDirectories(parentDir);
             }
         },
     );

--- a/tests/unit/views/commitPanelActions.commitAccuracy.test.ts
+++ b/tests/unit/views/commitPanelActions.commitAccuracy.test.ts
@@ -27,12 +27,15 @@ const notificationsMock = vi.hoisted(() => ({
 vi.mock("../../../src/utils/notifications", () => notificationsMock);
 
 import { commitSelectedFromPanel } from "../../../src/views/commitPanelActions";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 const directories: string[] = [];
 
 afterEach(async () => {
-    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true })));
+    await Promise.all(
+        directories.splice(0).map((directory) => removeScratchDirectories(directory)),
+    );
 });
 
 async function git(repo: string, args: string[]): Promise<string> {

--- a/tests/unit/visual/harness/hostContexts.test.ts
+++ b/tests/unit/visual/harness/hostContexts.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -56,6 +56,7 @@ import {
 } from "../../../visual/harness/hostContexts";
 
 import * as webviewHtml from "../../../../src/views/webviewHtml";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const DEFAULT_BACKGROUND_VAR = "var(--vscode-editor-background)";
 const DARK_MODERN = darkModern as HostFixture;
@@ -307,11 +308,9 @@ describe("resolved host-context production oracle", () => {
 
     afterAll(async () => {
         await Promise.all(
-            [...workspaces.values()].map((workspace) =>
-                rm(workspace.home, { recursive: true, force: true }),
-            ),
+            [...workspaces.values()].map((workspace) => removeScratchDirectories(workspace.home)),
         );
-        await rm(parentDir, { recursive: true, force: true });
+        await removeScratchDirectories(parentDir);
     });
 
     beforeEach(() => {

--- a/tests/unit/visual/oracles/findingsBaselineFile.test.ts
+++ b/tests/unit/visual/oracles/findingsBaselineFile.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -9,6 +9,7 @@ import {
     baselineFile,
     UPDATE_ENV_VAR,
 } from "../../../visual/oracles/findingsBaselineFile";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const originalUpdateValue = process.env[UPDATE_ENV_VAR];
 const temporaryDirectories: string[] = [];
@@ -17,9 +18,7 @@ afterEach(async () => {
     if (originalUpdateValue === undefined) delete process.env[UPDATE_ENV_VAR];
     else process.env[UPDATE_ENV_VAR] = originalUpdateValue;
     await Promise.all(
-        temporaryDirectories
-            .splice(0)
-            .map((directory) => rm(directory, { recursive: true, force: true })),
+        temporaryDirectories.splice(0).map((directory) => removeScratchDirectories(directory)),
     );
 });
 

--- a/tests/unit/visual/oracles/pinnedBaseImage.test.ts
+++ b/tests/unit/visual/oracles/pinnedBaseImage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -10,6 +10,7 @@ import {
     checkPinnedProvenance,
     readPinnedBaseImage,
 } from "../../../visual/oracles/pinnedBaseImage";
+import { removeScratchDirectoriesSync } from "../../../helpers/scratchDirectories";
 
 const PIN_PATH = resolve(__dirname, "../../../e2e/docker/base-image.txt");
 const ENVIRONMENT_PATH = resolve(__dirname, "../../../visual/fixtures/baselineEnvironment.json");
@@ -24,7 +25,7 @@ describe("pinned base image oracle", () => {
 
             expect(readPinnedBaseImage(pinPath)).toBe(validDigest);
         } finally {
-            rmSync(directory, { recursive: true, force: true });
+            removeScratchDirectoriesSync(directory);
         }
     });
 
@@ -36,7 +37,7 @@ describe("pinned base image oracle", () => {
 
             expect(() => readPinnedBaseImage(pinPath)).toThrow("Pinned base image pin not found");
         } finally {
-            rmSync(directory, { recursive: true, force: true });
+            removeScratchDirectoriesSync(directory);
         }
     });
 

--- a/tests/unit/visual/playwright/visualEnvironmentGuard.test.ts
+++ b/tests/unit/visual/playwright/visualEnvironmentGuard.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,6 +18,7 @@ import {
 } from "../../../visual/playwright/visualEnvironmentGuard";
 import { BASELINE_PLATFORM } from "../../../visual/oracles/findingsBaselineFile";
 import type { VisualEnvironment } from "../../../visual/oracles/visualEnvironment";
+import { removeScratchDirectoriesSync } from "../../../helpers/scratchDirectories";
 
 const validDigest = `repo@sha256:${"a".repeat(64)}`;
 const defaultCompareBaseImage = Symbol("default compare base image");
@@ -40,7 +41,7 @@ function withTemporaryEnvironmentPath(
     const environmentPath = join(directory, "baselineEnvironment.json");
     const pinPath = join(directory, "base-image.txt");
     writeFileSync(pinPath, `# test pin\n\n${validDigest}\n`, "utf8");
-    const cleanup = (): void => rmSync(directory, { recursive: true, force: true });
+    const cleanup = (): void => removeScratchDirectoriesSync(directory);
     try {
         const result = run(environmentPath, pinPath);
         if (result instanceof Promise) return result.finally(cleanup);

--- a/tests/unit/visual/publishWorkflow.test.ts
+++ b/tests/unit/visual/publishWorkflow.test.ts
@@ -6,7 +6,6 @@ import {
     mkdtempSync,
     readdirSync,
     readFileSync,
-    rmSync,
     writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -15,6 +14,7 @@ import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { oracles } from "../../oracles";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
 
 const { sanitizedGitEnv } = oracles.get("gitEnv");
 
@@ -263,7 +263,7 @@ function runVersionGate(script: string, version: string, options: VersionGateOpt
                 : [],
         } satisfies VersionGateRun;
     } finally {
-        rmSync(workspace, { recursive: true, force: true });
+        removeScratchDirectoriesSync(workspace);
     }
 }
 
@@ -344,7 +344,7 @@ function runTagStep(script: string, tagPlacement: "head" | "older" | "absent") {
             older: STRANDED_SHA,
         };
     } finally {
-        rmSync(workspace, { recursive: true, force: true });
+        removeScratchDirectoriesSync(workspace);
     }
 }
 

--- a/tests/unit/visual/recorder/recordMergeEditorWebviewFixture.test.ts
+++ b/tests/unit/visual/recorder/recordMergeEditorWebviewFixture.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -45,6 +45,7 @@ import {
     setFakeWorkspaceConfiguration,
 } from "../../../visual/recorder/workspaceConfigurationDouble";
 import { createScratchWorkspaces } from "../../fixtures/scratchWorkspaces";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const CONFLICTED_SCENARIO = REPOSITORY_SCENARIOS.find((scenario) => scenario.id === "conflicted");
 if (!CONFLICTED_SCENARIO) {
@@ -268,8 +269,8 @@ describe("merge-editor webview recorder", () => {
             ).rejects.toThrow(/exactly one conflicted file/);
         } finally {
             await Promise.all([
-                rm(cleanWorkspace.home, { recursive: true, force: true }),
-                rm(cleanDestination, { recursive: true, force: true }),
+                removeScratchDirectories(cleanWorkspace.home),
+                removeScratchDirectories(cleanDestination),
             ]);
         }
     });

--- a/tests/unit/visual/recorder/recordShelfConflictEditorWebviewFixture.test.ts
+++ b/tests/unit/visual/recorder/recordShelfConflictEditorWebviewFixture.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -54,6 +54,7 @@ import {
 } from "../../../visual/recorder/workspaceConfigurationDouble";
 import { REPOSITORY_SCENARIOS, type ScenarioWorkspace } from "../../../fixtures/repo/scenarios";
 import { createScratchWorkspaces } from "../../fixtures/scratchWorkspaces";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
 
@@ -465,8 +466,8 @@ describe("shelf-conflict-editor webview recorder", () => {
             ).rejects.toThrow(/shelf|manifest|exactly one/i);
         } finally {
             await Promise.all([
-                rm(cleanWorkspace.home, { recursive: true, force: true }),
-                rm(cleanDestination, { recursive: true, force: true }),
+                removeScratchDirectories(cleanWorkspace.home),
+                removeScratchDirectories(cleanDestination),
             ]);
         }
     });

--- a/tests/unit/visual/recorder/recordUndockedWebviewFixture.test.ts
+++ b/tests/unit/visual/recorder/recordUndockedWebviewFixture.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -47,6 +47,7 @@ import {
     resetFakeWorkspaceConfigurationForTests,
 } from "../../../visual/recorder/workspaceConfigurationDouble";
 import { createScratchWorkspaces } from "../../fixtures/scratchWorkspaces";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const MID_REBASE_SCENARIO = REPOSITORY_SCENARIOS.find(
     (scenario) => scenario.id === UNDOCKED_MID_REBASE_SCENARIO,
@@ -265,8 +266,8 @@ describe("undocked webview recorder", () => {
             ).rejects.toThrow(/expected the mid-rebase scenario to have an active rebase/);
         } finally {
             await Promise.all([
-                rm(cleanWorkspace.home, { recursive: true, force: true }),
-                rm(cleanDestination, { recursive: true, force: true }),
+                removeScratchDirectories(cleanWorkspace.home),
+                removeScratchDirectories(cleanDestination),
             ]);
         }
     });

--- a/tests/unit/visual/recorder/webviewFixtureGate.test.ts
+++ b/tests/unit/visual/recorder/webviewFixtureGate.test.ts
@@ -44,7 +44,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, realpathSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -74,6 +74,7 @@ import {
     type WebviewFixtureRecorderEntry,
 } from "../../../visual/recorder/webviewFixtureRegistry";
 import type { WebviewFixture } from "../../../visual/recorder/webviewFixtureTypes";
+import { removeScratchDirectories } from "../../../helpers/scratchDirectories";
 
 const REPO_ROOT = path.resolve(__dirname, "../../../..");
 const REAL_FIXTURES_DIR = path.join(REPO_ROOT, "tests", "visual", "fixtures");
@@ -276,7 +277,7 @@ describe("runWebviewFixtureGate", () => {
                 });
                 expect(findings[0].detail.length).toBeGreaterThan(0);
             } finally {
-                await rm(scratchRepoRoot, { recursive: true, force: true });
+                await removeScratchDirectories(scratchRepoRoot);
             }
         },
         REAL_SCENARIO_TIMEOUT_MS,
@@ -342,7 +343,7 @@ describe("runWebviewFixtureGate", () => {
                         }),
                     ).toEqual([]);
                 } finally {
-                    await rm(scratchRepoRoot, { recursive: true, force: true });
+                    await removeScratchDirectories(scratchRepoRoot);
                 }
             },
             REAL_SCENARIO_TIMEOUT_MS,
@@ -377,7 +378,7 @@ describe("runWebviewFixtureGate", () => {
                         ),
                     ).toBe(await committedBytesInRepo());
                 } finally {
-                    await rm(scratchRepoRoot, { recursive: true, force: true });
+                    await removeScratchDirectories(scratchRepoRoot);
                 }
             },
             REAL_SCENARIO_TIMEOUT_MS,
@@ -414,7 +415,7 @@ describe("runWebviewFixtureGate", () => {
                         "orphan-scenario",
                     );
                 } finally {
-                    await rm(scratchRepoRoot, { recursive: true, force: true });
+                    await removeScratchDirectories(scratchRepoRoot);
                 }
             },
             REAL_SCENARIO_TIMEOUT_MS,
@@ -444,7 +445,7 @@ describe("runWebviewFixtureGate", () => {
                     // Still the drifted bytes: the default gate reports drift, it never repairs it.
                     expect(await readFile(committedPath, "utf8")).toBe(drifted);
                 } finally {
-                    await rm(scratchRepoRoot, { recursive: true, force: true });
+                    await removeScratchDirectories(scratchRepoRoot);
                 }
             },
             REAL_SCENARIO_TIMEOUT_MS,
@@ -484,7 +485,7 @@ describe("runWebviewFixtureGate", () => {
                 path: orphanPath,
             });
         } finally {
-            await rm(scratchRepoRoot, { recursive: true, force: true });
+            await removeScratchDirectories(scratchRepoRoot);
         }
     });
 
@@ -520,7 +521,7 @@ describe("runWebviewFixtureGate", () => {
                 expect(calls).toEqual(["clean", "dirty"]);
                 expect(preparations).toHaveLength(2);
             } finally {
-                await rm(scratchRepoRoot, { recursive: true, force: true });
+                await removeScratchDirectories(scratchRepoRoot);
             }
         });
 
@@ -545,7 +546,7 @@ describe("runWebviewFixtureGate", () => {
                 expect(existsSync(preparations[0].destination)).toBe(false);
                 expect(existsSync(preparations[0].home)).toBe(false);
             } finally {
-                await rm(scratchRepoRoot, { recursive: true, force: true });
+                await removeScratchDirectories(scratchRepoRoot);
             }
         });
 
@@ -576,7 +577,7 @@ describe("runWebviewFixtureGate", () => {
                 expect(existsSync(preparations[0].destination)).toBe(false);
                 expect(existsSync(preparations[0].home)).toBe(false);
             } finally {
-                await rm(scratchRepoRoot, { recursive: true, force: true });
+                await removeScratchDirectories(scratchRepoRoot);
             }
         });
 
@@ -611,7 +612,7 @@ describe("runWebviewFixtureGate", () => {
                 expect(existsSync(preparations[0].destination)).toBe(false);
                 expect(existsSync(preparations[0].home)).toBe(false);
             } finally {
-                await rm(scratchRepoRoot, { recursive: true, force: true });
+                await removeScratchDirectories(scratchRepoRoot);
             }
         });
     });
@@ -650,7 +651,7 @@ describe("runWebviewFixtureGate", () => {
                 expect(existsSync(workspace.root)).toBe(true);
                 expect(existsSync(path.dirname(workspace.root))).toBe(true);
             } finally {
-                await rm(path.dirname(workspace.root), { recursive: true, force: true });
+                await removeScratchDirectories(path.dirname(workspace.root));
             }
         });
     });
@@ -740,7 +741,7 @@ describe("runWebviewFixtureGate", () => {
                         assertDisposableScenarioPath(realpathSync(allocated), "clean", role),
                     ).not.toThrow();
                 } finally {
-                    await rm(allocated, { recursive: true, force: true });
+                    await removeScratchDirectories(allocated);
                 }
             },
         );

--- a/tests/visual/recorder/webviewFixtureGate.ts
+++ b/tests/visual/recorder/webviewFixtureGate.ts
@@ -32,7 +32,7 @@
  */
 
 import { realpathSync } from "node:fs";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -43,6 +43,7 @@ import {
 } from "../../fixtures/repo/scenarios";
 import { serializeWebviewFixture, webviewFixtureFilePath } from "./webviewFixtureFile";
 import type { WebviewFixtureRecorderEntry } from "./webviewFixtureRegistry";
+import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 
 /** Directory name directly under `tests/visual/fixtures/` that is NOT a webview-payload context
  * directory. See this module's own doc comment for why `host` specifically is excluded here.
@@ -173,7 +174,7 @@ export async function prepareIntoScratchDestination(
     try {
         return await prepare(destination);
     } catch (error) {
-        await rm(destination, { recursive: true, force: true });
+        await removeScratchDirectories(destination);
         throw error;
     }
 }
@@ -210,8 +211,8 @@ async function disposeScenarioWorkspace(workspace: ScenarioWorkspace): Promise<v
     const destination = path.dirname(workspace.root);
     assertDisposableScenarioPath(destination, workspace.id, "destination");
     assertDisposableScenarioPath(workspace.home, workspace.id, "home");
-    await rm(destination, { recursive: true, force: true });
-    await rm(workspace.home, { recursive: true, force: true });
+    await removeScratchDirectories(destination);
+    await removeScratchDirectories(workspace.home);
 }
 
 /**
@@ -247,7 +248,7 @@ function isStrictlyContainedIn(parent: string, child: string): boolean {
  * (`seed.ts:150`, and `scenarios.ts`'s `toWorkspace` / `prepareEmptyRepo`). That is a convention,
  * not something the type system enforces -- a future builder returning a root sitting directly AT
  * its destination makes the derivation resolve one level too high, to the OS temp root, and the
- * `rm(..., { recursive: true })` stops being a cleanup and becomes an unrecoverable delete of every
+ * `removeScratchDirectories(...)` stops being a cleanup and becomes an unrecoverable delete of every
  * other process's scratch state. The supplied one: `runWebviewFixtureGate`'s `prepareScenario`
  * option is injectable, so `workspace.root` and `workspace.home` are whatever a scenario returns.
  * A scenario rooted anywhere in the repository -- `<repoRoot>/tests/workspace`, say -- yielded a


### PR DESCRIPTION
## What

Routes every recursive scratch-directory removal in `tests/` through the retrying delete, and adds a lint rule so the next one cannot be written by hand.

This is the follow-up to #229, which fixed the Windows index-lock classifier. That PR's CI attribution turned up a *separate*, pre-existing flake in the Windows portability leg — this fixes it.

## Why

Tests build real repositories in temp directories and delete them in teardown. Git keeps writing into `.git/objects/pack` after the command that triggered it has returned, so a file can appear between a recursive `rm`'s `readdir` and its `rmdir`. That surfaces as `ENOTEMPTY`/`EBUSY` — and on Windows as `EPERM`, because a name another handle still holds open cannot be removed there at all.

Because these run in teardown, **the failure lands on whichever row is executing rather than on the row that caused it.** That is what made it hard to attribute:

| attempt (same commit) | failing test | error |
|---|---|---|
| 1 | 2 hydration tests in `CommitPanelViewProvider.test.ts` | `EBUSY … rmdir` |
| 2 | `harness.test.ts` — different file | `EBUSY … rmdir` |
| 3 | — | green |

Different innocent test each time, none with a failing assertion of its own. Base rate ≈ 38% on the portability leg for runs on 2026-08-24 onward, including dependabot lockfile branches that touch no source at all — which is what rules out any recent code change as the cause.

`removeScratchDirectories` (`maxRetries: 10, retryDelay: 50`) already existed for exactly this and 13 files used it. 180 removals across 91 files did not.

## Scope

| shape | n | action |
|---|---|---|
| `rm(X, { recursive: true, force: true })` | 138 | → `removeScratchDirectories(X)` |
| `rmSync(X, { recursive: true, force: true })` | 34 | → new `removeScratchDirectoriesSync(X)` |
| `rm(X, { recursive: true })`, no force | 7 | → helper (6 are one teardown idiom; the 7th simulates `git rebase --abort` in a mock) |
| `rm(file)` / `rm(x, { force: true })` | **29** | **untouched** — no `readdir` step to lose |
| `actual.rm` in `resourceCleanup.test.ts` | 1 | **retry options inline, binding kept** |

That last one is deliberate: the helper imports `rm` from `node:fs/promises`, which that suite mocks, so routing its teardown through the helper would add to the very `rmMock` call count its assertions read.

The 29 single-file removals are why the rule keys on *`recursive` present + `maxRetries` absent* rather than banning the `rm` import.

## The guard, and where it lives

The new `no-restricted-syntax` rule is in **its own config block**, not the existing `tests/**/*.ts` one. That block carries an `ignores` list for the unrelated oracle-import rule — and `tests/unit/e2e/oracles.test.ts` alone holds seven of these removals. Hanging the rule there would have exempted exactly the files nobody would think to re-check, and linted clean while doing it.

## Test plan

- [x] All 8 gates: `format:check`, `lint:strict`, `lint:complexity`, `typecheck`, `architecture:check`, `verify:manifest`, `l10n:validate`, `build` — **rc=0 each**
- [x] Full suite: **4218 passed / 0 failed, 304 files, rc=0** — identical count to `main`, so no test silently stopped running
- [x] `detect_changes` — **LOW risk, 0 affected processes**; every changed file is under `tests/`
- [x] **Lint rule proved in both directions.** A probe file with three shapes that must flag (`rm`/`rmSync`/`fs.rm` with `recursive`, no `maxRetries`) and three that must stay legal (`rm(file)`, `rm(x, {force})`, `rm` already retrying) produced **exactly 3 errors, at exactly lines 9/10/11**, each naming `no-restricted-syntax`. Not green-by-construction.
- [ ] Windows portability leg — the actual layer. See caveat below.

## Caveat, stated plainly

**A single green Windows run does not prove this fixed the flake.** At a ~38% failure rate, a green run happens ~62% of the time anyway. What is proved: every recursive teardown now uses Node's documented remedy for that exact errno class, and no future one can be added without the lint rule refusing it. What is not proved: that no other Windows race remains.

No production code changes, so no version bump — matching #227 and #228.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of temporary workspace cleanup with retry-aware directory removal.
  * Updated cleanup for asynchronous and synchronous test scenarios.
  * Made filesystem durability checks more accurate on Windows.

* **Tests**
  * Standardized temporary-directory cleanup across the test suite.
  * Added checks to prevent unreliable recursive removal patterns in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->