### PR TITLE
feat(commit-checks): show complete GitHub checks and add refresh (v0.30.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] - 2026-08-27
+
+### Added
+
+- GitHub commit checks now have a Refresh button, so you can get the latest results without reopening the commit.
+
+### Fixed
+
+- GitHub commit checks now show every check, including commits with lots of checks.
+- Finished GitHub workflows no longer stay stuck as "In progress", and the loading spinner stops when the latest checks are complete.
+
 ## [0.29.0] - 2026-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- GitHub commit checks now have a Refresh button, so you can get the latest results without reopening the commit.
+- GitHub commit checks now have a Refresh button that shows when new results are loading, so you can update them without reopening the commit.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/services/commitChecks/githubProvider.ts
+++ b/src/services/commitChecks/githubProvider.ts
@@ -40,6 +40,8 @@ interface GitHubStatus {
     target_url?: unknown;
 }
 
+const GITHUB_PAGE_SIZE = 100;
+
 /** Parses GitHub.com remote URLs from HTTPS, SSH, and scp-like Git remotes. */
 export function parseGithubRemoteUrl(remoteUrl: string): GitHubRepoRef | null {
     const trimmed = remoteUrl.trim();
@@ -137,8 +139,8 @@ export class GitHubProvider implements CommitChecksProvider {
         )}/commits/${encodeURIComponent(hash)}`;
 
         const [checkRunsResult, statusesResult] = await Promise.allSettled([
-            this.fetchJson(`${base}/check-runs?per_page=100`, headers),
-            this.fetchJson(`${base}/statuses?per_page=100`, headers),
+            fetchAllCheckRuns(this.fetchJson, base, headers),
+            fetchAllStatuses(this.fetchJson, base, headers),
         ]);
 
         if (checkRunsResult.status === "rejected" && statusesResult.status === "rejected") {
@@ -171,6 +173,81 @@ export class GitHubProvider implements CommitChecksProvider {
             this.ciCdPattern,
         );
     }
+}
+
+/**
+ * Fetches every check-run page advertised by GitHub.
+ *
+ * The promise rejects when any page fails, so callers never normalize a partial check-run
+ * collection as a successful endpoint result.
+ *
+ * @param fetchJson - Authenticated HTTP boundary used for each sequential page request.
+ * @param base - Commit API URL without an endpoint suffix.
+ * @param headers - Authenticated GitHub request headers.
+ * @returns A combined check-run payload suitable for the normalizer.
+ */
+async function fetchAllCheckRuns(
+    fetchJson: FetchJson,
+    base: string,
+    headers: Record<string, string>,
+): Promise<{ check_runs: GitHubCheckRun[] }> {
+    const firstPage = await fetchJson(
+        `${base}/check-runs?per_page=${GITHUB_PAGE_SIZE}&filter=latest&page=1`,
+        headers,
+    );
+    const checkRuns = readCheckRuns(firstPage);
+    for (let page = 2; page <= pageCount(firstPage); page += 1) {
+        const response = await fetchJson(
+            `${base}/check-runs?per_page=${GITHUB_PAGE_SIZE}&filter=latest&page=${page}`,
+            headers,
+        );
+        checkRuns.push(...readCheckRuns(response));
+    }
+    return { check_runs: checkRuns };
+}
+
+/**
+ * Fetches every page from GitHub's combined-status endpoint as one atomic result.
+ *
+ * The promise rejects when any page fails, discarding earlier pages so endpoint degradation is
+ * handled by the provider's independent settled-result logic.
+ *
+ * @param fetchJson - Authenticated HTTP boundary used for each sequential page request.
+ * @param base - Commit API URL without an endpoint suffix.
+ * @param headers - Authenticated GitHub request headers.
+ * @returns A combined status payload suitable for the normalizer.
+ */
+async function fetchAllStatuses(
+    fetchJson: FetchJson,
+    base: string,
+    headers: Record<string, string>,
+): Promise<{ statuses: GitHubStatus[] }> {
+    const firstPage = await fetchJson(
+        `${base}/status?per_page=${GITHUB_PAGE_SIZE}&page=1`,
+        headers,
+    );
+    const statuses = readStatuses(firstPage);
+    for (let page = 2; page <= pageCount(firstPage); page += 1) {
+        const response = await fetchJson(
+            `${base}/status?per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
+            headers,
+        );
+        statuses.push(...readStatuses(response));
+    }
+    return { statuses };
+}
+
+/**
+ * Returns the number of pages advertised by a GitHub paginated response.
+ *
+ * @param value - First-page payload from a paginated endpoint.
+ * @returns At least one page, even when the payload has no usable total count.
+ */
+function pageCount(value: unknown): number {
+    if (!value || typeof value !== "object") return 1;
+    const totalCount = (value as { total_count?: unknown }).total_count;
+    if (typeof totalCount !== "number" || !Number.isFinite(totalCount)) return 1;
+    return Math.max(1, Math.ceil(totalCount / GITHUB_PAGE_SIZE));
 }
 
 /**

--- a/src/webviews/react/CommitList.tsx
+++ b/src/webviews/react/CommitList.tsx
@@ -70,6 +70,7 @@ interface Props {
     onCommitHover?: (commit: Commit, event: React.MouseEvent) => void;
     onCommitUnhover?: () => void;
     commitChecks?: ReadonlyMap<string, CommitChecksSnapshot | "loading">;
+    /** Requests checks for the supplied hashes; `force` bypasses the host/provider cache. */
     onRequestCommitChecks?: (hashes: string[], force?: boolean) => void;
     onOpenCommitCheckUrl?: (url: string) => void;
     onSignInForCommitChecks?: (host: string) => void;
@@ -418,10 +419,17 @@ export function CommitList({
         requestedCommitHashes,
     ]);
 
-    /** Keeps row-triggered loading aligned with this surface's full exact-viewport demand. */
-    const handleRequestCommitChecksFromRow = useCallback(() => {
-        onRequestCommitChecks?.(requestedCommitHashes, false);
-    }, [onRequestCommitChecks, requestedCommitHashes]);
+    /** Keeps row-triggered loading aligned with viewport demand or a single forced refresh. */
+    const handleRequestCommitChecksFromRow = useCallback(
+        (hash: string, force?: boolean) => {
+            if (force) {
+                onRequestCommitChecks?.([hash], true);
+                return;
+            }
+            onRequestCommitChecks?.(requestedCommitHashes, false);
+        },
+        [onRequestCommitChecks, requestedCommitHashes],
+    );
 
     const branchScopeLabel = selectedBranch
         ? t("commit.scope.branch", { branch: selectedBranch })

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -5,6 +5,7 @@ import { IoIosCloseCircleOutline } from "react-icons/io";
 import { VscRefresh } from "react-icons/vsc";
 import type { CommitChecksSnapshot, CommitCheckState } from "../../../types";
 import { t } from "../shared/i18n";
+import { SPIN_KEYFRAMES } from "../shared/components/iconStyles";
 import { JETBRAINS_UI, SHADOW, Z_INDEX } from "../shared/tokens";
 
 /** Commit-check data cached by hash, including the in-flight marker used while GitHub responds. */
@@ -25,6 +26,16 @@ const PANEL_MIN_WIDTH = 310;
 const PANEL_MIN_HEIGHT = 190;
 const PANEL_TEXT_MAX_WIDTH = 340;
 const PANEL_MAX_HEIGHT = 360;
+const REFRESH_MOTION_STYLES = `${SPIN_KEYFRAMES}
+[data-refreshing="true"] svg {
+    animation: intelligit-spin 0.8s linear infinite;
+    transform-box: fill-box;
+    transform-origin: center;
+    will-change: transform;
+}
+@media (prefers-reduced-motion: reduce) {
+    [data-refreshing="true"] svg { animation: none !important; }
+}`;
 
 type PanelPlacement = "left" | "right";
 type VerticalPlacement = "above" | "below" | "center";
@@ -47,11 +58,27 @@ export function CommitChecksButton({
     const buttonRef = React.useRef<HTMLButtonElement>(null);
     const panelRef = React.useRef<HTMLDivElement>(null);
     const [position, setPosition] = React.useState<PanelPosition | null>(null);
+    const [refreshRequest, setRefreshRequest] = React.useState<{
+        hash: string;
+        snapshot: CommitChecksSnapshot | undefined;
+    } | null>(null);
     const closePanel = React.useCallback(() => setPosition(null), []);
+    const refreshing =
+        refreshRequest?.hash === hash &&
+        (checks === "loading" || checks === refreshRequest.snapshot);
 
     const state = checks && checks !== "loading" ? checks.state : "pending";
     const buttonLabel = t("commit.checks.title");
     const buttonTitle = checks && checks !== "loading" ? checks.summary : buttonLabel;
+
+    const requestRefresh = (): void => {
+        if (refreshing) return;
+        setRefreshRequest({
+            hash,
+            snapshot: checks && checks !== "loading" ? checks : undefined,
+        });
+        onRequestChecks(hash, true);
+    };
 
     const openPanel = (): void => {
         const button = buttonRef.current;
@@ -144,7 +171,8 @@ export function CommitChecksButton({
                         hash={hash}
                         checks={checks}
                         position={position}
-                        onRequestChecks={onRequestChecks}
+                        refreshing={refreshing}
+                        onRefresh={requestRefresh}
                         onOpenCheckUrl={onOpenCheckUrl}
                         onSignIn={onSignIn}
                     />,
@@ -160,7 +188,8 @@ function CommitChecksPanel({
     hash,
     checks,
     position,
-    onRequestChecks,
+    refreshing,
+    onRefresh,
     onOpenCheckUrl,
     onSignIn,
 }: {
@@ -168,12 +197,14 @@ function CommitChecksPanel({
     hash: string;
     checks?: CommitChecksValue;
     position: PanelPosition;
-    /** Requests this commit's checks; `force` bypasses the host/provider cache. */
-    onRequestChecks: (hash: string, force?: boolean) => void;
+    refreshing: boolean;
+    /** Starts local refresh feedback before asking the host for a forced snapshot. */
+    onRefresh: () => void;
     onOpenCheckUrl: (url: string) => void;
     onSignIn?: (host: string) => void;
 }): React.ReactElement {
     const snapshot = checks && checks !== "loading" ? checks : undefined;
+    const refreshDisabled = checks === "loading" || refreshing;
     const signInHost =
         snapshot && snapshot.state === "unavailable" ? snapshot.signInHost : undefined;
     const transform = `${position.placement === "left" ? "translateX(-100%) " : ""}${
@@ -201,6 +232,7 @@ function CommitChecksPanel({
             onClick={(event) => event.stopPropagation()}
             data-testid="commit-checks-popover"
         >
+            <style>{REFRESH_MOTION_STYLES}</style>
             <span
                 aria-hidden="true"
                 data-testid="commit-checks-popover-caret-border"
@@ -233,17 +265,23 @@ function CommitChecksPanel({
                         type="button"
                         aria-label={t("common.refresh")}
                         title={t("common.refresh")}
-                        disabled={checks === "loading"}
-                        onClick={() => onRequestChecks(hash, true)}
+                        disabled={refreshDisabled}
+                        onClick={onRefresh}
+                        data-refreshing={String(refreshing)}
                         style={{
                             ...refreshButtonStyle,
-                            ...(checks === "loading" ? refreshButtonDisabledStyle : {}),
+                            ...(refreshDisabled ? refreshButtonDisabledStyle : {}),
                         }}
                     >
                         <VscRefresh size={14} aria-hidden="true" focusable="false" />
                     </button>
                 </div>
-                <div style={bodyStyle}>
+                {refreshing ? (
+                    <div role="status" aria-live="polite" style={refreshStatusStyle}>
+                        {t("commit.checks.loading")}
+                    </div>
+                ) : null}
+                <div style={bodyStyle} aria-busy={refreshing}>
                     {checks === "loading" || !checks ? (
                         <div style={emptyStyle}>{t("commit.checks.loading")}</div>
                     ) : snapshot && snapshot.items.length > 0 ? (
@@ -453,6 +491,12 @@ const refreshButtonStyle: React.CSSProperties = {
 const refreshButtonDisabledStyle: React.CSSProperties = {
     opacity: 0.6,
     cursor: "default",
+};
+
+const refreshStatusStyle: React.CSSProperties = {
+    color: JETBRAINS_UI.color.muted,
+    fontSize: 12,
+    padding: "10px 18px 0",
 };
 
 const panelHashStyle: React.CSSProperties = {

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -66,6 +66,8 @@ export function CommitChecksButton({
     const refreshing =
         refreshRequest?.hash === hash &&
         (checks === "loading" || checks === refreshRequest.snapshot);
+    const displayedChecks =
+        refreshing && refreshRequest.snapshot ? refreshRequest.snapshot : checks;
 
     const state = checks && checks !== "loading" ? checks.state : "pending";
     const buttonLabel = t("commit.checks.title");
@@ -169,7 +171,7 @@ export function CommitChecksButton({
                     <CommitChecksPanel
                         panelRef={panelRef}
                         hash={hash}
-                        checks={checks}
+                        checks={displayedChecks}
                         position={position}
                         refreshing={refreshing}
                         onRefresh={requestRefresh}

--- a/src/webviews/react/commit-list/CommitChecksPopover.tsx
+++ b/src/webviews/react/commit-list/CommitChecksPopover.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createPortal } from "react-dom";
 import { FiCheckCircle, FiMinusCircle } from "react-icons/fi";
 import { IoIosCloseCircleOutline } from "react-icons/io";
+import { VscRefresh } from "react-icons/vsc";
 import type { CommitChecksSnapshot, CommitCheckState } from "../../../types";
 import { t } from "../shared/i18n";
 import { JETBRAINS_UI, SHADOW, Z_INDEX } from "../shared/tokens";
@@ -12,7 +13,8 @@ export type CommitChecksValue = CommitChecksSnapshot | "loading";
 interface Props {
     hash: string;
     checks?: CommitChecksValue;
-    onRequestChecks: (hash: string) => void;
+    /** Requests this commit's checks; `force` bypasses the host/provider cache. */
+    onRequestChecks: (hash: string, force?: boolean) => void;
     onOpenCheckUrl: (url: string) => void;
     /** Sign in to the snapshot's `signInHost` from the popover (recoverable `unavailable` only). */
     onSignIn?: (host: string) => void;
@@ -142,6 +144,7 @@ export function CommitChecksButton({
                         hash={hash}
                         checks={checks}
                         position={position}
+                        onRequestChecks={onRequestChecks}
                         onOpenCheckUrl={onOpenCheckUrl}
                         onSignIn={onSignIn}
                     />,
@@ -157,6 +160,7 @@ function CommitChecksPanel({
     hash,
     checks,
     position,
+    onRequestChecks,
     onOpenCheckUrl,
     onSignIn,
 }: {
@@ -164,6 +168,8 @@ function CommitChecksPanel({
     hash: string;
     checks?: CommitChecksValue;
     position: PanelPosition;
+    /** Requests this commit's checks; `force` bypasses the host/provider cache. */
+    onRequestChecks: (hash: string, force?: boolean) => void;
     onOpenCheckUrl: (url: string) => void;
     onSignIn?: (host: string) => void;
 }): React.ReactElement {
@@ -219,8 +225,23 @@ function CommitChecksPanel({
             />
             <div style={panelStyle}>
                 <div style={titleStyle}>
-                    {t("commit.checks.title")}
-                    <span style={panelHashStyle}>{hash.slice(0, 7)}</span>
+                    <span>
+                        {t("commit.checks.title")}
+                        <span style={panelHashStyle}>{hash.slice(0, 7)}</span>
+                    </span>
+                    <button
+                        type="button"
+                        aria-label={t("common.refresh")}
+                        title={t("common.refresh")}
+                        disabled={checks === "loading"}
+                        onClick={() => onRequestChecks(hash, true)}
+                        style={{
+                            ...refreshButtonStyle,
+                            ...(checks === "loading" ? refreshButtonDisabledStyle : {}),
+                        }}
+                    >
+                        <VscRefresh size={14} aria-hidden="true" focusable="false" />
+                    </button>
                 </div>
                 <div style={bodyStyle}>
                     {checks === "loading" || !checks ? (
@@ -408,6 +429,30 @@ const titleStyle: React.CSSProperties = {
     fontWeight: 700,
     background: "var(--vscode-textLink-foreground)",
     color: "var(--vscode-button-foreground)",
+    position: "relative",
+};
+
+const refreshButtonStyle: React.CSSProperties = {
+    position: "absolute",
+    top: "50%",
+    right: 8,
+    transform: "translateY(-50%)",
+    width: 22,
+    height: 22,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    border: "none",
+    borderRadius: 4,
+    background: "transparent",
+    color: "inherit",
+    padding: 0,
+    cursor: "pointer",
+};
+
+const refreshButtonDisabledStyle: React.CSSProperties = {
+    opacity: 0.6,
+    cursor: "default",
 };
 
 const panelHashStyle: React.CSSProperties = {

--- a/src/webviews/react/commit-list/CommitListRows.tsx
+++ b/src/webviews/react/commit-list/CommitListRows.tsx
@@ -31,7 +31,8 @@ interface CommitListRowsProps {
     showDate: boolean;
     commitChecks?: ReadonlyMap<string, CommitChecksSnapshot | "loading">;
     onSelectCommit: (hash: string) => void;
-    onRequestCommitChecks?: (hash: string) => void;
+    /** Requests a commit's checks; `force` bypasses the host/provider cache. */
+    onRequestCommitChecks?: (hash: string, force?: boolean) => void;
     onOpenCommitCheckUrl?: (url: string) => void;
     onSignInForCommitChecks?: (host: string) => void;
     onCommitHover?: (commit: Commit, event: React.MouseEvent) => void;

--- a/src/webviews/react/commit-list/CommitRow.tsx
+++ b/src/webviews/react/commit-list/CommitRow.tsx
@@ -35,7 +35,8 @@ interface Props {
     showAuthor?: boolean;
     showDate?: boolean;
     checks?: CommitChecksValue;
-    onRequestChecks?: (hash: string) => void;
+    /** Requests this commit's checks; `force` bypasses the host/provider cache. */
+    onRequestChecks?: (hash: string, force?: boolean) => void;
     onOpenCheckUrl?: (url: string) => void;
     onSignIn?: (host: string) => void;
 }

--- a/tests/unit/services/commitChecks/githubProvider.test.ts
+++ b/tests/unit/services/commitChecks/githubProvider.test.ts
@@ -218,10 +218,10 @@ describe("GitHubProvider", () => {
             (call) => call[0] as string,
         );
         expect(calledUrls[0]).toBe(
-            "https://api.github.com/repos/owner/repo/commits/abc1234/check-runs?per_page=100",
+            "https://api.github.com/repos/owner/repo/commits/abc1234/check-runs?per_page=100&filter=latest&page=1",
         );
         expect(calledUrls[1]).toBe(
-            "https://api.github.com/repos/owner/repo/commits/abc1234/statuses?per_page=100",
+            "https://api.github.com/repos/owner/repo/commits/abc1234/status?per_page=100&page=1",
         );
         for (const call of (fetchJson as ReturnType<typeof vi.fn>).mock.calls) {
             const headers = call[1] as Record<string, string>;
@@ -475,7 +475,7 @@ describe("GitHubProvider", () => {
         // transport error and hide the actionable one.
         const provider = new GitHubProvider(
             vi.fn(async (url: string) => {
-                if (url.includes("/statuses")) throw new HttpError(401, "HTTP 401: Bad", {});
+                if (url.includes("/status?")) throw new HttpError(401, "HTTP 401: Bad", {});
                 throw new Error("HTTP request timed out");
             }),
         );
@@ -499,7 +499,7 @@ describe("GitHubProvider", () => {
 
     it("still normalizes when only one endpoint rejects", async () => {
         const fetchJson: FetchJson = vi.fn(async (url: string) => {
-            if (url.includes("/statuses")) throw new Error("statuses 500");
+            if (url.includes("/status?")) throw new Error("statuses 500");
             return {
                 check_runs: [{ name: "CI / build", status: "completed", conclusion: "success" }],
             };
@@ -515,7 +515,7 @@ describe("GitHubProvider", () => {
     it("admits a row the default filter drops when a custom ciCdPattern matches it", async () => {
         // "sonarcloud" is not a built-in CI/CD term; a custom include pattern keeps it.
         const fetchJson: FetchJson = vi.fn(async (url: string) => {
-            if (url.includes("/statuses")) return [{ context: "sonarcloud", state: "success" }];
+            if (url.includes("/status?")) return [{ context: "sonarcloud", state: "success" }];
             return { check_runs: [] };
         });
         const provider = new GitHubProvider(fetchJson, /sonarcloud/i);
@@ -527,7 +527,7 @@ describe("GitHubProvider", () => {
 
     it("drops a default-CI row when a narrow custom ciCdPattern excludes it", async () => {
         const fetchJson: FetchJson = vi.fn(async (url: string) => {
-            if (url.includes("/statuses")) return [];
+            if (url.includes("/status?")) return [];
             return {
                 check_runs: [{ name: "CI / build", status: "completed", conclusion: "success" }],
             };

--- a/tests/unit/services/commitChecks/githubProvider.test.ts
+++ b/tests/unit/services/commitChecks/githubProvider.test.ts
@@ -229,6 +229,133 @@ describe("GitHubProvider", () => {
         }
     });
 
+    it("fetches every page of GitHub check runs and combined statuses", async () => {
+        const checkRuns = Array.from({ length: 101 }, (_, index) => ({
+            name: `CI / check ${index}`,
+            status: "completed",
+            conclusion: "success",
+        }));
+        const statuses = Array.from({ length: 101 }, (_, index) => ({
+            context: `CI status ${index}`,
+            state: "success",
+        }));
+        const fetchJson = fetchReturning((url) => {
+            const parsed = new URL(url);
+            const page = Number(parsed.searchParams.get("page") ?? "1");
+            const start = (page - 1) * 100;
+            if (parsed.pathname.endsWith("/check-runs")) {
+                return {
+                    total_count: checkRuns.length,
+                    check_runs: checkRuns.slice(start, start + 100),
+                };
+            }
+            return {
+                state: "success",
+                total_count: statuses.length,
+                statuses: statuses.slice(start, start + 100),
+            };
+        });
+        const provider = new GitHubProvider(fetchJson);
+
+        const snapshot = await provider.getChecks(githubRef, "abc1234");
+
+        expect(snapshot.items).toHaveLength(202);
+        expect(fetchJson).toHaveBeenCalledTimes(4);
+        const calledUrls = (fetchJson as ReturnType<typeof vi.fn>).mock.calls.map(
+            (call) => call[0] as string,
+        );
+        expect(calledUrls).toEqual(
+            expect.arrayContaining([
+                "https://api.github.com/repos/owner/repo/commits/abc1234/check-runs?per_page=100&filter=latest&page=1",
+                "https://api.github.com/repos/owner/repo/commits/abc1234/check-runs?per_page=100&filter=latest&page=2",
+                "https://api.github.com/repos/owner/repo/commits/abc1234/status?per_page=100&page=1",
+                "https://api.github.com/repos/owner/repo/commits/abc1234/status?per_page=100&page=2",
+            ]),
+        );
+        expect(calledUrls.some((url) => url.includes("/statuses?"))).toBe(false);
+        expect(calledUrls.some((url) => url.includes("page=3"))).toBe(false);
+    });
+
+    it("uses GitHub's combined status so old pending history cannot keep a completed context pending", async () => {
+        const fetchJson = fetchReturning((url) => {
+            if (url.includes("/check-runs")) return { total_count: 0, check_runs: [] };
+            if (url.includes("/statuses?")) {
+                return [
+                    { context: "CI / build", state: "success" },
+                    { context: "CI / build", state: "pending" },
+                ];
+            }
+            return {
+                state: "success",
+                total_count: 1,
+                statuses: [{ context: "CI / build", state: "success" }],
+            };
+        });
+        const provider = new GitHubProvider(fetchJson);
+
+        const snapshot = await provider.getChecks(githubRef, "abc1234");
+
+        expect(snapshot.state).toBe("success");
+        expect(snapshot.items).toHaveLength(1);
+        expect(snapshot.items[0]).toMatchObject({ name: "CI / build", state: "success" });
+        const calledUrls = (fetchJson as ReturnType<typeof vi.fn>).mock.calls.map(
+            (call) => call[0] as string,
+        );
+        expect(calledUrls.some((url) => url.includes("/statuses?"))).toBe(false);
+    });
+
+    it("discards an endpoint's earlier pages when a later page fails", async () => {
+        const firstPageChecks = Array.from({ length: 100 }, (_, index) => ({
+            name: `CI / check ${index}`,
+            status: "completed",
+            conclusion: "success",
+        }));
+        const fetchJson = vi.fn(async (url: string) => {
+            const parsed = new URL(url);
+            if (parsed.pathname.endsWith("/check-runs")) {
+                if (parsed.searchParams.get("page") === "2") throw new Error("page 2 failed");
+                return { total_count: 101, check_runs: firstPageChecks };
+            }
+            return {
+                state: "success",
+                total_count: 1,
+                statuses: [{ context: "CI / status", state: "success" }],
+            };
+        });
+        const provider = new GitHubProvider(fetchJson);
+
+        const snapshot = await provider.getChecks(githubRef, "abc1234");
+
+        expect(snapshot.state).toBe("success");
+        expect(snapshot.items).toEqual([
+            expect.objectContaining({ name: "CI / status", state: "success" }),
+        ]);
+    });
+
+    it("keeps sign-in recovery when a later page rejects the GitHub session", async () => {
+        const firstPageChecks = Array.from({ length: 100 }, (_, index) => ({
+            name: `CI / check ${index}`,
+            status: "completed",
+            conclusion: "success",
+        }));
+        const fetchJson = vi.fn(async (url: string) => {
+            const parsed = new URL(url);
+            if (parsed.pathname.endsWith("/check-runs")) {
+                if (parsed.searchParams.get("page") === "2") {
+                    throw new HttpError(401, "HTTP 401: Bad credentials", {});
+                }
+                return { total_count: 101, check_runs: firstPageChecks };
+            }
+            throw new Error("status endpoint failed");
+        });
+        const provider = new GitHubProvider(fetchJson);
+
+        const snapshot = await provider.getChecks(githubRef, "abc1234");
+
+        expect(snapshot.state).toBe("unavailable");
+        expect(snapshot.signInHost).toBe("github.com");
+    });
+
     it("does not prompt or fetch when no GitHub session already exists", async () => {
         mocks.getSession.mockResolvedValue(undefined);
         const fetchJson = vi.fn();

--- a/tests/webview/unit/low-coverage-components.test.tsx
+++ b/tests/webview/unit/low-coverage-components.test.tsx
@@ -689,6 +689,81 @@ describe("low coverage components", () => {
         }
     });
 
+    it("CommitList force-refreshes only the commit whose popover action was clicked", async () => {
+        const onRequestCommitChecks = vi.fn();
+        const commits: Commit[] = ["1111111", "2222222"].map((hash, index) => ({
+            hash,
+            shortHash: hash,
+            message: `Commit ${index}`,
+            author: "Mahesh",
+            email: "m@example.com",
+            date: "2026-02-19T00:00:00Z",
+            parentHashes: [],
+            refs: [],
+        }));
+        const snapshots = new Map(
+            commits.map((commit) => [
+                commit.hash,
+                {
+                    hash: commit.hash,
+                    state: "success" as const,
+                    summary: "All checks passed",
+                    items: [
+                        {
+                            name: "CI / build",
+                            state: "success" as const,
+                            source: "check-run" as const,
+                        },
+                    ],
+                },
+            ]),
+        );
+        const clientHeight = vi
+            .spyOn(HTMLElement.prototype, "clientHeight", "get")
+            .mockReturnValue(ROW_HEIGHT * commits.length);
+        let mounted: ReturnType<typeof mount> | undefined;
+        try {
+            mounted = mount(
+                <CommitList
+                    commits={commits}
+                    selectedHash={null}
+                    filterText=""
+                    hasMore={false}
+                    unpushedHashes={new Set()}
+                    selectedBranch={null}
+                    onSelectCommit={vi.fn()}
+                    onFilterText={vi.fn()}
+                    onLoadMore={vi.fn()}
+                    onCommitAction={vi.fn()}
+                    commitChecks={snapshots}
+                    onRequestCommitChecks={onRequestCommitChecks}
+                    onOpenCommitCheckUrl={vi.fn()}
+                />,
+            );
+            await flush();
+            expect(onRequestCommitChecks).toHaveBeenLastCalledWith(
+                commits.map((commit) => commit.hash),
+                false,
+            );
+            onRequestCommitChecks.mockClear();
+
+            const trigger = mounted.container.querySelector(
+                `[data-testid="commit-checks-button-${commits[0].hash}"]`,
+            ) as HTMLButtonElement;
+            act(() => trigger.click());
+            const refreshButton = document.body.querySelector(
+                'button[aria-label="Refresh"]',
+            ) as HTMLButtonElement;
+            expect(refreshButton).not.toBeNull();
+            act(() => refreshButton.click());
+
+            expect(onRequestCommitChecks.mock.calls).toEqual([[[commits[0].hash], true]]);
+        } finally {
+            if (mounted) unmount(mounted.root, mounted.container);
+            clientHeight.mockRestore();
+        }
+    });
+
     it("CommitList clears previous demand when check callbacks are disabled", async () => {
         const onRequestCommitChecks = vi.fn();
         const commit: Commit = {

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -1000,7 +1000,7 @@ describe("webview ui smoke", () => {
             error: "Sign in to refresh checks.",
             items: [],
         };
-        const render = (checks: CommitChecksSnapshot): React.ReactElement => (
+        const render = (checks: CommitChecksSnapshot | "loading"): React.ReactElement => (
             <CommitChecksButton
                 hash={hash}
                 checks={checks}
@@ -1029,6 +1029,10 @@ describe("webview ui smoke", () => {
         )?.textContent;
         expect(refreshStyles).toContain("animation: intelligit-spin");
         expect(refreshStyles).toContain("@media (prefers-reduced-motion: reduce)");
+
+        act(() => mounted.root.render(render("loading")));
+        expect(document.body.querySelector('[role="status"]')).not.toBeNull();
+        expect(document.body.textContent).toContain("Existing check");
 
         act(() => refreshButton.click());
         expect(onRequestChecks).toHaveBeenCalledOnce();

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -786,6 +786,13 @@ describe("webview ui smoke", () => {
         expect(document.body.textContent).toContain("GitGuardian Security Checks");
         expect(document.body.textContent).toContain("Code Review Skipped");
         expect(document.body.textContent).not.toContain("All checks passed");
+        const refreshButton = document.body.querySelector(
+            'button[aria-label="Refresh"]',
+        ) as HTMLButtonElement;
+        expect(refreshButton).not.toBeNull();
+        expect(refreshButton.disabled).toBe(false);
+        act(() => refreshButton.click());
+        expect(onRequestChecks).toHaveBeenCalledWith("abc1234", true);
         const popover = document.body.querySelector('[data-testid="commit-checks-popover"]');
         const panel = popover?.querySelector("div");
         const caretBorder = document.body.querySelector(
@@ -821,7 +828,7 @@ describe("webview ui smoke", () => {
             link?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         });
 
-        expect(onRequestChecks).not.toHaveBeenCalled();
+        expect(onRequestChecks).toHaveBeenCalledTimes(1);
         expect(onOpenCheckUrl).toHaveBeenCalledWith("https://example.test/security");
 
         act(() => {
@@ -939,6 +946,30 @@ describe("webview ui smoke", () => {
         expect(spinnerAnimation?.getAttribute("type")).toBe("rotate");
         expect(spinnerAnimation?.getAttribute("repeatCount")).toBe("indefinite");
         unmount(pendingMounted.root, pendingMounted.container);
+    });
+
+    it("disables commit-check refresh while that commit is loading", () => {
+        const onRequestChecks = vi.fn();
+        const mounted = mount(
+            <CommitChecksButton
+                hash="loading123"
+                checks="loading"
+                onRequestChecks={onRequestChecks}
+                onOpenCheckUrl={vi.fn()}
+            />,
+        );
+        const trigger = mounted.container.querySelector("button") as HTMLButtonElement;
+        act(() => trigger.click());
+
+        const refreshButton = document.body.querySelector(
+            'button[aria-label="Refresh"]',
+        ) as HTMLButtonElement;
+        expect(refreshButton).not.toBeNull();
+        expect(refreshButton.disabled).toBe(true);
+        act(() => refreshButton.click());
+        expect(onRequestChecks).not.toHaveBeenCalled();
+
+        unmount(mounted.root, mounted.container);
     });
 
     it("offers a host-targeted Sign in button only for a recoverable unavailable snapshot", () => {

--- a/tests/webview/unit/ui-smoke.test.tsx
+++ b/tests/webview/unit/ui-smoke.test.tsx
@@ -972,6 +972,83 @@ describe("webview ui smoke", () => {
         unmount(mounted.root, mounted.container);
     });
 
+    it("keeps visible commit checks and refresh feedback until a new snapshot arrives", () => {
+        const onRequestChecks = vi.fn();
+        const hash = "refresh123";
+        const currentSnapshot: CommitChecksSnapshot = {
+            hash,
+            state: "success",
+            summary: "Existing checks passed",
+            items: [
+                {
+                    name: "Existing check",
+                    description: "The displayed result remains visible while refreshing.",
+                    state: "success",
+                    source: "status",
+                },
+            ],
+        };
+        const nextSnapshot: CommitChecksSnapshot = {
+            ...currentSnapshot,
+            summary: "Updated checks passed",
+            items: [{ ...currentSnapshot.items[0], name: "Updated check" }],
+        };
+        const unavailableSnapshot: CommitChecksSnapshot = {
+            hash,
+            state: "unavailable",
+            summary: "Checks unavailable",
+            error: "Sign in to refresh checks.",
+            items: [],
+        };
+        const render = (checks: CommitChecksSnapshot): React.ReactElement => (
+            <CommitChecksButton
+                hash={hash}
+                checks={checks}
+                onRequestChecks={onRequestChecks}
+                onOpenCheckUrl={vi.fn()}
+            />
+        );
+        const mounted = mount(render(currentSnapshot));
+        const trigger = mounted.container.querySelector("button") as HTMLButtonElement;
+        act(() => trigger.click());
+        const refreshButton = document.body.querySelector(
+            'button[aria-label="Refresh"]',
+        ) as HTMLButtonElement;
+
+        act(() => refreshButton.click());
+        expect(onRequestChecks).toHaveBeenCalledExactlyOnceWith(hash, true);
+        expect(refreshButton.disabled).toBe(true);
+        expect(refreshButton.dataset.refreshing).toBe("true");
+        const status = document.body.querySelector('[role="status"]');
+        expect(status?.textContent).toBe("Loading checks...");
+        expect(status?.closest('[aria-busy="true"]')).toBeNull();
+        expect(document.body.querySelector('[aria-busy="true"]')).not.toBeNull();
+        expect(document.body.textContent).toContain("Existing check");
+        const refreshStyles = Array.from(document.querySelectorAll("style")).find((style) =>
+            style.textContent?.includes('[data-refreshing="true"] svg'),
+        )?.textContent;
+        expect(refreshStyles).toContain("animation: intelligit-spin");
+        expect(refreshStyles).toContain("@media (prefers-reduced-motion: reduce)");
+
+        act(() => refreshButton.click());
+        expect(onRequestChecks).toHaveBeenCalledOnce();
+
+        act(() => mounted.root.render(render(currentSnapshot)));
+        expect(document.body.querySelector('[role="status"]')).not.toBeNull();
+
+        act(() => mounted.root.render(render(nextSnapshot)));
+        expect(refreshButton.disabled).toBe(false);
+        expect(document.body.querySelector('[role="status"]')).toBeNull();
+        expect(document.body.textContent).toContain("Updated check");
+
+        act(() => refreshButton.click());
+        act(() => mounted.root.render(render(unavailableSnapshot)));
+        expect(refreshButton.disabled).toBe(false);
+        expect(document.body.querySelector('[role="status"]')).toBeNull();
+        expect(document.body.textContent).toContain("Sign in to refresh checks.");
+        unmount(mounted.root, mounted.container);
+    });
+
     it("offers a host-targeted Sign in button only for a recoverable unavailable snapshot", () => {
         const onRequestChecks = vi.fn();
         const onOpenCheckUrl = vi.fn();


### PR DESCRIPTION
### Title

feat(commit-checks): show complete GitHub checks and add refresh (v0.30.0)

### Motivation

GitHub commit checks could omit results or stay marked as in progress after a workflow had finished, leaving the loading spinner running. Users also had no way to request the latest result without reopening the commit.

### Summary

- Load every GitHub check reported for a commit, including commits with large check lists.
- Use GitHub's current combined status so older pending results cannot override a finished workflow.
- Add a Refresh button to the commit-check popover and refresh only the selected commit. The button spins and a visible loading message appears while new results are fetched.
- Disable refresh while that commit is already loading.
- Prepare the user-facing changelog and manifest for version 0.30.0.

### Detailed Changes

#### Code

- Fetch all GitHub check-run and status pages as complete endpoint results.
- Keep the existing degraded behavior when one GitHub endpoint fails, including sign-in recovery for rejected sessions.
- Pass a forced, commit-scoped refresh action from the popover to the existing request path, while keeping existing check rows visible and showing refresh progress.

#### Tests

- Added provider regression tests for complete pagination, current workflow status, later-page failure handling, and sign-in recovery.
- Added webview tests for the Refresh action, commit scoping, the spinning button, the visible loading message, and completion when a new snapshot arrives.

#### Documentation

- Added plain-language 0.30.0 release notes to `CHANGELOG.md`.

#### CI/CD

- None.

#### Dependencies

- None.

#### Data/output files

- None committed. The 0.30.0 VSIX was built and verified locally.

### Testing

- Unit/regression tests: GitHub provider 25/25; commit-check UI file 25/25; previously affected webview tests 51/51.
- Feature/bug verification: Verified the real commit-check popover in an Extension Development Host, including the accessible Refresh button and check list. The transient spinner/loading state is covered by the component test.
- Validation summary: Format, strict lint, dependency checks, architecture, localization validation/audit, three TypeScript projects, development and production builds, and VSIX packaging/verification passed.
- Full-suite note: the latest local full run had one unrelated merge-editor timing-budget miss; its isolated rerun passed 3/3. The previous integrated full suite passed 4,497/4,497 across 336 test files. React Doctor reports 47 optional warnings already present in the repository.

- Hosted checks: all passed after rerunning one Windows shard that initially hit five unrelated 30-second fixture-test timeouts.

### Risks / Notes

- If a later GitHub page fails, that endpoint is discarded instead of showing a misleading partial list; results from the other endpoint can still be shown.
- No dependencies, settings, or persisted data formats changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Refresh button to commit checks for retrieving the latest results for an individual commit.
  - Refresh is disabled while checks are loading and shows clear loading feedback during updates.

- **Bug Fixes**
  - Commit checks now include results across all available pages, preventing incomplete status displays.
  - Failed page requests no longer produce partial or misleading check results.
  - Updated GitHub status handling for more reliable results.

- **Chores**
  - Updated the extension version to 0.30.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->