### PR TITLE
fix: confirm worktree deletion and stop offering to open the active one (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to IntelliGit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.7] - 2026-09-11
+
+### Fixed
+
+- Deleting a Git worktree (an extra folder checked out from the same repository) now always asks you to confirm first. Before, IntelliGit only asked when the worktree had uncommitted changes, so a worktree without any was deleted straight away.
+- Clicking the worktree you are already working in no longer asks whether to open it in the current window or in a new window. Both choices only opened the same folder again.
+
 ## [0.32.6] - 2026-09-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "intelligit",
     "displayName": "IntelliGit",
     "description": "%extension.description%",
-    "version": "0.32.6",
+    "version": "0.32.7",
     "publisher": "MaheshKok",
     "icon": "media/intelligit-icon.png",
     "license": "MIT",

--- a/src/services/worktreeService.ts
+++ b/src/services/worktreeService.ts
@@ -133,7 +133,7 @@ export class WorktreeService implements vscode.Disposable {
         return this.refresh();
     }
 
-    /** Remove a non-current, non-main worktree after dirty-state confirmation. */
+    /** Remove a non-current, non-main worktree after confirmation. */
     async removeWorktree(worktreePath: string): Promise<GitWorktree[] | undefined> {
         const worktrees = await this.listWorktrees();
         const target = path.resolve(worktreePath);
@@ -145,15 +145,17 @@ export class WorktreeService implements vscode.Disposable {
 
         const dirtyOutput = await this.createExecutor(worktree.path).run(["status", "--porcelain"]);
         const force = dirtyOutput.trim().length > 0;
-        if (force) {
-            const confirm = vscode.l10n.t("Delete Worktree");
-            const picked = await vscode.window.showWarningMessage(
-                vscode.l10n.t("Worktree has uncommitted changes. Delete it anyway?"),
-                { modal: true },
-                confirm,
-            );
-            if (picked !== confirm) return undefined;
-        }
+        // Removing a worktree deletes a checkout, so both paths confirm. The dirty one keeps its
+        // stronger wording because it also discards uncommitted work.
+        const confirm = vscode.l10n.t("Delete Worktree");
+        const picked = await vscode.window.showWarningMessage(
+            force
+                ? vscode.l10n.t("Worktree has uncommitted changes. Delete it anyway?")
+                : vscode.l10n.t("Delete {path}?", { path: worktree.path }),
+            { modal: true },
+            confirm,
+        );
+        if (picked !== confirm) return undefined;
 
         await removeGitWorktree(this.executor, worktree.path, force);
         return this.refresh();

--- a/src/webviews/react/branch-column/BranchColumnSections.tsx
+++ b/src/webviews/react/branch-column/BranchColumnSections.tsx
@@ -272,7 +272,12 @@ function WorktreeRow({
 }): React.ReactElement {
     const label = getWorktreeLabel(worktree);
     const folderName = getPathBasename(worktree.path);
-    const activate = (): void => onAction?.("open", worktree.path);
+    // Opening the worktree already checked out offers a choice between reloading the window
+    // onto itself and opening a second window on the same folder. The context-menu handlers
+    // below already refuse for the current worktree; this keeps the click consistent with them.
+    const activate = (): void => {
+        if (!worktree.isCurrent) onAction?.("open", worktree.path);
+    };
     return (
         <button
             type="button"

--- a/tests/unit/services/worktreeService.test.ts
+++ b/tests/unit/services/worktreeService.test.ts
@@ -92,6 +92,10 @@ function createScopedExecutor(statusOutput: string): {
 
 describe("WorktreeService", () => {
     afterEach(async () => {
+        // `mockResolvedValueOnce` queues survive the test that set them. A row whose prompt
+        // never fires would hand its unconsumed answer to the next row, so a single defect
+        // reds two tests and the second red accuses the wrong code.
+        showWarningMessage.mockReset();
         includeFiles.value = [];
         await Promise.all(tempRoots.splice(0).map((root) => removeScratchDirectories(root)));
     });
@@ -314,6 +318,7 @@ describe("WorktreeService", () => {
         const scoped = createScopedExecutor("");
         const service = new WorktreeService(executor, () => fixturePath("/repo"), scoped.factory);
 
+        showWarningMessage.mockResolvedValueOnce("Delete Worktree");
         await service.removeWorktree(fixturePath("/worktrees/feature"));
 
         expect(scoped.runs).toHaveLength(1);
@@ -325,6 +330,36 @@ describe("WorktreeService", () => {
             fixturePath("/worktrees/feature"),
         ]);
         expect(executor.run).not.toHaveBeenCalledWith(expect.arrayContaining(["branch"]));
+    });
+
+    // Deleting a worktree throws away a checkout, and until now a clean one went without a
+    // word (#150). The dirty path already confirmed, so this covers the case that did not:
+    // declining must leave the worktree on disk.
+    it("asks before removing a clean worktree and leaves it alone when the answer is no", async () => {
+        const executor = createExecutor([
+            porcelainRecords([
+                { path: fixturePath("/repo"), branch: "main" },
+                { path: fixturePath("/worktrees/feature"), branch: "feature/x" },
+            ]),
+            "",
+            porcelain("main"),
+        ]);
+        const scoped = createScopedExecutor("");
+        const service = new WorktreeService(executor, () => fixturePath("/repo"), scoped.factory);
+
+        showWarningMessage.mockResolvedValueOnce(undefined);
+        const result = await service.removeWorktree(fixturePath("/worktrees/feature"));
+
+        expect(
+            showWarningMessage,
+            "a clean worktree was deleted without asking",
+        ).toHaveBeenCalled();
+        expect(result, "declining the prompt still removed the worktree").toBeUndefined();
+        expect(executor.run).not.toHaveBeenCalledWith([
+            "worktree",
+            "remove",
+            fixturePath("/worktrees/feature"),
+        ]);
     });
 
     it("requires explicit confirmation before force-removing a dirty worktree", async () => {

--- a/tests/webview/unit/worktree-row-actions.test.tsx
+++ b/tests/webview/unit/worktree-row-actions.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BranchColumnSections } from "../../../src/webviews/react/branch-column/BranchColumnSections";
+import type { GitWorktree } from "../../../src/types";
+import { initReactDomTestEnvironment, mount, unmount } from "../../helpers/reactDomTestUtils";
+import { installWebviewI18n } from "../../helpers/webviewI18nTestUtils";
+
+initReactDomTestEnvironment();
+installWebviewI18n();
+
+const CURRENT: GitWorktree = {
+    path: "/repo/worktrees/active",
+    head: "a".repeat(40),
+    branch: "active",
+    state: "linked",
+    isMain: false,
+    isCurrent: true,
+    isLocked: false,
+    isPrunable: false,
+};
+
+const OTHER: GitWorktree = {
+    ...CURRENT,
+    path: "/repo/worktrees/other",
+    branch: "other",
+    isCurrent: false,
+};
+
+function renderWorktrees(): {
+    container: HTMLDivElement;
+    root: ReturnType<typeof mount>["root"];
+    onWorktreeAction: ReturnType<typeof vi.fn>;
+} {
+    const onWorktreeAction = vi.fn();
+    const view = mount(
+        <BranchColumnSections
+            selectedBranch={null}
+            expandedSections={new Set(["worktrees"])}
+            expandedFolders={new Set()}
+            localTree={[]}
+            remoteGroups={new Map()}
+            worktrees={[CURRENT, OTHER]}
+            filteredWorktrees={[CURRENT, OTHER]}
+            filterNeedle=""
+            locals={[]}
+            remotes={[]}
+            selectedBranchNames={new Set()}
+            onSelectBranch={vi.fn()}
+            onClearSelectedBranches={vi.fn()}
+            onToggleSection={vi.fn()}
+            onToggleFolder={vi.fn()}
+            onBranchClick={vi.fn()}
+            onBranchContextMenu={vi.fn()}
+            onOpenBranchContextMenuFromRow={vi.fn()}
+            onWorktreeAction={onWorktreeAction}
+            onWorktreeContextMenu={vi.fn()}
+            onOpenWorktreeContextMenuFromRow={vi.fn()}
+        />,
+    );
+    return { ...view, onWorktreeAction };
+}
+
+function clickWorktree(container: HTMLDivElement, path: string): void {
+    const row = container.querySelector<HTMLElement>(`[data-worktree-path="${path}"]`);
+    if (!row) throw new Error(`No worktree row rendered for ${path}`);
+    act(() => row.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+describe("worktree rows", () => {
+    // `open` is what raises the "Open in Current Window / Open in New Window" picker. Offering
+    // that for the worktree already open is a choice between reloading the window onto itself
+    // and opening a second window onto the same folder (#150). The right-click and keyboard
+    // menu handlers on this row already refuse for the current worktree; the click did not.
+    it("does not raise the open action for the worktree already checked out", () => {
+        const { container, root, onWorktreeAction } = renderWorktrees();
+        try {
+            clickWorktree(container, CURRENT.path);
+            expect(
+                onWorktreeAction,
+                "clicking the active worktree asked which window to open it in",
+            ).not.toHaveBeenCalled();
+        } finally {
+            unmount(root, container);
+        }
+    });
+
+    // The control for the mutation above: without this, disabling the click outright would
+    // still pass, and the section would become inert for every worktree.
+    it("still opens another worktree on click", () => {
+        const { container, root, onWorktreeAction } = renderWorktrees();
+        try {
+            clickWorktree(container, OTHER.path);
+            expect(onWorktreeAction).toHaveBeenCalledWith("open", OTHER.path);
+        } finally {
+            unmount(root, container);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #150. Two bugs from one report.

## 1. A clean worktree was deleted with no confirmation

`WorktreeService.removeWorktree` only prompted inside the `force` branch — the one taken when `git status --porcelain` came back non-empty. A clean worktree went straight to `git worktree remove` on the first click, even though that deletes a checkout.

Both paths confirm now. The dirty one keeps its stronger wording ("Worktree has uncommitted changes. Delete it anyway?") because it also discards uncommitted work; the clean one reuses `Delete {path}?`, the string `panelFileActions.ts` and `repositoryCommands.ts` already use for delete confirmations, so nothing new enters the catalogs and all 11 locales are already translated.

## 2. Clicking the active worktree offered to open it

`WorktreeRow`'s `onClick` fired `onAction("open", path)` unconditionally, which raises the "Open in Current Window / Open in New Window" picker — a choice between reloading the window onto itself and opening a second window on the same folder. The row's `onContextMenu` and `onKeyDown` handlers already guarded on `!worktree.isCurrent`; only the click did not.

## Tests

- `tests/unit/services/worktreeService.test.ts` — new: declining the prompt on a clean worktree leaves it on disk.
- `tests/webview/unit/worktree-row-actions.test.tsx` (new file) — clicking the current worktree raises nothing; clicking another still opens it.

Two existing tests were updated rather than the code being bent to keep them green:

- `removes a clean worktree without force and leaves branches untouched` encoded the old no-prompt behaviour, so it now answers the prompt. Its actual subject — that a clean removal runs without `--force` and touches no branch — is unchanged.
- The suite's `afterEach` now resets `showWarningMessage`. `mockResolvedValueOnce` queues outlive the test that set them, so a row whose prompt never fires hands its unconsumed answer to the next row; without this, one defect reddened two tests and the second red accused the wrong code.

Mutation-proved, each red naming its own assertion and no other:

| Mutation | Red |
| --- | --- |
| confirmation only on the dirty path again | `asks before removing a clean worktree…` → "a clean worktree was deleted without asking" |
| worktree row click unguarded again | `does not raise the open action for the worktree already checked out` |
| worktree row click disabled for every worktree | `still opens another worktree on click` |

## Verified

- All nine pre-commit gates green (`format:check`, `lint:strict`, `deps:check:strict`, `architecture:check`, `l10n:validate`, `l10n:audit`, `typecheck` ×3, `build`, `vsce package`). `l10n:audit` reports 0 strings missing from the English catalog.
- `bun run test` — 4817/4819. The two failures, `merge-editor-performance … measured render target` and `diffBudgets … measured tiers within the host targets`, are render-timing budgets (the pair `INTELLIGIT_SKIP_TIMING_BUDGETS=1` exists for); both pass in isolation and neither test can reach anything in this diff.

## Not done

Not exercised in the Extension Development Host.

https://claude.ai/code/session_01TdNkf3WvDZAMWu3mJWNr1v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worktree deletion now always requires confirmation, with tailored messaging for worktrees that contain uncommitted changes.
  - Clicking the currently checked-out worktree no longer triggers an unnecessary open action.
  - Declining deletion confirmation now safely leaves the worktree unchanged.

- **Tests**
  - Added coverage for worktree deletion confirmations and branch-column click behavior.

- **Chores**
  - Updated the application version to 0.32.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->