### PR TITLE
fix(views): retire webview subscriptions when a view is re-resolved

### DIFF
--- a/src/activation/common.ts
+++ b/src/activation/common.ts
@@ -40,6 +40,32 @@ export function setViewContext(key: string, value: boolean): Thenable<unknown> {
 }
 
 /**
+ * A view provider that can retire the listeners it installed on a view it no longer renders.
+ *
+ * `vscode.WebviewViewProvider` has no disposal contract, so the handover below tests for this
+ * member structurally. A provider that does not implement it simply keeps whatever it registered --
+ * which is the pre-existing behavior, not a new failure mode.
+ */
+interface RetiresViewSubscriptions {
+    disposeViewSubscriptions(): void;
+}
+
+/**
+ * Reports whether a provider can retire its per-view subscriptions.
+ *
+ * The E2E capture seam wraps providers in a forwarding `Proxy` that binds methods to the real
+ * target, so this check and the call it guards both survive a captured provider.
+ */
+function retiresViewSubscriptions(
+    provider: vscode.WebviewViewProvider,
+): provider is vscode.WebviewViewProvider & RetiresViewSubscriptions {
+    return (
+        typeof (provider as Partial<RetiresViewSubscriptions>).disposeViewSubscriptions ===
+        "function"
+    );
+}
+
+/**
  * Keeps a registered webview view ID stable while swapping the provider that renders it.
  *
  * No-repository mode uses this wrapper for onboarding views that can later become
@@ -80,6 +106,13 @@ export class SwitchableWebviewViewProvider implements vscode.WebviewViewProvider
      * subscription; this only changes which provider receives future resolves.
      */
     setProvider(provider: vscode.WebviewViewProvider): void {
+        // Before the swap, not after: the outgoing provider's listeners sit on the SAME webview the
+        // incoming one is about to re-resolve. Each provider only disposes its own subscriptions on
+        // re-resolve, so nothing else in this handover can retire the provider being replaced --
+        // leaving it live to act on messages from a document another provider now renders.
+        if (this.resolved && retiresViewSubscriptions(this.currentProvider)) {
+            this.currentProvider.disposeViewSubscriptions();
+        }
         this.currentProvider = provider;
         if (!this.resolved) return;
         void provider.resolveWebviewView(

--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -189,6 +189,15 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     private activeRepositoryRoot: string | null = null;
     private visibleRefreshCount = 0;
     private themeChangeDisposables: vscode.Disposable[] = [];
+    /**
+     * Subscriptions installed by the most recent {@link resolveWebviewView}.
+     *
+     * VS Code can resolve the same `WebviewView` more than once, and
+     * `SwitchableWebviewViewProvider.setProvider` re-resolves a retained view against a different
+     * provider, so a discarded `Disposable` leaves the previous resolve's listener live on a
+     * document this provider no longer renders.
+     */
+    private readonly viewDisposables: vscode.Disposable[] = [];
     private readonly iconTheme: IconThemeService;
     private readonly PAGE_SIZE = 500;
     private branches: Branch[] = [];
@@ -1127,6 +1136,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         _token: vscode.CancellationToken,
     ): void {
         this.disposeThemeChangeDisposables();
+        this.disposeViewSubscriptions();
         this.iconTheme.dispose();
         this.view = webviewView;
         this.lastPostedPayload = undefined;
@@ -1137,42 +1147,48 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.iconTheme.attachWebview(webviewView.webview);
         this.registerThemeChangeListeners();
         const thisView = webviewView;
-        webviewView.onDidDispose(() => {
-            if (this.view === thisView) {
-                this.view = undefined;
-                this.iconTheme.dispose();
-                this.disposeThemeChangeDisposables();
-            }
-        });
-        webviewView.webview.onDidReceiveMessage(async (msg) => {
-            const message: unknown = msg;
-            try {
-                // Inside the try, not before it. Adoption reads state owned by VS Code rather than
-                // by this provider, so it can raise; raising ahead of the try rejected this async
-                // listener before `handleMessage` ran, which posted nothing, showed nothing and
-                // logged nothing. Every retry then died at the same line, so a panel waiting on
-                // hydration stayed blank while looking, from every angle, like a host that had
-                // simply gone quiet.
-                this.adoptLiveSender(thisView);
-                await this.handleMessage(message);
-            } catch (err) {
-                const errorMessage = getErrorMessage(err);
-                vscode.window.showErrorMessage(errorMessage);
-                this.postToWebview({
-                    type: "error",
-                    ...this.repositoryScopeForError(message),
-                    message: errorMessage,
-                });
-            }
-        });
+        this.viewDisposables.push(
+            webviewView.onDidDispose(() => {
+                if (this.view === thisView) {
+                    this.view = undefined;
+                    this.iconTheme.dispose();
+                    this.disposeThemeChangeDisposables();
+                }
+            }),
+        );
+        this.viewDisposables.push(
+            webviewView.webview.onDidReceiveMessage(async (msg) => {
+                const message: unknown = msg;
+                try {
+                    // Inside the try, not before it. Adoption reads state owned by VS Code rather
+                    // than by this provider, so it can raise; raising ahead of the try rejected
+                    // this async listener before `handleMessage` ran, which posted nothing, showed
+                    // nothing and logged nothing. Every retry then died at the same line, so a
+                    // panel waiting on hydration stayed blank while looking, from every angle, like
+                    // a host that had simply gone quiet.
+                    this.adoptLiveSender(thisView);
+                    await this.handleMessage(message);
+                } catch (err) {
+                    const errorMessage = getErrorMessage(err);
+                    vscode.window.showErrorMessage(errorMessage);
+                    this.postToWebview({
+                        type: "error",
+                        ...this.repositoryScopeForError(message),
+                        message: errorMessage,
+                    });
+                }
+            }),
+        );
         webviewView.webview.html = this.getHtml(webviewView.webview);
-        webviewView.onDidChangeVisibility(() => {
-            if (!webviewView.visible) return;
-            const runtime = this.getActiveRuntime();
-            if (!runtime) return;
-            void this.postWorkingTreeSnapshot(runtime).catch(() => {});
-            this.refreshAllRepositoriesWithErrorHandling(true);
-        });
+        this.viewDisposables.push(
+            webviewView.onDidChangeVisibility(() => {
+                if (!webviewView.visible) return;
+                const runtime = this.getActiveRuntime();
+                if (!runtime) return;
+                void this.postWorkingTreeSnapshot(runtime).catch(() => {});
+                this.refreshAllRepositoriesWithErrorHandling(true);
+            }),
+        );
         // Deliberately NOT hydrating the repository list here. `handleReadyMessage` calls
         // `postRepositoryListHydration()` unconditionally, and `ready` always follows a resolve --
         // it is sent by the very webview this method creates. Hydrating here posted a byte-identical
@@ -2241,6 +2257,7 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.disposeAllRuntimeWatchers();
         this.iconTheme.dispose();
         this.disposeThemeChangeDisposables();
+        this.disposeViewSubscriptions();
         this._onDidChangeFileCount.dispose();
         this._onDidChangeWorkingTree.dispose();
         this._onCommitSelected.dispose();
@@ -2360,6 +2377,17 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
     }
     private disposeThemeChangeDisposables(): void {
         disposeAll(this.themeChangeDisposables);
+    }
+
+    /**
+     * Retires every listener the last {@link resolveWebviewView} installed on its view.
+     *
+     * Called at the top of each resolve, and by `SwitchableWebviewViewProvider.setProvider` when
+     * another provider takes over the view: a retired provider must stop acting on messages from a
+     * document it no longer owns.
+     */
+    disposeViewSubscriptions(): void {
+        disposeAll(this.viewDisposables);
     }
 
     /**

--- a/src/views/OnboardingViewProvider.ts
+++ b/src/views/OnboardingViewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { randomBytes } from "crypto";
 import { escapeHtmlAttr, escapeHtmlText } from "./webviewHtml";
+import { disposeAll } from "./shared/themeListeners";
 
 /**
  * Startup context that determines which onboarding call-to-action commands are exposed.
@@ -18,6 +19,16 @@ export class OnboardingViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = "intelligit.onboarding";
 
     private view?: vscode.WebviewView;
+
+    /**
+     * Subscriptions installed by the most recent {@link resolveWebviewView}.
+     *
+     * VS Code can resolve the same `WebviewView` more than once, and
+     * `SwitchableWebviewViewProvider.setProvider` re-resolves a retained view against a different
+     * provider, so a discarded `Disposable` leaves the previous resolve's listener live on a
+     * document this provider no longer renders.
+     */
+    private readonly viewDisposables: vscode.Disposable[] = [];
 
     /**
      * Configures onboarding content for the current activation state.
@@ -44,32 +55,48 @@ export class OnboardingViewProvider implements vscode.WebviewViewProvider {
         _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken,
     ): void {
+        this.disposeViewSubscriptions();
         this.view = webviewView;
         webviewView.webview.options = {
             enableScripts: true,
             localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, "media")],
         };
 
-        webviewView.onDidDispose(() => {
-            this.view = undefined;
-        });
+        this.viewDisposables.push(
+            webviewView.onDidDispose(() => {
+                this.view = undefined;
+            }),
+        );
 
-        webviewView.webview.onDidReceiveMessage((msg) => {
-            const type = this.getMessageType(msg);
-            switch (type) {
-                case "cloneRepository":
-                    void vscode.commands.executeCommand("intelligit.cloneRepository");
-                    break;
-                case "openFolder":
-                    void vscode.commands.executeCommand("intelligit.openFolder");
-                    break;
-                case "initializeRepository":
-                    void vscode.commands.executeCommand("intelligit.initializeRepository");
-                    break;
-            }
-        });
+        this.viewDisposables.push(
+            webviewView.webview.onDidReceiveMessage((msg) => {
+                const type = this.getMessageType(msg);
+                switch (type) {
+                    case "cloneRepository":
+                        void vscode.commands.executeCommand("intelligit.cloneRepository");
+                        break;
+                    case "openFolder":
+                        void vscode.commands.executeCommand("intelligit.openFolder");
+                        break;
+                    case "initializeRepository":
+                        void vscode.commands.executeCommand("intelligit.initializeRepository");
+                        break;
+                }
+            }),
+        );
 
         webviewView.webview.html = this.getHtml(webviewView.webview);
+    }
+
+    /**
+     * Retires every listener the last {@link resolveWebviewView} installed on its view.
+     *
+     * Called at the top of each resolve, and by `SwitchableWebviewViewProvider.setProvider` when
+     * another provider takes over the view: a retired provider must stop acting on messages from a
+     * document it no longer owns.
+     */
+    disposeViewSubscriptions(): void {
+        disposeAll(this.viewDisposables);
     }
 
     /**

--- a/tests/unit/views/webviewResolveSubscriptions.test.ts
+++ b/tests/unit/views/webviewResolveSubscriptions.test.ts
@@ -97,10 +97,12 @@ function createMultiListenerWebviewView(): {
     readonly messages: ListenerRegistry;
     readonly disposals: ListenerRegistry;
     readonly visibilityChanges: ListenerRegistry;
+    readonly posted: unknown[];
 } {
     const messages = new ListenerRegistry();
     const disposals = new ListenerRegistry();
     const visibilityChanges = new ListenerRegistry();
+    const posted: unknown[] = [];
 
     const webview = {
         options: {} as vscode.WebviewOptions,
@@ -108,7 +110,10 @@ function createMultiListenerWebviewView(): {
         cspSource: "vscode-webview://webview-resolve-subscriptions-test",
         asWebviewUri: (uri: vscode.Uri) => uri,
         onDidReceiveMessage: messages.register,
-        postMessage: () => Promise.resolve(true),
+        postMessage: (message: unknown) => {
+            posted.push(message);
+            return Promise.resolve(true);
+        },
     };
 
     const webviewView = {
@@ -120,7 +125,12 @@ function createMultiListenerWebviewView(): {
         onDidChangeVisibility: visibilityChanges.register,
     } as unknown as vscode.WebviewView;
 
-    return { webviewView, messages, disposals, visibilityChanges };
+    return { webviewView, messages, disposals, visibilityChanges, posted };
+}
+
+/** Drains synchronously-queued microtasks -- the commit panel's message listener is `async`. */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
 }
 
 function createOnboardingProvider(): OnboardingViewProvider {
@@ -184,12 +194,26 @@ describe("webview provider resolve subscriptions", () => {
         ).toBe(1);
     });
 
-    it("leaves no onboarding listener behind after the no-repository -> repository handover", () => {
+    it("leaves no onboarding listener behind after the no-repository -> repository handover", async () => {
         const view = createMultiListenerWebviewView();
         const switchable = new SwitchableWebviewViewProvider(createOnboardingProvider());
         switchable.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
 
         switchable.setProvider(createCommitPanelProvider());
+
+        // Asserted BEFORE the leak checks below, deliberately. This fix has two failure directions
+        // -- retiring too little (the leak) and retiring too much (a deaf panel) -- and a listener
+        // COUNT reads zero under both, so whichever assertion runs first is the only one a
+        // mutation can name. This one owns the over-retirement direction; the count below owns the
+        // leak. `ready` is the incoming provider's own handshake, and onboarding ignores it.
+        view.messages.fire({ type: "ready" });
+        await flushMicrotasks();
+
+        expect(
+            view.posted.length,
+            "the handover left NO live commit-panel listener: a `ready` message reached nothing, " +
+                "so the incoming provider never answered its own document",
+        ).toBeGreaterThan(0);
 
         expect(
             view.messages.size,

--- a/tests/unit/views/webviewResolveSubscriptions.test.ts
+++ b/tests/unit/views/webviewResolveSubscriptions.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Subscription-lifetime test for the two webview providers that VS Code can resolve more than once
+ * against the SAME `WebviewView` instance.
+ *
+ * `SwitchableWebviewViewProvider` (`src/activation/common.ts:82`) keeps a registered view ID stable
+ * while swapping the provider behind it: `setProvider` re-resolves the retained view against the
+ * new provider. So the no-repository -> repository handover calls `resolveWebviewView` twice on one
+ * view -- once for `OnboardingViewProvider`, once for `CommitPanelViewProvider` -- and every
+ * subscription the first resolve installed is still live on that webview unless the provider
+ * retired it. `webview.onDidReceiveMessage` returns a `Disposable` for exactly this reason.
+ *
+ * Why this file exists rather than an assertion added to `CommitPanelViewProvider.test.ts`: that
+ * file's `createInspectableCommitPanelWebviewView` (`:113`) registers events as
+ * `messageHandler = listener` / `disposeHandler = listener` -- assignment, not append -- and returns
+ * an inert disposable. A double that keeps one handler per event and ignores disposal cannot tell a
+ * provider that re-registers from one that registers once: both leave exactly one reachable
+ * handler. The double below keeps listener ARRAYS and honours the returned disposable, which is the
+ * only shape that can observe registration lifetime at all. The existing double is not weakened --
+ * it is unsuitable for this question, not wrong for its own.
+ *
+ * The counts are the defect, but the handover test also states the consequence directly: a retired
+ * onboarding provider must not act on messages arriving from the commit panel's document. Today it
+ * does -- `OnboardingViewProvider`'s listener still dispatches `cloneRepository` / `openFolder` /
+ * `initializeRepository` from a document that has been re-rendered by a different provider.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+/** Hoisted above the `vi.mock` factory below -- same convention as `CommitPanelViewProvider.test.ts`. */
+const { executedCommands } = vi.hoisted(() => ({ executedCommands: [] as string[] }));
+
+// `createCommitInfoVscodeDouble` is a throwing double: `vscode.commands` is deliberately absent
+// because no recording scenario reaches it. `OnboardingViewProvider`'s message listener is exactly
+// such a path, so this layer records the dispatch instead of throwing on it -- the leaked listener
+// firing has to be observable as data, not as an exception thrown from inside an event callback.
+vi.mock("vscode", () => {
+    const base = createCommitInfoVscodeDouble();
+    return new Proxy(base, {
+        get(target, property) {
+            if (property === "commands") {
+                return {
+                    executeCommand: (command: string): Promise<undefined> => {
+                        executedCommands.push(command);
+                        return Promise.resolve(undefined);
+                    },
+                };
+            }
+            return Reflect.get(target, property) as unknown;
+        },
+    });
+});
+
+import type * as vscode from "vscode";
+import { createFakeExtensionUri } from "../../visual/recorder/commitInfoVscodeDouble";
+import { SwitchableWebviewViewProvider } from "../../../src/activation/common";
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+import { CommitPanelViewProvider } from "../../../src/views/CommitPanelViewProvider";
+import { OnboardingViewProvider } from "../../../src/views/OnboardingViewProvider";
+
+/** Resolve context/token stand-ins neither `resolveWebviewView` reads. */
+const INERT_CONTEXT = {} as vscode.WebviewViewResolveContext;
+const INERT_TOKEN = {} as vscode.CancellationToken;
+
+/**
+ * A VS Code event whose registrations accumulate and whose `Disposable` actually removes one.
+ * `size` is the live listener count -- what a leak is made of, and what a single-slot double erases.
+ */
+class ListenerRegistry {
+    private readonly listeners: Array<(arg: unknown) => unknown> = [];
+
+    get size(): number {
+        return this.listeners.length;
+    }
+
+    readonly register = (listener: (arg: never) => unknown): vscode.Disposable => {
+        const entry = listener as (arg: unknown) => unknown;
+        this.listeners.push(entry);
+        return {
+            dispose: (): void => {
+                const index = this.listeners.indexOf(entry);
+                if (index !== -1) this.listeners.splice(index, 1);
+            },
+        };
+    };
+
+    /** Fires every live listener, mirroring a real host: one event reaches all registrations. */
+    fire(arg: unknown): void {
+        for (const listener of [...this.listeners]) void listener(arg);
+    }
+}
+
+function createMultiListenerWebviewView(): {
+    readonly webviewView: vscode.WebviewView;
+    readonly messages: ListenerRegistry;
+    readonly disposals: ListenerRegistry;
+    readonly visibilityChanges: ListenerRegistry;
+} {
+    const messages = new ListenerRegistry();
+    const disposals = new ListenerRegistry();
+    const visibilityChanges = new ListenerRegistry();
+
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        html: "",
+        cspSource: "vscode-webview://webview-resolve-subscriptions-test",
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: messages.register,
+        postMessage: () => Promise.resolve(true),
+    };
+
+    const webviewView = {
+        webview,
+        visible: true,
+        description: undefined,
+        badge: undefined,
+        onDidDispose: disposals.register,
+        onDidChangeVisibility: visibilityChanges.register,
+    } as unknown as vscode.WebviewView;
+
+    return { webviewView, messages, disposals, visibilityChanges };
+}
+
+function createOnboardingProvider(): OnboardingViewProvider {
+    return new OnboardingViewProvider(createFakeExtensionUri(), "no-git-repo", "IntelliGit");
+}
+
+/** No `repoRootUri`: `resolveWebviewView` never reads one, and omitting it keeps the constructor
+ * off `setRepositoriesInternal` so this file stays a pure subscription-lifetime test. */
+function createCommitPanelProvider(): CommitPanelViewProvider {
+    return new CommitPanelViewProvider(
+        createFakeExtensionUri(),
+        new GitOps(new GitExecutor("/fake/repo")),
+    );
+}
+
+beforeEach(() => {
+    executedCommands.length = 0;
+});
+
+describe("webview provider resolve subscriptions", () => {
+    it("retires the previous resolve's subscriptions when onboarding re-resolves one view", () => {
+        const provider = createOnboardingProvider();
+        const view = createMultiListenerWebviewView();
+
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        expect(
+            view.messages.size,
+            "OnboardingViewProvider.resolveWebviewView discarded the Disposable returned by " +
+                "webview.onDidReceiveMessage, so the first resolve's listener is still live",
+        ).toBe(1);
+        expect(
+            view.disposals.size,
+            "OnboardingViewProvider.resolveWebviewView discarded the Disposable returned by " +
+                "webviewView.onDidDispose, so the first resolve's listener is still live",
+        ).toBe(1);
+    });
+
+    it("retires the previous resolve's subscriptions when the commit panel re-resolves one view", () => {
+        const provider = createCommitPanelProvider();
+        const view = createMultiListenerWebviewView();
+
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        expect(
+            view.messages.size,
+            "CommitPanelViewProvider.resolveWebviewView discarded the Disposable returned by " +
+                "webview.onDidReceiveMessage, so the first resolve's listener is still live",
+        ).toBe(1);
+        expect(
+            view.disposals.size,
+            "CommitPanelViewProvider.resolveWebviewView discarded the Disposable returned by " +
+                "webviewView.onDidDispose, so the first resolve's listener is still live",
+        ).toBe(1);
+        expect(
+            view.visibilityChanges.size,
+            "CommitPanelViewProvider.resolveWebviewView discarded the Disposable returned by " +
+                "webviewView.onDidChangeVisibility, so the first resolve's listener is still live",
+        ).toBe(1);
+    });
+
+    it("leaves no onboarding listener behind after the no-repository -> repository handover", () => {
+        const view = createMultiListenerWebviewView();
+        const switchable = new SwitchableWebviewViewProvider(createOnboardingProvider());
+        switchable.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+
+        switchable.setProvider(createCommitPanelProvider());
+
+        expect(
+            view.messages.size,
+            "SwitchableWebviewViewProvider.setProvider re-resolved the retained view, and the " +
+                "retired OnboardingViewProvider's message listener survived the handover",
+        ).toBe(1);
+
+        view.messages.fire({ type: "cloneRepository" });
+
+        expect(
+            executedCommands,
+            "a retired OnboardingViewProvider acted on a message arriving from the commit " +
+                "panel's document",
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

`SwitchableWebviewViewProvider.setProvider` re-resolves a retained `WebviewView` against a new provider, so the no-repository → repository handover calls `resolveWebviewView` twice on one view. Both view providers discarded the `Disposable` that `onDidReceiveMessage` returns, so the first resolve's listeners stayed attached to a webview a different provider now renders.

Measured with a faithful multi-listener double: **2 live message listeners** on the commit panel after the handover, plus a leaked `onDidDispose`.

Harmless today. The leaked onboarding listener only handles `cloneRepository` / `openFolder` / `initializeRepository`, and the commit-panel document never sends any of them. This is a latent defect, not a user-facing one.

## Two halves, because one is not enough

**Each provider keeps its own subscriptions and retires them at the top of `resolveWebviewView`** — the shape `CommitPanelViewProvider` already used for its theme disposables and icon theme. That closes VS Code re-resolving the same view against the same provider.

**It does not close the handover.** Each provider retires only *its own* array, and after the swap the outgoing provider never resolves again, so nothing would ever retire it. `setProvider` now retires the outgoing provider before the swap, tested structurally because `vscode.WebviewViewProvider` carries no disposal contract. The E2E capture seam's forwarding `Proxy` binds methods to the real target, so both the check and the call survive a captured provider.

## Three sites, not two

`CommitPanelViewProvider` discarded **three** disposables, not the two originally identified — `onDidChangeVisibility` (`:1169`) is the same defect and is fixed with the other two rather than left as a half fix.

## Why no existing test could see it

`createInspectableCommitPanelWebviewView` registers events as `messageHandler = listener` — assignment, not append — and returns an inert disposable. A double holding one handler per event cannot tell a provider that re-registers from one that registers once: both leave exactly one reachable handler. The new test builds a local double with listener **arrays** and working disposables. No existing test was weakened; the shared double is unsuitable for this question, not wrong for its own.

## Assertion order turned out to be load-bearing

This fix has two failure directions — retiring too little (the leak) and retiring too much (a permanently deaf panel) — and a listener **count** reads wrong under both. Because assertions short-circuit, whichever runs first is the only one a mutation can name. The over-retirement mutation reddened only the count, and the behavioural assertion below it never executed: it looked load-bearing and was provably dead. The survivor check now runs ahead of the counts, so each direction owns a distinct named assertion.

## Test plan

- [x] `npx vitest run tests/unit/views/webviewResolveSubscriptions.test.ts` before the fix → 3 failed, each `expected 2 to be 1` on the live listener count (committed as `127fa925`, ahead of the fix)
- [x] Mutation A — onboarding drops its own retirement → red on `retires the previous resolve's subscriptions when onboarding re-resolves one view`; 151 siblings green
- [x] Mutation B — commit panel drops its own retirement → red on `...when the commit panel re-resolves one view`; 151 siblings green
- [x] Mutation C — `setProvider` drops the outgoing-provider retirement → red on `leaves no onboarding listener behind after the no-repository -> repository handover`; 151 siblings green
- [x] Mutation D — retire *after* registering (opposite direction) → red on `the handover left NO live commit-panel listener: a ready message reached nothing`; 150 siblings green
- [x] All three target files restored byte-identical after every mutation
- [x] `bun run test` → 4377 passed (4377), twice consecutively
- [x] `bun run typecheck` → clean across ext / webview / tests
- [x] All nine pre-commit gates on both commits
- [x] `detect_changes(scope: compare, base_ref: main)` → 28 touched symbols, 0 affected execution flows, risk low

## Two things to decide before merging

**No version bump.** `package.json` stays at 0.28.0, so merging this publishes nothing. That is deliberate — bumping here would collide with #233, which takes 0.28.1. The fix is latent with no user-visible effect, so it can ride the next release instead of claiming one of its own.

**Merge #233 first, then rebase.** Both branches are cut from the same `main` commit. They touch no common file today, but #233 owns the next version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
