### PR TITLE
fix(commit-panel): rebind the document when a reloaded one keeps asking

### DIFF
--- a/src/views/CommitPanelViewProvider.ts
+++ b/src/views/CommitPanelViewProvider.ts
@@ -110,6 +110,20 @@ function isHydrationReAsk(attempt: unknown): boolean {
 }
 
 /**
+ * Whether a `ready` message is a document announcing itself rather than re-asking.
+ *
+ * Deliberately not the negation of {@link isHydrationReAsk}, because the two questions fail safe
+ * in OPPOSITE directions. A re-ask that is misread as a first announcement costs one redundant
+ * Git read; a malformed or absent count that is misread as a NEW DOCUMENT would let
+ * {@link CommitPanelViewProvider.handleReadyMessage} reload a panel that was working. So this one
+ * is strictly the literal 1: a producer that predates the field, or sends a string, or sends 0,
+ * counts as no document at all and simply never earns a rebind.
+ */
+function isOpeningAsk(attempt: unknown): boolean {
+    return attempt === 1;
+}
+
+/**
  * Whether a root event can change what an expanded repository row shows.
  *
  * The row watcher this replaced was a `createFileSystemWatcher`, so it only ever saw disk
@@ -216,6 +230,14 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * runtime caches a re-ask is answered from. Never reset: a later mount that re-asks is served
      * from those same caches, so what matters is that SOME attempt filled them, not which one. */
     private startupReadCompleted = false;
+    /** How many documents have announced themselves behind the CURRENT view, counted by opening
+     * asks. VS Code can rebuild a hidden view's document without re-running `resolveWebviewView`,
+     * and a remount of the React shell looks identical from here, so this is the only host-side
+     * signal that the thing on the other end of the channel is not the thing that was resolved. */
+    private documentGeneration = 0;
+    /** Whether this resolve has already spent its single document rebind -- see
+     * {@link rebindDocument} for why the budget cannot be per-generation. */
+    private rebindSpent = false;
     private readonly _onDidChangeFileCount = new vscode.EventEmitter<number>();
     readonly onDidChangeFileCount = this._onDidChangeFileCount.event;
     private readonly _onDidChangeWorkingTree = new vscode.EventEmitter<void>();
@@ -1140,6 +1162,11 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.iconTheme.dispose();
         this.view = webviewView;
         this.lastPostedPayload = undefined;
+        // A resolve is a new view, so its document count starts over and its rebind budget is
+        // refilled. Both are scoped to the view rather than to the provider on purpose: the
+        // failure they guard is one view outliving the document it was resolved with.
+        this.documentGeneration = 0;
+        this.rebindSpent = false;
         webviewView.webview.options = {
             enableScripts: true,
             localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, "dist")],
@@ -1540,6 +1567,18 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
      * stop asking after fifteen tries and leave the panel blank for the rest of the session.
      */
     private async handleReadyMessage(attempt?: unknown): Promise<void> {
+        if (isOpeningAsk(attempt)) this.documentGeneration += 1;
+        // A document that is not the one this view was resolved with, that has been answered, and
+        // that is asking again: its answers are not reaching it, and no number of further answers
+        // down the same channel will. Rebuild the document instead and let it re-announce.
+        //
+        // Nothing else is posted on this path. The rescue tears down the document that would have
+        // received them, and the replacement sends its own opening ask, which is served by the
+        // ordinary hydration below.
+        if (isHydrationReAsk(attempt) && this.documentGeneration > 1 && !this.rebindSpent) {
+            this.rebindDocument();
+            return;
+        }
         // A fresh webview context has received nothing, so any commit-detail post made during
         // this handler must never be suppressed as a duplicate of what the PREVIOUS context was
         // sent. `ready` fires again whenever VS Code tears this view down while it is hidden and
@@ -2188,6 +2227,29 @@ export class CommitPanelViewProvider implements vscode.WebviewViewProvider {
         this.view = sender;
         this.iconTheme.attachWebview(sender.webview);
         this.registerThemeChangeListeners();
+    }
+
+    /**
+     * Rebuilds the view's document so it is bound to the channel this provider posts into.
+     *
+     * Re-setting `html` is the only lever the extension host has here. `postToWebview` already
+     * reaches `this.view.webview` -- the live object, never a stale handle -- so when a document
+     * keeps asking after being answered, the answers are leaving correctly and arriving nowhere.
+     * Replacing the document is what puts a listener back on the other end.
+     *
+     * The budget is one per resolve, and it is a hard ceiling rather than a tuning choice: the
+     * new document announces itself with its own opening ask, which raises
+     * {@link documentGeneration} again. A per-generation budget would therefore re-arm on the
+     * very document it just created, and a replacement that also failed to bind would reload the
+     * panel forever. Spending it once converts an unbounded silent failure into a single
+     * recovery attempt; if that attempt fails the panel is blank, which is where it already was.
+     */
+    private rebindDocument(): void {
+        const view = this.view;
+        if (!view) return;
+        this.rebindSpent = true;
+        this.lastPostedPayload = undefined;
+        view.webview.html = this.getHtml(view.webview);
     }
 
     /**

--- a/tests/unit/views/commitPanelDocumentReload.test.ts
+++ b/tests/unit/views/commitPanelDocumentReload.test.ts
@@ -1,0 +1,203 @@
+/**
+ * What the commit panel does when a SECOND document announces itself behind one `WebviewView`.
+ *
+ * VS Code can rebuild a hidden view's document without re-running `resolveWebviewView`, and the
+ * React shell also re-announces on remount. Both arrive at the host identically: a fresh
+ * `ready` carrying `attempt: 1` on a view that already had one. The host answers it -- and on the
+ * failing CI runs the answer never lands, so the panel re-asks on its timer and stays on
+ * `commit-panel-awaiting-hydration` for the rest of the session.
+ *
+ * Measured on main run 32968204695, row `shelf-apply`: the E2E handshake trace shows 9 `in ready`
+ * and 16 `out setRepositories` all under document generation 2, beside a webview reporting
+ * `hydration=<asks:18 received:0 last:null>`. Every PASSING row in that run stayed at generation
+ * 1. So the trigger is empirical and clean -- a second opening ask that keeps asking after being
+ * answered -- even though the trace cannot say whether the underlying cause is a VS Code document
+ * reload or a component remount. This file pins the host's RESPONSE to that trigger, which is the
+ * part we control and the part that decides whether the user gets a working panel.
+ *
+ * The rescue is re-setting `webview.html`, which forces the view to build a document bound to the
+ * channel the host is posting into. It is bounded to once per resolve on purpose: the rescue
+ * itself creates a new document that announces itself, so a per-generation budget would re-arm
+ * forever and reload the panel in a loop.
+ *
+ * Why a local double rather than `createInspectableCommitPanelWebviewView`
+ * (`tests/unit/views/CommitPanelViewProvider.test.ts:113`): that one stores ONE handler per event
+ * and, more to the point here, exposes `html` as a plain field, so an assignment is invisible.
+ * Counting assignments is the whole oracle. The shared double is not weakened -- it is unsuitable
+ * for this question, not wrong for its own.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createCommitInfoVscodeDouble } from "../../visual/recorder/commitInfoVscodeDouble";
+
+// `createCommitInfoVscodeDouble` deliberately omits `vscode.commands`; `resolveWebviewView` reaches
+// it through `updateViewCount`'s `setContext`. Same layering as
+// `tests/unit/views/webviewResolveSubscriptions.test.ts`.
+vi.mock("vscode", () => {
+    const base = createCommitInfoVscodeDouble();
+    return new Proxy(base, {
+        get(target, property) {
+            if (property === "commands") {
+                return {
+                    executeCommand: (): Promise<undefined> => Promise.resolve(undefined),
+                };
+            }
+            return Reflect.get(target, property) as unknown;
+        },
+    });
+});
+
+import type * as vscode from "vscode";
+import { createFakeExtensionUri } from "../../visual/recorder/commitInfoVscodeDouble";
+import { GitExecutor } from "../../../src/git/executor";
+import { GitOps } from "../../../src/git/operations";
+import { CommitPanelViewProvider } from "../../../src/views/CommitPanelViewProvider";
+
+const INERT_CONTEXT = {} as vscode.WebviewViewResolveContext;
+const INERT_TOKEN = {} as vscode.CancellationToken;
+
+/** A VS Code event whose registrations accumulate and whose `Disposable` actually removes one. */
+class ListenerRegistry {
+    private readonly listeners: Array<(arg: unknown) => unknown> = [];
+
+    readonly register = (listener: (arg: never) => unknown): vscode.Disposable => {
+        const entry = listener as (arg: unknown) => unknown;
+        this.listeners.push(entry);
+        return {
+            dispose: (): void => {
+                const index = this.listeners.indexOf(entry);
+                if (index !== -1) this.listeners.splice(index, 1);
+            },
+        };
+    };
+
+    fire(arg: unknown): void {
+        for (const listener of [...this.listeners]) void listener(arg);
+    }
+}
+
+interface ReloadableView {
+    readonly webviewView: vscode.WebviewView;
+    readonly messages: ListenerRegistry;
+    readonly posted: unknown[];
+    /** How many times `webview.html` has been ASSIGNED -- the rebind oracle. */
+    htmlAssignments: () => number;
+}
+
+function createReloadableWebviewView(): ReloadableView {
+    const messages = new ListenerRegistry();
+    const disposals = new ListenerRegistry();
+    const visibilityChanges = new ListenerRegistry();
+    const posted: unknown[] = [];
+    let htmlAssignments = 0;
+    let htmlValue = "";
+
+    const webview = {
+        options: {} as vscode.WebviewOptions,
+        // An accessor, not a field: assigning `html` is the observable act this file is about, and
+        // a plain field records only the last value, never that it was written again.
+        get html(): string {
+            return htmlValue;
+        },
+        set html(value: string) {
+            htmlValue = value;
+            htmlAssignments += 1;
+        },
+        cspSource: "vscode-webview://commit-panel-document-reload-test",
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: messages.register,
+        postMessage: (message: unknown) => {
+            posted.push(message);
+            return Promise.resolve(true);
+        },
+    };
+
+    const webviewView = {
+        webview,
+        visible: true,
+        description: undefined,
+        badge: undefined,
+        onDidDispose: disposals.register,
+        onDidChangeVisibility: visibilityChanges.register,
+    } as unknown as vscode.WebviewView;
+
+    return { webviewView, messages, posted, htmlAssignments: () => htmlAssignments };
+}
+
+/** Drains microtasks -- the commit panel's message listener is `async`. */
+function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+/** No `repoRootUri`, so the constructor stays off `setRepositoriesInternal` and `getActiveRuntime`
+ * returns undefined -- this file is about the handshake, not about Git. */
+function createCommitPanelProvider(): CommitPanelViewProvider {
+    return new CommitPanelViewProvider(
+        createFakeExtensionUri(),
+        new GitOps(new GitExecutor("/fake/repo")),
+    );
+}
+
+/** One `ready`, awaited, so the async listener has run before the next assertion. */
+async function ask(view: ReloadableView, attempt: number): Promise<void> {
+    view.messages.fire({ type: "ready", attempt });
+    await flushMicrotasks();
+}
+
+describe("commit panel document reload", () => {
+    it("rebinds the document channel when a second document keeps asking after being answered", async () => {
+        const provider = createCommitPanelProvider();
+        const view = createReloadableWebviewView();
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const afterResolve = view.htmlAssignments();
+
+        await ask(view, 1); // first document announces itself
+        await ask(view, 1); // a SECOND document announces itself behind the same view
+        await ask(view, 2); // and is still asking, so the host's answer is not reaching it
+
+        expect(
+            view.htmlAssignments(),
+            "a second document announced itself, was answered, and kept asking -- the host never " +
+                "re-set webview.html, so its replies keep going to a channel that document is not " +
+                "on and the panel stays blank for the rest of the session",
+        ).toBeGreaterThan(afterResolve);
+    });
+
+    it("does not rebind while a single document is still in its opening burst", async () => {
+        const provider = createCommitPanelProvider();
+        const view = createReloadableWebviewView();
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const afterResolve = view.htmlAssignments();
+
+        await ask(view, 1);
+        await ask(view, 2);
+        await ask(view, 3);
+
+        expect(
+            view.htmlAssignments(),
+            "one document re-asking on its timer is the ordinary healthy path; re-setting " +
+                "webview.html there throws away a document that was about to hydrate",
+        ).toBe(afterResolve);
+    });
+
+    it("rescues a stuck view at most once per resolve", async () => {
+        const provider = createCommitPanelProvider();
+        const view = createReloadableWebviewView();
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const afterResolve = view.htmlAssignments();
+
+        await ask(view, 1);
+        await ask(view, 1);
+        await ask(view, 2); // rescue fires here
+
+        await ask(view, 1); // the rescue's own document announces itself
+        await ask(view, 2); // and if it also fails, the budget must already be spent
+
+        expect(
+            view.htmlAssignments(),
+            "the rescue re-sets webview.html, which itself creates a document that announces " +
+                "itself -- so a budget that re-arms per generation reloads the panel forever",
+        ).toBe(afterResolve + 1);
+    });
+});

--- a/tests/unit/views/commitPanelDocumentReload.test.ts
+++ b/tests/unit/views/commitPanelDocumentReload.test.ts
@@ -145,6 +145,12 @@ async function ask(view: ReloadableView, attempt: number): Promise<void> {
     await flushMicrotasks();
 }
 
+/** A `ready` with no `attempt` at all -- what a producer predating the field sends. */
+async function askWithoutCount(view: ReloadableView): Promise<void> {
+    view.messages.fire({ type: "ready" });
+    await flushMicrotasks();
+}
+
 describe("commit panel document reload", () => {
     it("rebinds the document channel when a second document keeps asking after being answered", async () => {
         const provider = createCommitPanelProvider();
@@ -199,5 +205,23 @@ describe("commit panel document reload", () => {
             "the rescue re-sets webview.html, which itself creates a document that announces " +
                 "itself -- so a budget that re-arms per generation reloads the panel forever",
         ).toBe(afterResolve + 1);
+    });
+
+    it("counts no documents at all when ready carries no attempt", async () => {
+        const provider = createCommitPanelProvider();
+        const view = createReloadableWebviewView();
+        provider.resolveWebviewView(view.webviewView, INERT_CONTEXT, INERT_TOKEN);
+        const afterResolve = view.htmlAssignments();
+
+        await askWithoutCount(view);
+        await askWithoutCount(view);
+        await ask(view, 2);
+
+        expect(
+            view.htmlAssignments(),
+            "`attempt` is untrusted webview input; reading a missing count as a NEW DOCUMENT would " +
+                "let a producer that predates the field earn a rebind and reload a working panel. " +
+                "Only the literal 1 counts as a document announcing itself",
+        ).toBe(afterResolve);
     });
 });


### PR DESCRIPTION
## The failure

A `WebviewView` can outlive the document it was resolved with. VS Code rebuilds a hidden view's document without re-running `resolveWebviewView`, and a remount of the React shell is indistinguishable from the host side. Either way the extension host sees a fresh `ready` carrying `attempt: 1` on a view that already had one, answers it, and the answer never lands. The panel then re-asks on its timer until it gives up and stays blank for the rest of the session.

Measured on main run `32968204695`, row `shelf-apply`: 9 `in ready` and 16 `out setRepositories` **all under document generation 2**, beside a webview reporting `hydration=<asks:18 received:0 last:null>`. Every passing row in that run stayed at generation 1. That is the handshake trace instrument's first real payoff — the generation field is what separates the failing row from the passing ones.

This is the flake that blocks the **release**, not the merge: `publish.yml:317` and `publish.yml:490` both gate on `needs.e2e-full.result == 'success'`.

## Two things the earlier diagnosis had wrong

- **`postToWebview` was never posting to a stale handle.** It reads `this.view.webview`, the live object, and `postWebviewMessage` already reports an undelivered post. The answers leave correctly and arrive nowhere, so making it "generation-aware" would fix nothing.
- **Generation `.2` proves a second *opening ask*, not specifically a VS Code document reload.** `useExtensionMessages.ts` re-initialises `let attempt = 1` on every effect run, so a remount produces a byte-identical signature. The fix keys on the trigger that is actually observable, which covers both causes.

## The fix

Re-setting `webview.html` is the only lever the host has. It is spent when a document that is **not** the resolved one has been answered and is **still asking** — the replacement document is bound to the channel this provider posts into.

Bounded to **one rebind per resolve**, and that is a hard ceiling rather than a tuning choice: the replacement announces itself and raises the generation again, so a per-generation budget would re-arm on the document it just created and reload the panel forever.

`isOpeningAsk` is deliberately **not** the negation of `isHydrationReAsk` — the two questions fail safe in opposite directions. Misreading a re-ask as a first announcement costs one redundant Git read; misreading a missing count as a *new document* would reload a working panel. So only the literal `1` counts.

Purely additive: 86 insertions, **0 deletions**.

## Test plan

Reproduced as a committed red test first (`6e0b88d0`), then fixed (`0c13acb5`).

Red as committed, for the right reason — `html` assigned once at resolve and never again:

```
rebinds the document channel ...   -> expected 1 to be greater than 1
rescues a stuck view at most once  -> expected 1 to be 2
```

The double is local rather than `createInspectableCommitPanelWebviewView`: that one holds `html` as a plain field, so a re-assignment is invisible, and counting assignments is the whole oracle. No existing test was weakened, and `playwright.e2e.config.ts:34` `retries: 0` is untouched.

Mutation-proven, each direction naming its own assertion:

| Mutation | Red tests |
|---|---|
| rescue removed entirely | *rebinds the document channel…* + *rescues a stuck view at most once…* |
| `documentGeneration > 1` dropped | *does not rebind while a single document is still in its opening burst* + *counts no documents at all when ready carries no attempt* |
| once-per-resolve budget removed | *rescues a stuck view at most once per resolve* (only) |
| `isOpeningAsk` loosened to `!isHydrationReAsk` | *counts no documents at all when ready carries no attempt* (only) |

Source restored byte-identical after the pass (`sha256 3b7943dc…`).

- [x] `npx vitest run tests/unit/views/commitPanelDocumentReload.test.ts` — 4/4
- [x] `bun run test` — 4382/4383. The one failure, `screenshotComparatorMeta.test.ts`, imports nothing from `src/` (it spawns Playwright) and passes alone in 3.4s; it is a contention timeout, not this change.
- [x] Nine pre-commit gates green: prettier, eslint `--max-warnings=0`, knip, depcruise (317 modules), l10n validate + audit, three typecheck projects, build, vsce package.

## What this does not prove

The unit test pins the **host's response to the trigger**, not the end-to-end symptom — the flake reproduces intermittently on Windows CI only. Confidence rests on the trigger being exclusive to the failing row.

`received:0` alongside 16 acked posts is still unexplained by any mechanism visible in the code. This is a rescue, not a root-cause fix: it cannot make a blank panel worse, but the real signal is whether `e2e-full` stops producing generation-`.2` rows on main.

A second stuck cycle within one resolve is not rescued — deliberate ceiling, documented at `rebindDocument`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit-panel handling when its webview document reloads.
  * Prevented repeated hydration attempts from causing unnecessary reloads.
  * Preserved normal retry behavior during panel startup.

* **Tests**
  * Added coverage for document reloads, retry handling, and rebind limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->