### PR TITLE
fix: clear the ahead count after a push from a worktree (#147, 0.32.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.6] - 2026-09-10
+
+### Fixed
+
+- In a Git worktree (an extra folder checked out from the same repository), pushing now clears the ↑ count of commits waiting to be pushed as soon as the push is done. Before, the old count stayed until something else made IntelliGit refresh.
+- A worktree now also updates straight away after other branch changes, such as a fetch or a deleted branch, even when they were made from another folder of the same repository.
+
 ## [0.32.5] - 2026-09-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.32.5",
+    "version": "0.32.6",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/git/gitDirectory.ts
+++ b/src/git/gitDirectory.ts
@@ -20,3 +20,23 @@ export function resolveGitDir(repoRoot: string): string {
         return dotGit;
     }
 }
+
+/**
+ * Resolves the Git directory that holds a repository's shared state.
+ *
+ * A linked worktree owns `HEAD`, `index`, and the in-progress operation files, but not refs:
+ * `refs/`, `packed-refs`, and the object store live in the common directory that every worktree
+ * shares, and Git records the way back in a `commondir` pointer file. Callers that watch or read
+ * refs need this; callers that read per-worktree state want `resolveGitDir` instead. For a plain
+ * checkout the two are the same directory, so a missing or unreadable pointer falls back to it.
+ */
+export function resolveGitCommonDir(repoRoot: string): string {
+    const gitDir = resolveGitDir(repoRoot);
+    try {
+        const pointer = readFileSync(path.join(gitDir, "commondir"), "utf8").trim();
+        if (!pointer) return gitDir;
+        return path.isAbsolute(pointer) ? pointer : path.resolve(gitDir, pointer);
+    } catch {
+        return gitDir;
+    }
+}

--- a/src/services/repositoryChangeEvents.ts
+++ b/src/services/repositoryChangeEvents.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { resolveGitDir } from "../git/gitDirectory";
+import { resolveGitCommonDir, resolveGitDir } from "../git/gitDirectory";
 import { logGitOpsWarning } from "../git/operationSupport";
 
 /** Sources whose existing watcher pathways can invalidate a repository diff snapshot. */
@@ -198,7 +198,10 @@ class RootWorkingTreeWatcher implements vscode.Disposable {
         }
 
         try {
-            const refsPath = path.join(gitDir, "refs");
+            // Refs are shared state, so they live in the common directory. A linked worktree's
+            // own `refs` tree exists but stays empty, and watching it would miss every ref a
+            // push or fetch moves.
+            const refsPath = path.join(resolveGitCommonDir(this.repoRoot), "refs");
             if (process.platform === "linux") {
                 const watcher = vscode.workspace.createFileSystemWatcher(
                     new vscode.RelativePattern(vscode.Uri.file(refsPath), "**/*"),

--- a/src/services/repositoryChangeEvents.ts
+++ b/src/services/repositoryChangeEvents.ts
@@ -170,6 +170,7 @@ class RootWorkingTreeWatcher implements vscode.Disposable {
     /** Registers the existing Git metadata paths that can move symbolic refs. */
     private registerGitWatchers(): void {
         const gitDir = resolveGitDir(this.repoRoot);
+        const commonDir = resolveGitCommonDir(this.repoRoot);
         const gitStateFiles = new Set([
             "HEAD",
             "FETCH_HEAD",
@@ -179,29 +180,18 @@ class RootWorkingTreeWatcher implements vscode.Disposable {
             "index",
         ]);
 
-        try {
-            this.retainFsWatcher(
-                fs.watch(gitDir, (_event, filename) => {
-                    const name = filename?.toString();
-                    if (!name) {
-                        this.fire({ repoRoot: this.repoRoot, source: "git-state" });
-                    } else if (gitStateFiles.has(name)) {
-                        this.fire({
-                            repoRoot: this.repoRoot,
-                            source: name === "index" ? "git-index" : "git-state",
-                        });
-                    }
-                }),
-            );
-        } catch {
-            /* .git may not be watchable for virtual roots or isolated test fixtures. */
-        }
+        this.watchGitStateFiles(gitDir, gitStateFiles);
+        // A linked worktree's Git directory has no `packed-refs`: Git keeps the one file every
+        // worktree shares in the common directory, beside `refs`. That directory also holds the
+        // main checkout's own `HEAD` and `index`, so only `packed-refs` is taken from it. In a
+        // plain checkout the two are one directory, already watched above.
+        if (commonDir !== gitDir) this.watchGitStateFiles(commonDir, new Set(["packed-refs"]));
 
         try {
             // Refs are shared state, so they live in the common directory. A linked worktree's
             // own `refs` tree exists but stays empty, and watching it would miss every ref a
             // push or fetch moves.
-            const refsPath = path.join(resolveGitCommonDir(this.repoRoot), "refs");
+            const refsPath = path.join(commonDir, "refs");
             if (process.platform === "linux") {
                 const watcher = vscode.workspace.createFileSystemWatcher(
                     new vscode.RelativePattern(vscode.Uri.file(refsPath), "**/*"),
@@ -222,6 +212,27 @@ class RootWorkingTreeWatcher implements vscode.Disposable {
             }
         } catch {
             /* The refs directory may not exist yet or the platform may not support this watcher. */
+        }
+    }
+
+    /** Watches one Git directory for a change to any of `names`, or to an entry Node cannot name. */
+    private watchGitStateFiles(dir: string, names: ReadonlySet<string>): void {
+        try {
+            this.retainFsWatcher(
+                fs.watch(dir, (_event, filename) => {
+                    const name = filename?.toString();
+                    if (!name) {
+                        this.fire({ repoRoot: this.repoRoot, source: "git-state" });
+                    } else if (names.has(name)) {
+                        this.fire({
+                            repoRoot: this.repoRoot,
+                            source: name === "index" ? "git-index" : "git-state",
+                        });
+                    }
+                }),
+            );
+        } catch {
+            /* .git may not be watchable for virtual roots or isolated test fixtures. */
         }
     }
 

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -1,6 +1,6 @@
 // WebviewViewProvider for the bottom panel commit graph.
 // Loads the CommitGraphApp React app, handles pagination, branch filtering,
-// and posts selected commit hashes back to the extension host..
+// and posts selected commit hashes back to the extension host.
 
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";

--- a/src/views/CommitGraphViewProvider.ts
+++ b/src/views/CommitGraphViewProvider.ts
@@ -1,6 +1,6 @@
 // WebviewViewProvider for the bottom panel commit graph.
 // Loads the CommitGraphApp React app, handles pagination, branch filtering,
-// and posts selected commit hashes back to the extension host.
+// and posts selected commit hashes back to the extension host..
 
 import * as vscode from "vscode";
 import { GitOps } from "../git/operations";

--- a/tests/unit/fixtures/harness.test.ts
+++ b/tests/unit/fixtures/harness.test.ts
@@ -25,8 +25,9 @@ import { MANIFEST_SCHEMA_VERSION, writeFixtureManifest } from "../../fixtures/re
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 describe("createFixtureWorkspace", () => {
     let cleanupDirs: string[] = [];

--- a/tests/unit/fixtures/manifest.test.ts
+++ b/tests/unit/fixtures/manifest.test.ts
@@ -179,7 +179,7 @@ describe("manifest", () => {
 
             expect(observedUnexpected).toBeNull();
             expect(observedMissing + observedValid).toBeGreaterThan(0);
-        }, 30_000);
+        });
     });
 
     describe("hard failures -- distinct message per cause", () => {
@@ -426,7 +426,7 @@ describe("manifest", () => {
 
             const entries = await readdir(workDir);
             expect(entries).toEqual(["manifest.json"]);
-        }, 30_000);
+        });
     });
 
     describe("directory hygiene", () => {

--- a/tests/unit/fixtures/rehydrate.test.ts
+++ b/tests/unit/fixtures/rehydrate.test.ts
@@ -33,9 +33,10 @@ import { DECLARED_REWRITES, rehydrateCopy } from "../../fixtures/repo/rehydrate"
 import { snapshotWorkspace, type PlaceholderRoots } from "../../fixtures/repo/snapshot";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 /** `grep -rIl` over `root` for the literal `needle`, tolerating grep's "no match" exit code (1)
  * as an empty result rather than a thrown error -- independent of any production code under test. */

--- a/tests/unit/fixtures/resourceCleanup.test.ts
+++ b/tests/unit/fixtures/resourceCleanup.test.ts
@@ -14,8 +14,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFixtureWorkspace, type FixtureWorkspace } from "../../fixtures/repo/harness";
 import { gitSpellingOf } from "../../helpers/gitPathSpelling";
 import { git } from "./gitTestHelpers";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 const execFileAsync = promisify(execFile);
 
 const { rmMock } = vi.hoisted(() => ({ rmMock: vi.fn() }));

--- a/tests/unit/fixtures/restoreFidelity.test.ts
+++ b/tests/unit/fixtures/restoreFidelity.test.ts
@@ -25,8 +25,9 @@ import {
 } from "../../fixtures/repo/phase6Snapshot";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 import { git } from "./gitTestHelpers";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 interface SeededManifestFixture {
     readonly template: FixtureTemplate;

--- a/tests/unit/fixtures/runFixtureSetup.test.ts
+++ b/tests/unit/fixtures/runFixtureSetup.test.ts
@@ -28,8 +28,9 @@ import {
     runFixtureSetup,
 } from "../../fixtures/repo/runFixtureSetup";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 async function exists(candidate: string): Promise<boolean> {
     try {

--- a/tests/unit/fixtures/runFixtureTeardown.test.ts
+++ b/tests/unit/fixtures/runFixtureTeardown.test.ts
@@ -22,8 +22,9 @@ import {
 import { runFixtureSetup } from "../../fixtures/repo/runFixtureSetup";
 import { runFixtureTeardown } from "../../fixtures/repo/runFixtureTeardown";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 async function exists(candidate: string): Promise<boolean> {
     try {

--- a/tests/unit/fixtures/scenarios.independence.test.ts
+++ b/tests/unit/fixtures/scenarios.independence.test.ts
@@ -20,8 +20,9 @@ import {
     trackScratchHome,
 } from "./scenariosTestHelpers";
 import { REPOSITORY_SCENARIO_IDS } from "../../fixtures/repo/scenarios";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 afterAll(removeTrackedScratchDirectories);
 

--- a/tests/unit/fixtures/seed.test.ts
+++ b/tests/unit/fixtures/seed.test.ts
@@ -29,6 +29,7 @@ import {
 import { OVERLONG_NAMES_FAIL_REMOVAL } from "../../helpers/platformCapabilities";
 import { createScratchWorkspaces } from "./scratchWorkspaces";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
 
@@ -76,7 +77,7 @@ describe("seedFixtureTemplate", () => {
         scratch.register(templateA.home);
         templateB = await seedFixtureTemplate(destinationB);
         scratch.register(templateB.home);
-    }, 60_000);
+    }, withWindowsHeadroom(60_000));
 
     afterAll(async () => {
         await scratch.removeAll();
@@ -443,7 +444,7 @@ describe("seedFixtureTemplate failure cleanup", () => {
         }
 
         expect(await readdir(homeParent)).toEqual([]);
-    }, 30_000);
+    });
 });
 
 /**

--- a/tests/unit/fixtures/seedDeterminism.test.ts
+++ b/tests/unit/fixtures/seedDeterminism.test.ts
@@ -21,9 +21,10 @@ import {
     type FixtureSnapshot,
 } from "../../fixtures/repo/phase6Snapshot";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 async function run(
     command: string,

--- a/tests/unit/fixtures/snapshot.test.ts
+++ b/tests/unit/fixtures/snapshot.test.ts
@@ -46,8 +46,9 @@ import {
 // `EBUSY: resource busy or locked, rmdir ...\not-a-repo` on the row whose own assertions had all
 // passed (#223). Retrying past writes the test does not control is what the helper exists for.
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 const UNUSED_PROFILE_DIR = "/nonexistent/profile";
 
 function buildDurableStateSnapshot(

--- a/tests/unit/fixtures/snapshotNormalize.test.ts
+++ b/tests/unit/fixtures/snapshotNormalize.test.ts
@@ -34,6 +34,7 @@ import type { FsEntry } from "../../fixtures/repo/snapshotTypes";
 import { captured, notCaptured } from "../../fixtures/repo/snapshotTypes";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 /**
  * The two tests below each seed a git template and then copy the whole tree -- `.git` included --
@@ -49,7 +50,7 @@ import { removeScratchDirectories } from "../../helpers/scratchDirectories";
  * Sized at roughly 12x the measured Windows cost rather than at that bad day, because one
  * observed swing is a floor on the variance, not a ceiling.
  */
-const COPY_HEAVY_TIMEOUT_MS = 90_000;
+const COPY_HEAVY_TIMEOUT_MS = withWindowsHeadroom(90_000);
 
 describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8's real scenario)", () => {
     let scratchDirs: string[] = [];

--- a/tests/unit/fixtures/workspaceIsolation.test.ts
+++ b/tests/unit/fixtures/workspaceIsolation.test.ts
@@ -19,8 +19,9 @@ import {
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 describe("Phase 6 step 35 -- workspace isolation", () => {
     let workspaces: FixtureWorkspace[] = [];

--- a/tests/unit/git/gitDirectory.test.ts
+++ b/tests/unit/git/gitDirectory.test.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveGitCommonDir, resolveGitDir } from "../../../src/git/gitDirectory";
+import { removeScratchDirectoriesSync } from "../../helpers/scratchDirectories";
+
+// These run against the real filesystem on purpose. The behaviour under test is how Git lays a
+// linked worktree out on disk -- a `.git` pointer file, a `commondir` pointer beside it -- so a
+// mocked `fs` would be asserting this file's own idea of that layout rather than Git's.
+let fixture: string | undefined;
+
+afterEach(() => {
+    if (fixture) removeScratchDirectoriesSync(fixture);
+    fixture = undefined;
+});
+
+/** Builds a main checkout plus one linked worktree, laid out the way `git worktree add` does. */
+function makeWorktreeFixture(): { mainGitDir: string; worktreeRoot: string } {
+    fixture = mkdtempSync(path.join(tmpdir(), "intelligit-gitdir-"));
+    const mainGitDir = path.join(fixture, "main", ".git");
+    const worktreeGitDir = path.join(mainGitDir, "worktrees", "wt");
+    const worktreeRoot = path.join(fixture, "wt");
+    mkdirSync(path.join(mainGitDir, "refs", "remotes", "origin"), { recursive: true });
+    mkdirSync(path.join(worktreeGitDir, "refs"), { recursive: true });
+    mkdirSync(worktreeRoot, { recursive: true });
+    writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
+    writeFileSync(path.join(worktreeRoot, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    return { mainGitDir, worktreeRoot };
+}
+
+describe("resolveGitCommonDir", () => {
+    it("follows a linked worktree's commondir pointer to the shared Git directory", () => {
+        const { mainGitDir, worktreeRoot } = makeWorktreeFixture();
+        expect(resolveGitCommonDir(worktreeRoot)).toBe(mainGitDir);
+    });
+
+    // Guards the pair, not just the new resolver: per-worktree state (HEAD, index, rebase files)
+    // must keep resolving to the worktree's own directory, or moving refs onto the common one
+    // would have dragged every other caller of `resolveGitDir` along with it.
+    it("leaves the per-worktree Git directory pointing at the worktree", () => {
+        const { mainGitDir, worktreeRoot } = makeWorktreeFixture();
+        expect(resolveGitDir(worktreeRoot)).toBe(path.join(mainGitDir, "worktrees", "wt"));
+    });
+
+    it("returns the repository's own Git directory when there is no worktree pointer", () => {
+        fixture = mkdtempSync(path.join(tmpdir(), "intelligit-gitdir-"));
+        const repoRoot = path.join(fixture, "repo");
+        mkdirSync(path.join(repoRoot, ".git", "refs"), { recursive: true });
+        expect(resolveGitCommonDir(repoRoot)).toBe(path.join(repoRoot, ".git"));
+    });
+});

--- a/tests/unit/services/repositoryChangeEvents.test.ts
+++ b/tests/unit/services/repositoryChangeEvents.test.ts
@@ -39,6 +39,11 @@ const mocks = vi.hoisted(() => ({
         dispose: ReturnType<typeof vi.fn>;
     }>,
     fsWatchers: [] as unknown[],
+    /** Every directory handed to a watcher, by whichever route the platform takes. */
+    watchedPaths: [] as string[],
+    /** Per-root overrides for the two Git directory resolvers, keyed by normalized root. */
+    gitDirs: {} as Record<string, string>,
+    commonDirs: {} as Record<string, string>,
     documentChangeHandlers: [] as Array<(event: { document: FakeDocument }) => void>,
     documentSaveHandlers: [] as Array<(document: FakeDocument) => void>,
 }));
@@ -84,7 +89,8 @@ vi.mock("vscode", () => {
             onDidCreateFiles: vi.fn(() => disposable()),
             onDidDeleteFiles: vi.fn(() => disposable()),
             onDidRenameFiles: vi.fn(() => disposable()),
-            createFileSystemWatcher: vi.fn(() => {
+            createFileSystemWatcher: vi.fn((pattern: { baseUri: { fsPath: string } }) => {
+                mocks.watchedPaths.push(pattern.baseUri.fsPath);
                 const watcher = {
                     onDidChange: vi.fn(() => disposable()),
                     onDidCreate: vi.fn(() => disposable()),
@@ -104,14 +110,18 @@ vi.mock("vscode", () => {
 vi.mock("fs", async () => {
     const { EventEmitter: NodeEventEmitter } = await import("node:events");
     return {
-        watch: vi.fn(() => {
+        watch: vi.fn((target: string) => {
+            mocks.watchedPaths.push(target);
             const watcher = Object.assign(new NodeEventEmitter(), { close: vi.fn() });
             mocks.fsWatchers.push(watcher);
             return watcher;
         }),
     };
 });
-vi.mock("../../../src/git/gitDirectory", () => ({ resolveGitDir: () => "/repo/.git" }));
+vi.mock("../../../src/git/gitDirectory", () => ({
+    resolveGitDir: (root: string) => mocks.gitDirs[root] ?? "/repo/.git",
+    resolveGitCommonDir: (root: string) => mocks.commonDirs[root] ?? "/repo/.git",
+}));
 
 import { EventEmitter } from "node:events";
 import { subscribeToRepositoryWorkingTreeChanges } from "../../../src/services/repositoryChangeEvents";
@@ -120,6 +130,9 @@ afterEach(() => {
     mocks.disposables.length = 0;
     mocks.watchers.length = 0;
     mocks.fsWatchers.length = 0;
+    mocks.watchedPaths.length = 0;
+    for (const key of Object.keys(mocks.gitDirs)) delete mocks.gitDirs[key];
+    for (const key of Object.keys(mocks.commonDirs)) delete mocks.commonDirs[key];
     mocks.documentChangeHandlers.length = 0;
     mocks.documentSaveHandlers.length = 0;
     vi.clearAllMocks();
@@ -164,6 +177,26 @@ describe("repository working-tree changes", () => {
         } finally {
             canonical.dispose();
             alternate?.dispose();
+        }
+    });
+
+    // A linked worktree's own Git directory keeps `refs` permanently empty: Git writes every
+    // ref -- including the remote-tracking ref a push moves -- into the shared common
+    // directory. Watching the worktree's own `refs` arms a directory nothing ever writes to,
+    // so a push from a worktree publishes no `git-refs` event, no full refresh runs, and the
+    // branch column's ahead count keeps counting commits that are already pushed (#147).
+    it("watches the shared refs directory for a linked worktree, not the worktree's own", () => {
+        const worktree = fixtureRoot("/wt");
+        mocks.gitDirs[worktree] = path.join(fixtureRoot("/main"), ".git", "worktrees", "wt");
+        mocks.commonDirs[worktree] = path.join(fixtureRoot("/main"), ".git");
+        const subscription = subscribeToRepositoryWorkingTreeChanges(worktree, vi.fn());
+        try {
+            expect(
+                mocks.watchedPaths,
+                "the refs watcher is armed on the worktree's own Git directory, whose refs tree Git never writes to",
+            ).toContain(path.join(fixtureRoot("/main"), ".git", "refs"));
+        } finally {
+            subscription.dispose();
         }
     });
 

--- a/tests/unit/services/repositoryChangeEvents.test.ts
+++ b/tests/unit/services/repositoryChangeEvents.test.ts
@@ -25,7 +25,7 @@ const REPO_A = fixtureRoot("/repo-a");
 const REPO_B = fixtureRoot("/repo-b");
 
 /** The shape of a real `fs.FSWatcher` this suite depends on: an emitter that can be closed. */
-type FakeFsWatcher = EventEmitter & { close: ReturnType<typeof vi.fn> };
+type FakeFsWatcher = EventEmitter & { close: ReturnType<typeof vi.fn>; target: string };
 
 /** The two `TextDocument` members the workspace route reads. */
 type FakeDocument = { uri: { fsPath: string }; isDirty: boolean };
@@ -106,13 +106,19 @@ vi.mock("vscode", () => {
 
 // A real `EventEmitter`, not a stub with an `on` spy. The defect under test is Node's own
 // rule that an `error` event with no listener is rethrown as an uncaught exception, so a
-// hand-rolled fake would decide the outcome the assertion is supposed to measure.
+// hand-rolled fake would decide the outcome the assertion is supposed to measure. Node also
+// attaches the listener passed to `fs.watch` to that emitter's `change` event, so a test
+// reports a write inside a watched directory by emitting `change` on its handle.
 vi.mock("fs", async () => {
     const { EventEmitter: NodeEventEmitter } = await import("node:events");
     return {
-        watch: vi.fn((target: string) => {
+        watch: vi.fn((target: string, ...rest: unknown[]) => {
             mocks.watchedPaths.push(target);
-            const watcher = Object.assign(new NodeEventEmitter(), { close: vi.fn() });
+            const watcher = Object.assign(new NodeEventEmitter(), { close: vi.fn(), target });
+            const listener = rest.find(
+                (arg): arg is (...args: unknown[]) => void => typeof arg === "function",
+            );
+            if (listener) watcher.on("change", listener);
             mocks.fsWatchers.push(watcher);
             return watcher;
         }),
@@ -195,6 +201,43 @@ describe("repository working-tree changes", () => {
                 mocks.watchedPaths,
                 "the refs watcher is armed on the worktree's own Git directory, whose refs tree Git never writes to",
             ).toContain(path.join(fixtureRoot("/main"), ".git", "refs"));
+        } finally {
+            subscription.dispose();
+        }
+    });
+
+    // `packed-refs` is shared state too, but unlike `refs` a linked worktree's own Git directory
+    // has no copy of it: Git keeps the one file in the common directory. Deleting a packed ref --
+    // `fetch --prune` dropping a gone upstream, `push --delete` dropping its tracking ref -- leaves
+    // its only lasting change in that file, so a worktree whose watcher cannot see it keeps a
+    // stale ahead count. The common directory also holds the main checkout's own `HEAD` and
+    // `index`, which say nothing about this worktree and must not refresh it.
+    it("publishes a git-state change when a linked worktree's shared packed-refs is rewritten", () => {
+        const worktree = fixtureRoot("/wt");
+        const commonDir = path.join(fixtureRoot("/main"), ".git");
+        mocks.gitDirs[worktree] = path.join(commonDir, "worktrees", "wt");
+        mocks.commonDirs[worktree] = commonDir;
+        const listener = vi.fn();
+        const subscription = subscribeToRepositoryWorkingTreeChanges(worktree, listener);
+        try {
+            const commonDirWatcher = fsWatchers().find((watcher) => watcher.target === commonDir);
+            expect(
+                commonDirWatcher,
+                "nothing watches the common directory, the only place a linked worktree's packed-refs lives",
+            ).toBeDefined();
+
+            commonDirWatcher?.emit("change", "rename", "packed-refs");
+            expect(
+                listener,
+                "a packed-refs rewrite published no git-state change, so no full refresh recomputes the ahead count",
+            ).toHaveBeenCalledWith({ repoRoot: worktree, source: "git-state" });
+
+            listener.mockClear();
+            commonDirWatcher?.emit("change", "change", "HEAD");
+            expect(
+                listener,
+                "the main checkout's HEAD moved and refreshed a worktree whose HEAD did not",
+            ).not.toHaveBeenCalled();
         } finally {
             subscription.dispose();
         }


### PR DESCRIPTION
Fixes #147.

## The bug

Pushing from a linked worktree left the branch column still showing `↑N` for commits it had just pushed. It cleared only when something unrelated happened later.

## Root cause

The ahead count is only recomputed by `RefreshService.debouncedFullRefresh()`, and after a push the only thing that schedules one is the `git-refs` watcher in `repositoryChangeEvents.ts`.

That watcher was armed on `resolveGitDir(root)/refs`. In a linked worktree `resolveGitDir` correctly returns `<main>/.git/worktrees/<name>` — the right answer for `HEAD`, `index`, and in-progress rebase/merge state — but its `refs/` subdirectory is one Git creates and never writes to. Refs are shared: verified on a real repository that a push from a worktree touches only

```
<main>/.git/refs/heads/<branch>
<main>/.git/refs/remotes/origin/<branch>
```

with nothing under the worktree's own Git directory. So the watcher observed a directory that never changes, no `git-refs` event fired, and no full refresh ran.

A plain checkout was unaffected: there `gitDir === commonDir`, so the old path was already the right one.

## The fix

`resolveGitCommonDir` follows the `commondir` pointer file Git writes beside a linked worktree's `HEAD`, and the refs watcher uses it. `resolveGitDir` is unchanged, and every caller that reads genuinely per-worktree state keeps using it.

## Tests

- `tests/unit/git/gitDirectory.test.ts` (new) — real filesystem, no `fs` mock, because the behaviour under test is Git's on-disk layout: pointer followed for a worktree, `resolveGitDir` still worktree-scoped, plain repository falls back to its own `.git`.
- `tests/unit/services/repositoryChangeEvents.test.ts` — the reproducing test: the refs watcher must be armed on the shared directory.

Mutation-proved, each red naming its own assertion and no other:

| Mutation | Red |
| --- | --- |
| `resolveGitCommonDir` ignores the `commondir` pointer | `follows a linked worktree's commondir pointer to the shared Git directory` |
| `resolveGitCommonDir` always climbs two levels (no fallback) | `returns the repository's own Git directory when there is no worktree pointer` |
| refs watcher back on the per-worktree Git directory | `watches the shared refs directory for a linked worktree, not the worktree's own` |

## Verified

- All nine pre-commit gates green (`format:check`, `lint:strict`, `deps:check:strict`, `architecture:check`, `l10n:validate`, `l10n:audit`, `typecheck` ×3, `build`, `vsce package`).
- `bun run test` — 4819/4820. The one failure, `merge-editor-performance … keeps accepted diff-viewer tiers within the measured render target`, is a render-timing budget; it passes in isolation and nothing in this diff is reachable from the merge editor.

## Follow-up commits

- **Shared `packed-refs`** (`4ebbca0c` test, `3a354bf9` fix, from the CodeRabbit review). A linked worktree's own Git directory has no `packed-refs`; Git keeps the one shared file in the common directory. Deleting a packed ref (`fetch --prune`, `push --delete`) leaves its only lasting change in that file, and the git-state watcher never saw it. For a linked worktree the watcher now also watches the common directory, taking only `packed-refs` from it, since that directory's `HEAD` and `index` belong to the main checkout. A plain checkout is unchanged. The regression test in `tests/unit/services/repositoryChangeEvents.test.ts` covers the linked-worktree case.
- **Windows test timeouts** (`4895f8ff`). The fixture suites passed their own 30–90 s timeouts, which override the 180 s Windows floor `vitest.config.ts` takes from `harnessTimeouts()`. They are now wrapped in `withWindowsHeadroom`; Linux and macOS keep their numbers.
- **Release** (`c74651be`). Version 0.32.6, with a CHANGELOG entry saying what worktree users will notice: the push count clears right after a push, and other branch changes, such as a fetch or a deleted branch, show up straight away.

## Not done

Not exercised in the Extension Development Host.

https://claude.ai/code/session_01TdNkf3WvDZAMWu3mJWNr1v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving shared Git directories in linked worktrees.
  - Improved Git repository change detection by monitoring shared references and packed reference updates.

- **Bug Fixes**
  - Git ref changes in linked worktrees are now detected reliably, including changes made through the main checkout.

- **Tests**
  - Added coverage for shared Git directory resolution and linked-worktree monitoring.
  - Improved test timeout handling on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
