### PR TITLE
fix(e2e-capture): tag the handshake trace with the document generation (v0.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The diagnostic trail the end-to-end suite prints when the Changes panel fails to appear now names which generation of the panel's document each line belongs to. This changes nothing about the extension itself — the trail is produced only while the test control channel is active, and never in a normal install — but it closes a gap that sent four investigations of the intermittent blank Changes panel down the wrong path. Every line already carried a number identifying the panel it came from, and identical numbers on a matched question-and-answer pair were read as proof that the extension had answered the panel that asked. They could not prove that. The number is assigned once per view, and VS Code can rebuild a hidden view's document without rebuilding the view around it, so every document that ever lives behind one view shares a single number. An answer sent to a document that no longer exists therefore looked exactly like an answer the live document received and ignored, and the evidence collected through that number could never tell the two apart. It can now. The blank panel itself is not fixed by this — what changes is that the next occurrence can say which of those two things happened, which is what picking the right fix requires.
+- When the end-to-end tests fail because the Changes panel never appeared, they print a short diagnostic trail. Each line now says which version of the panel's page it came from.
+
+  This does not change the extension. The trail is only printed while the test control channel is on, never in a normal install.
+
+  Why it was needed: every line already had a number, but that number names the view, not the page inside it. VS Code can reload a hidden view's page without rebuilding the view, so every page behind one view shared the same number. That made two different things look identical — the extension answering the live page, and the extension answering a page that no longer exists. Four investigations into the intermittent blank Changes panel could not tell them apart.
+
+  The blank panel is still not fixed. What changes is that the next time it happens, the trail can say which of the two went wrong, which is what picking the right fix needs.
 
 ## [0.28.0] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2026-08-26
+
+### Changed
+
+- The diagnostic trail the end-to-end suite prints when the Changes panel fails to appear now names which generation of the panel's document each line belongs to. This changes nothing about the extension itself — the trail is produced only while the test control channel is active, and never in a normal install — but it closes a gap that sent four investigations of the intermittent blank Changes panel down the wrong path. Every line already carried a number identifying the panel it came from, and identical numbers on a matched question-and-answer pair were read as proof that the extension had answered the panel that asked. They could not prove that. The number is assigned once per view, and VS Code can rebuild a hidden view's document without rebuilding the view around it, so every document that ever lives behind one view shares a single number. An answer sent to a document that no longer exists therefore looked exactly like an answer the live document received and ignored, and the evidence collected through that number could never tell the two apart. It can now. The blank panel itself is not fixed by this — what changes is that the next occurrence can say which of those two things happened, which is what picking the right fix requires.
+
 ## [0.28.0] - 2026-08-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.28.0",
+    "version": "0.28.1",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/e2e/webviewCapture.ts
+++ b/src/e2e/webviewCapture.ts
@@ -72,6 +72,25 @@ const HANDSHAKE_TRACED_TYPES = new Set(["ready", "setRepositories"]);
 const HANDSHAKE_TRACE_PREFIX = "[intelligit-e2e] handshake";
 
 /**
+ * Whether `message` is a document announcing itself for the first time.
+ *
+ * The webview's retry numbers its asks from 1 per DOCUMENT
+ * (`src/webviews/react/commit-panel/hooks/useExtensionMessages.ts`), so a second `attempt: 1`
+ * behind one wrapper is a document that was rebuilt, not a view that was re-resolved.
+ *
+ * Only a literal `1` counts. `isHydrationReAsk` reads unknown input the other way round because
+ * its failure costs a redundant Git read; here the cost is inverted -- a missing or malformed
+ * `attempt` reported as a fresh document would convict a reload that never happened, and this
+ * field exists to convict. Undercounting leaves the next dump as mute as the last, which is
+ * recoverable; a phantom generation sends the next investigation somewhere real evidence does not.
+ */
+function isOpeningAsk(message: unknown): boolean {
+    if (typeof message !== "object" || message === null) return false;
+    const { type, attempt } = message as { type?: unknown; attempt?: unknown };
+    return type === "ready" && attempt === 1;
+}
+
+/**
  * Numbers each wrapped webview so the two legs of one handshake can be attributed to the same
  * boundary object -- or proven to belong to different ones.
  *
@@ -105,16 +124,26 @@ export function resetWebviewWrapperNumberingForTests(): void {
  * remains is whether it was posted to the SAME webview that asked -- and `contextId` alone cannot
  * say, because both legs of both views print `commit-panel`. `instance` is that missing field:
  * differing numbers across a matched in/out pair convict the record-versus-sender split in
- * `CommitPanelViewProvider.postToWebview`, and identical numbers acquit it and leave VS Code
- * dropping a post it acknowledged.
+ * `CommitPanelViewProvider.postToWebview`.
+ *
+ * Identical numbers acquit that split -- and they used to be read as leaving "VS Code dropped a
+ * post it acknowledged" as the sole survivor. They never did. `instance` counts WRAPS, one per
+ * `resolveWebviewView`, and VS Code rebuilds a hidden view's document without re-running it; the
+ * numbering comment above says exactly this, and the conclusion drawn from it did not. So a host
+ * answering a document generation that no longer exists printed byte-identically to a host
+ * answering the live one, and the 2026-08-25 runs (PR #232, 32881969364 and 32883412896) could not
+ * separate them. `generation` is the field that does: it advances on each `attempt: 1` behind one
+ * wrapper (see {@link isOpeningAsk}), so `#1.1 out` beside `#1.2 in` is an answer posted into a
+ * dead document, and a matched pair convicts VS Code's own delivery instead.
  *
  * Message TYPE only, never a payload: a captured message can carry real repository data, and this
- * line ends up in a CI artifact. The instance number is an in-process counter and names nothing
- * about the workspace, so it is safe to print under the same rule.
+ * line ends up in a CI artifact. Both numbers are in-process counters and name nothing about the
+ * workspace, so they are safe to print under the same rule.
  */
 function traceHandshake(
     contextId: WebviewContextId,
     instance: number,
+    generation: number,
     direction: "in" | "out",
     message: unknown,
 ): void {
@@ -123,7 +152,9 @@ function traceHandshake(
             ? (message as { type?: unknown }).type
             : undefined;
     if (typeof type !== "string" || !HANDSHAKE_TRACED_TYPES.has(type)) return;
-    console.error(`${HANDSHAKE_TRACE_PREFIX} ${contextId}#${instance} ${direction} ${type}`);
+    console.error(
+        `${HANDSHAKE_TRACE_PREFIX} ${contextId}#${instance}.${generation} ${direction} ${type}`,
+    );
 }
 
 /**
@@ -169,6 +200,11 @@ export function wrapWebviewForCapture(
     // Allocated per wrap rather than per message, so every line this wrapper ever emits carries the
     // same number and a pair that disagrees is a genuinely different boundary object.
     const instance = ++webviewWrapperCount;
+    // How many documents have announced themselves behind this one wrapper. Read through
+    // `documentGeneration` rather than directly: a post traced before any `ready` belongs to the
+    // first document, not to a zeroth one that never existed.
+    let announcedDocuments = 0;
+    const documentGeneration = (): number => Math.max(announcedDocuments, 1);
     return {
         get options() {
             return webview.options;
@@ -195,7 +231,10 @@ export function wrapWebviewForCapture(
         ): vscode.Disposable =>
             webview.onDidReceiveMessage(
                 (message: unknown) => {
-                    traceHandshake(contextId, instance, "in", message);
+                    // Counted before the line is emitted, so the reload's own `ready` prints under
+                    // the generation it opens rather than under the one it replaced.
+                    if (isOpeningAsk(message)) announcedDocuments += 1;
+                    traceHandshake(contextId, instance, documentGeneration(), "in", message);
                     return listener.call(thisArgs, message);
                 },
                 undefined,
@@ -204,7 +243,7 @@ export function wrapWebviewForCapture(
         asWebviewUri: (localResource: vscode.Uri) => webview.asWebviewUri(localResource),
         postMessage: (message: unknown): Thenable<boolean> => {
             sink.record(contextId, message);
-            traceHandshake(contextId, instance, "out", message);
+            traceHandshake(contextId, instance, documentGeneration(), "out", message);
             return webview.postMessage(message);
         },
     };

--- a/src/e2e/webviewCapture.ts
+++ b/src/e2e/webviewCapture.ts
@@ -205,6 +205,25 @@ export function wrapWebviewForCapture(
     // first document, not to a zeroth one that never existed.
     let announcedDocuments = 0;
     const documentGeneration = (): number => Math.max(announcedDocuments, 1);
+    // Subscribed ONCE here, not inside `onDidReceiveMessage` below. That method is a
+    // per-SUBSCRIPTION wrapper, so a tap placed inside it runs once per registered listener rather
+    // than once per message -- and `vscode.Webview` fires every listener. Two subscriptions on one
+    // webview therefore counted a single opening `ready` twice and advanced the generation twice,
+    // which is the one failure direction this field must not have: it exists to convict a stale
+    // document generation, and an overcount convicts a reload that never happened.
+    //
+    // Registered before any caller can subscribe, so the count and the line still land ahead of the
+    // handler that acts on the message. Never disposed, deliberately: the tap must outlive any
+    // individual subscription, since a provider that re-resolves disposes its own listener and
+    // registers another, and a tap tied to one of those would stop tracing when it went. Nothing
+    // here allocates unless `isE2eControlChannelActive()` already gated this wrapper into
+    // existence.
+    webview.onDidReceiveMessage((message: unknown) => {
+        // Counted before the line is emitted, so the reload's own `ready` prints under the
+        // generation it opens rather than under the one it replaced.
+        if (isOpeningAsk(message)) announcedDocuments += 1;
+        traceHandshake(contextId, instance, documentGeneration(), "in", message);
+    });
     return {
         get options() {
             return webview.options;
@@ -221,25 +240,16 @@ export function wrapWebviewForCapture(
         get cspSource() {
             return webview.cspSource;
         },
-        // Wrapped rather than merely bound, so the INBOUND leg is observable too. The listener is
-        // invoked unchanged and its return value passed straight back: this must stay a tap on the
-        // wire, never a filter on it.
+        // Forwarded untouched. The INBOUND leg is observed by the single tap installed above
+        // instead of here, so this stays a plain pass-through: a subscription must reach the real
+        // webview with its own `thisArgs` and `disposables` intact, and its return value must come
+        // straight back. A tap on the wire, never a filter on it -- and never a per-subscription
+        // multiplier on what the wire is counted to have carried.
         onDidReceiveMessage: (
             listener: (message: unknown) => unknown,
             thisArgs?: unknown,
             disposables?: vscode.Disposable[],
-        ): vscode.Disposable =>
-            webview.onDidReceiveMessage(
-                (message: unknown) => {
-                    // Counted before the line is emitted, so the reload's own `ready` prints under
-                    // the generation it opens rather than under the one it replaced.
-                    if (isOpeningAsk(message)) announcedDocuments += 1;
-                    traceHandshake(contextId, instance, documentGeneration(), "in", message);
-                    return listener.call(thisArgs, message);
-                },
-                undefined,
-                disposables,
-            ),
+        ): vscode.Disposable => webview.onDidReceiveMessage(listener, thisArgs, disposables),
         asWebviewUri: (localResource: vscode.Uri) => webview.asWebviewUri(localResource),
         postMessage: (message: unknown): Thenable<boolean> => {
             sink.record(contextId, message);

--- a/tests/unit/e2e/webviewCapture.test.ts
+++ b/tests/unit/e2e/webviewCapture.test.ts
@@ -164,7 +164,7 @@ describe("wrapWebviewForCapture: handshake trace", () => {
                 "the listener outlives whoever owned it",
         ).toBe(ownDisposables);
         expect(lines, "the ask must be traced, naming context, instance and direction").toEqual([
-            "[intelligit-e2e] handshake commit-panel#1 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 in ready",
         ]);
     });
 
@@ -189,7 +189,7 @@ describe("wrapWebviewForCapture: handshake trace", () => {
             lines,
             "only the two handshake types may be traced: a line per message would evict the " +
                 "handshake from the dump's bounded console trail",
-        ).toEqual(["[intelligit-e2e] handshake commit-panel#1 out setRepositories"]);
+        ).toEqual(["[intelligit-e2e] handshake commit-panel#1.1 out setRepositories"]);
     });
 
     /**
@@ -229,9 +229,9 @@ describe("wrapWebviewForCapture: handshake trace", () => {
                 "split in postToWebview, and differing ones convict it -- a trace that cannot " +
                 "tell those apart is why four investigations ended without an answer",
         ).toEqual([
-            "[intelligit-e2e] handshake commit-panel#1 in ready",
-            "[intelligit-e2e] handshake commit-panel#2 out setRepositories",
-            "[intelligit-e2e] handshake commit-panel#2 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 in ready",
+            "[intelligit-e2e] handshake commit-panel#2.1 out setRepositories",
+            "[intelligit-e2e] handshake commit-panel#2.1 in ready",
         ]);
     });
 

--- a/tests/unit/e2e/webviewCapture.test.ts
+++ b/tests/unit/e2e/webviewCapture.test.ts
@@ -235,6 +235,61 @@ describe("wrapWebviewForCapture: handshake trace", () => {
         ]);
     });
 
+    /**
+     * The case the instance number cannot reach, and wrongly claimed to have excluded.
+     *
+     * `webviewWrapperCount` increments inside `wrapWebviewForCapture`, which runs once per
+     * `resolveWebviewView`. VS Code reloads a hidden view's document WITHOUT re-running
+     * `resolveWebviewView` -- `CommitPanelViewProvider.handleReadyMessage`'s own comment is built
+     * on that fact -- so a reload keeps one wrapper, and therefore one number. Two documents then
+     * print byte-identically to one, which means "the host answered a document generation that no
+     * longer exists" cannot be told apart from "the host answered the live document".
+     *
+     * That is precisely the pair the 2026-08-25 dumps left open. Identical numbers across a matched
+     * in/out pair do acquit the record-versus-sender split in `postToWebview`, but the surviving
+     * explanation is NOT "VS Code dropped a post it acknowledged" alone: a stale document
+     * generation survives with it, and no field in the line separates them.
+     *
+     * A fresh document always opens its handshake at `attempt: 1`; a re-ask from a document that is
+     * still alive carries a higher number. Counting only a literal `1` is deliberate -- the failure
+     * direction is an undercount (a reload that goes unreported), never a phantom reload, and for a
+     * line whose job is to convict, a false conviction is the more expensive mistake.
+     */
+    it("distinguishes two document generations behind one wrapped view", () => {
+        const fake = makeFakeWebview();
+        const wrapped = wrapWebviewForCapture(
+            fake.webview,
+            "commit-panel",
+            new WebviewCaptureSink(),
+        );
+
+        const lines = tracedLines(() => {
+            wrapped.onDidReceiveMessage(() => undefined);
+            // Document generation one: opening ask, then a re-ask from that same live document.
+            fake.receive({ type: "ready", attempt: 1 });
+            fake.receive({ type: "ready", attempt: 2 });
+            void wrapped.postMessage({ type: "setRepositories", repositories: [] });
+            // VS Code reloads the document behind the same view. `resolveWebviewView` does not run,
+            // so nothing re-wraps -- but the script does re-run, and its counter restarts at one.
+            fake.receive({ type: "ready", attempt: 1 });
+            void wrapped.postMessage({ type: "setRepositories", repositories: [] });
+        });
+
+        expect(
+            lines,
+            "a reload behind a live view must change the traced document generation: the wrapper " +
+                "number cannot, because it counts resolves and a reload is not one -- so without " +
+                "this field an answer posted into a dead document reads exactly like an answer " +
+                "the live document received and ignored",
+        ).toEqual([
+            "[intelligit-e2e] handshake commit-panel#1.1 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 out setRepositories",
+            "[intelligit-e2e] handshake commit-panel#1.2 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.2 out setRepositories",
+        ]);
+    });
+
     it("never puts a payload in the trace", () => {
         const fake = makeFakeWebview();
         const wrapped = wrapWebviewForCapture(

--- a/tests/unit/e2e/webviewCapture.test.ts
+++ b/tests/unit/e2e/webviewCapture.test.ts
@@ -31,9 +31,14 @@ interface FakeWebview {
     delivered: unknown[];
     setPostMessageResult(result: Thenable<boolean>): void;
     /**
-     * Delivers `message` to whatever listener the code under test subscribed, and returns that
-     * listener's own return value. The real host is the only producer of inbound messages, so this
-     * stands in for it -- a wrapper that swallowed the listener, or its result, fails here.
+     * Delivers `message` to EVERY listener the code under test subscribed, in registration order,
+     * and returns the last one's return value. The real host is the only producer of inbound
+     * messages, so this stands in for it -- a wrapper that swallowed the listener, or its result,
+     * fails here.
+     *
+     * Listeners are kept in an array rather than one slot because `vscode.Webview` fires all of
+     * them: a single slot cannot tell one subscription from several, which is exactly the
+     * distinction the per-subscription/per-message split below turns on.
      */
     receive(message: unknown): unknown;
     /** The `disposables` array the subscriber passed, if any. VS Code appends the subscription to
@@ -44,7 +49,7 @@ interface FakeWebview {
 /** A controllable double for `vscode.Webview` that records what it actually received. */
 function makeFakeWebview(): FakeWebview {
     let nextResult: Thenable<boolean> = Promise.resolve(true);
-    let listener: ((message: unknown) => unknown) | undefined;
+    let listeners: Array<(message: unknown) => unknown> = [];
     let disposablesPassed: vscode.Disposable[] | undefined;
     const delivered: unknown[] = [];
     const webview = {
@@ -56,9 +61,13 @@ function makeFakeWebview(): FakeWebview {
             _thisArgs?: unknown,
             disposables?: vscode.Disposable[],
         ) => {
-            listener = handler;
+            listeners.push(handler);
             disposablesPassed = disposables;
-            return { dispose: () => undefined };
+            return {
+                dispose: () => {
+                    listeners = listeners.filter((entry) => entry !== handler);
+                },
+            };
         },
         asWebviewUri: (uri: vscode.Uri) => uri,
         postMessage: (message: unknown) => {
@@ -74,12 +83,14 @@ function makeFakeWebview(): FakeWebview {
             nextResult = result;
         },
         receive(message: unknown): unknown {
-            if (!listener) {
+            if (listeners.length === 0) {
                 throw new Error(
                     "makeFakeWebview.receive: nothing has subscribed to onDidReceiveMessage yet.",
                 );
             }
-            return listener(message);
+            let result: unknown;
+            for (const entry of [...listeners]) result = entry(message);
+            return result;
         },
         subscribedDisposables: () => disposablesPassed,
     };
@@ -283,6 +294,55 @@ describe("wrapWebviewForCapture: handshake trace", () => {
                 "the live document received and ignored",
         ).toEqual([
             "[intelligit-e2e] handshake commit-panel#1.1 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.1 out setRepositories",
+            "[intelligit-e2e] handshake commit-panel#1.2 in ready",
+            "[intelligit-e2e] handshake commit-panel#1.2 out setRepositories",
+        ]);
+    });
+
+    /**
+     * One message is one event, however many listeners are subscribed to it.
+     *
+     * `onDidReceiveMessage` is a per-SUBSCRIPTION wrapper, so a tap installed inside it runs once
+     * per registered listener rather than once per message. Two subscriptions on one webview then
+     * counted a single opening `ready` twice and printed its line twice -- a generation that
+     * advances by two per reload, and a phantom generation for a reload that never happened.
+     *
+     * Two live subscriptions on one webview is not hypothetical: `SwitchableWebviewViewProvider`
+     * re-resolves a retained view against a new provider, and a provider that discards the
+     * `Disposable` its own `onDidReceiveMessage` returned leaves the previous one attached.
+     *
+     * The direction matters. This field exists to CONVICT a stale document generation, so an
+     * overcount is the expensive failure: it accuses a reload that did not occur, and every
+     * conclusion drawn from the accusation is wrong. An undercount only leaves the next dump as
+     * mute as the last, which is recoverable.
+     */
+    it("counts one inbound message once however many listeners are subscribed", () => {
+        const fake = makeFakeWebview();
+        const wrapped = wrapWebviewForCapture(
+            fake.webview,
+            "commit-panel",
+            new WebviewCaptureSink(),
+        );
+
+        const lines = tracedLines(() => {
+            wrapped.onDidReceiveMessage(() => undefined);
+            wrapped.onDidReceiveMessage(() => undefined);
+            fake.receive({ type: "ready", attempt: 1 });
+            void wrapped.postMessage({ type: "setRepositories", repositories: [] });
+            // A second document opens. With a per-subscription tap the generation would already be
+            // at three here, having counted the first reload twice.
+            fake.receive({ type: "ready", attempt: 1 });
+            void wrapped.postMessage({ type: "setRepositories", repositories: [] });
+        });
+
+        expect(
+            lines,
+            "two subscriptions on one webview traced a single message twice and advanced the " +
+                "document generation twice, so the field that exists to convict a stale " +
+                "generation would convict a reload that never happened",
+        ).toEqual([
             "[intelligit-e2e] handshake commit-panel#1.1 in ready",
             "[intelligit-e2e] handshake commit-panel#1.1 out setRepositories",
             "[intelligit-e2e] handshake commit-panel#1.2 in ready",


### PR DESCRIPTION
## Summary

The intermittent blank Changes panel has survived four investigations. This PR does not fix it. It fixes the reason those investigations kept ending without an answer.

`traceHandshake` in `src/e2e/webviewCapture.ts` prints a wrapper instance number, and its doc comment concluded that identical numbers across a matched in/out pair leave *"VS Code dropping a post it acknowledged"* as the surviving explanation. That conclusion is false, and the same comment says so three paragraphs earlier:

- `webviewWrapperCount` increments inside `wrapWebviewForCapture`, which runs **once per `resolveWebviewView`**.
- VS Code rebuilds a hidden view's document **without** re-running `resolveWebviewView` — `CommitPanelViewProvider.handleReadyMessage`'s own comment is built on that fact.
- So every document generation behind one view shares one number, and "the host answered a dead generation" prints byte-identically to "the host answered the live one".

Two hypotheses survived the whole time. The comment named one, and four investigations searched the wrong half of the space.

`traceHandshake` now prints `context#instance.generation`. The generation advances on each inbound `ready` carrying `attempt: 1`, which the webview's retry sends once per **document**; a re-ask from a live document carries a higher number and leaves it alone. `#1.1 out` beside `#1.2 in` is now an answer posted into a dead document; a matched pair convicts VS Code's own delivery instead.

Only a literal `1` counts, deliberately opposite to `isHydrationReAsk`'s reading of the same untrusted field. An undercount leaves the next dump as mute as the last, which is recoverable. A phantom generation would convict a reload that never happened, and this field exists to convict.

## What was ruled out on the way

- **`retainContextWhenHidden`** — set on all three commit-panel registrations, guarded by a discovery-based test (`tests/unit/activation/commitPanelRegistration.test.ts`).
- **`postToWebview`'s `!view` early return, `adoptLiveSender`, the record-versus-sender split** — with a single resolve the post target is provably the sender.
- **The webview client** — the `message` listener attaches before the first `ready`, and `recordHostMessage` runs before the switch, so `received:0` means no `message` event reached the document at all.

## One correction to the collected evidence

`CONSOLE_TRAIL_LIMIT = 25` (`tests/e2e/pageObjects/intelliGitView.ts:37`), but the reported 28 `in ready` + 22 `out setRepositories` is 50 lines. Those counts cannot have come from the bounded timeout dump, so they are totals read from the job log. If so, 28 inbound asks against a document reporting `asks:18` means at least 10 asks came from a document that no longer exists — direct support for the reload hypothesis, which the new field will label explicitly on the next failure.

## Found but not fixed

`SwitchableWebviewViewProvider.setProvider` re-resolves the retained view, and providers discard their subscription disposables, so the no-repository → repository handover leaves **2 live message listeners** on the commit panel's webview plus a leaked `onDidDispose`. Benign today — the leaked onboarding listener only handles `cloneRepository` / `openFolder` / `initializeRepository`, which the commit-panel document never sends.

No existing test can see it: `createInspectableCommitPanelWebviewView` stores one handler per event (`messageHandler = listener`) and returns an inert disposable, so re-registration is invisible to every test that uses it. Tracked separately rather than widened into this PR.

## ⚠️ Merging this publishes

`publish.yml` triggers on push to `main` and releases the current `package.json` version. Merging this bumps the marketplace to **v0.28.1**. The changelog entry states plainly that the blank panel is not fixed.

## Test plan

- [x] `bun vitest run tests/unit/e2e/webviewCapture.test.ts` before the fix → 1 failed, all five lines read `commit-panel#1`, red for the stated reason (committed as `b9d86519`, ahead of the fix)
- [x] Mutation A — `isOpeningAsk` accepts any numbered `ready` (too loose) → red on `distinguishes two document generations behind one wrapped view`, 16 siblings green
- [x] Mutation B — generation never advances (too strict) → red on the same named test, 16 siblings green
- [x] Target file restored byte-identical after both mutations
- [x] `bun run test` → 329 files, 4375 tests, all passed
- [x] `bun run typecheck` → clean across ext / webview / tests
- [x] All nine pre-commit gates on each commit (format:check, lint:strict, deps:check:strict, architecture:check, l10n:validate, l10n:audit, typecheck, build, vsce package)
- [ ] `e2e-full` on this branch — the trail's new shape is only observable there, and no consumer parses it (the flow suite folds these lines into its timeout message verbatim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when webview content reloads or reconnects.
  * Improved tracking of webview startup and recovery messages.
  * Improved handling of repeated subscriptions to prevent duplicate message traces.

* **Release**
  * Updated the extension to version 0.28.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->