### PR TITLE
fix: keep one selection ring across the commit lists (#246)

### DIFF
--- a/src/webviews/react/NativeCommitGraph.tsx
+++ b/src/webviews/react/NativeCommitGraph.tsx
@@ -147,6 +147,9 @@ export function NativeCommitGraph({
     const loadingMore = useRef(false);
     const selectedHashRef = useRef<string | null>(selectedHash);
     const selectFirstOnNextLoadRef = useRef(false);
+    // Hashes of the rows this list currently shows. A selected hash outside them was picked in
+    // another list (#246), so a refresh keeps it instead of re-selecting this list's first row.
+    const loadedHashesRef = useRef(new Set<string>());
     selectedHashRef.current = selectedHash;
     const currentBranch = useMemo(
         () => branches.find((branch) => branch.isCurrent && !branch.isRemote),
@@ -178,7 +181,10 @@ export function NativeCommitGraph({
                     const preservesSelectedHash =
                         !data.append &&
                         previousSelectedHash !== null &&
-                        data.commits.some((commit) => commit.hash === previousSelectedHash);
+                        (data.commits.some((commit) => commit.hash === previousSelectedHash) ||
+                            !loadedHashesRef.current.has(previousSelectedHash));
+                    if (!data.append) loadedHashesRef.current = new Set();
+                    for (const commit of data.commits) loadedHashesRef.current.add(commit.hash);
                     const nextSelectedHash = forceFirstCommit
                         ? firstCommitHash
                         : preservesSelectedHash
@@ -216,6 +222,11 @@ export function NativeCommitGraph({
                     break;
                 case "setFilterText":
                     dispatch({ type: "setFilterText", text: data.text });
+                    break;
+                case "setCommitDetail":
+                    // Every commit list receives the detail another list selected; ring that row.
+                    selectedHashRef.current = data.detail.hash;
+                    dispatch({ type: "selectCommit", hash: data.detail.hash });
                     break;
                 case "setBranches":
                     dispatch({

--- a/src/webviews/react/commit-graph/useCommitGraphMessages.ts
+++ b/src/webviews/react/commit-graph/useCommitGraphMessages.ts
@@ -35,6 +35,9 @@ export function useCommitGraphMessages(params: {
     } = params;
     const selectedHashRef = useRef<string | null>(selectedHash);
     const selectFirstOnNextLoadRef = useRef(false);
+    // Hashes of the rows this list currently shows. A selected hash outside them was picked in
+    // another list (#246), so a refresh keeps it instead of re-selecting this list's first row.
+    const loadedHashesRef = useRef(new Set<string>());
     selectedHashRef.current = selectedHash;
     // Held in a ref for the same reason as `selectedHashRef`: this effect owns the single
     // `ready` post and the window subscription, so its dependency list must stay fixed. Naming
@@ -68,7 +71,10 @@ export function useCommitGraphMessages(params: {
                     const preservesSelectedHash =
                         !data.append &&
                         previousSelectedHash !== null &&
-                        data.commits.some((commit) => commit.hash === previousSelectedHash);
+                        (data.commits.some((commit) => commit.hash === previousSelectedHash) ||
+                            !loadedHashesRef.current.has(previousSelectedHash));
+                    if (!data.append) loadedHashesRef.current = new Set();
+                    for (const commit of data.commits) loadedHashesRef.current.add(commit.hash);
                     const nextSelectedHash = forceFirstCommit
                         ? firstCommitHash
                         : preservesSelectedHash
@@ -120,6 +126,9 @@ export function useCommitGraphMessages(params: {
                     dispatch({ type: "setFilterText", text: data.text });
                     break;
                 case "setCommitDetail":
+                    // Every commit list receives the detail another list selected; ring that row.
+                    selectedHashRef.current = data.detail.hash;
+                    dispatch({ type: "selectCommit", hash: data.detail.hash });
                     dispatch({
                         type: "setCommitDetail",
                         detail: data.detail,

--- a/tests/unit/fixtures/harness.test.ts
+++ b/tests/unit/fixtures/harness.test.ts
@@ -25,8 +25,9 @@ import { MANIFEST_SCHEMA_VERSION, writeFixtureManifest } from "../../fixtures/re
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 describe("createFixtureWorkspace", () => {
     let cleanupDirs: string[] = [];

--- a/tests/unit/fixtures/manifest.test.ts
+++ b/tests/unit/fixtures/manifest.test.ts
@@ -179,7 +179,7 @@ describe("manifest", () => {
 
             expect(observedUnexpected).toBeNull();
             expect(observedMissing + observedValid).toBeGreaterThan(0);
-        }, 30_000);
+        });
     });
 
     describe("hard failures -- distinct message per cause", () => {
@@ -426,7 +426,7 @@ describe("manifest", () => {
 
             const entries = await readdir(workDir);
             expect(entries).toEqual(["manifest.json"]);
-        }, 30_000);
+        });
     });
 
     describe("directory hygiene", () => {

--- a/tests/unit/fixtures/rehydrate.test.ts
+++ b/tests/unit/fixtures/rehydrate.test.ts
@@ -33,9 +33,10 @@ import { DECLARED_REWRITES, rehydrateCopy } from "../../fixtures/repo/rehydrate"
 import { snapshotWorkspace, type PlaceholderRoots } from "../../fixtures/repo/snapshot";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 /** `grep -rIl` over `root` for the literal `needle`, tolerating grep's "no match" exit code (1)
  * as an empty result rather than a thrown error -- independent of any production code under test. */

--- a/tests/unit/fixtures/resourceCleanup.test.ts
+++ b/tests/unit/fixtures/resourceCleanup.test.ts
@@ -14,8 +14,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFixtureWorkspace, type FixtureWorkspace } from "../../fixtures/repo/harness";
 import { gitSpellingOf } from "../../helpers/gitPathSpelling";
 import { git } from "./gitTestHelpers";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 const execFileAsync = promisify(execFile);
 
 const { rmMock } = vi.hoisted(() => ({ rmMock: vi.fn() }));

--- a/tests/unit/fixtures/restoreFidelity.test.ts
+++ b/tests/unit/fixtures/restoreFidelity.test.ts
@@ -25,8 +25,9 @@ import {
 } from "../../fixtures/repo/phase6Snapshot";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
 import { git } from "./gitTestHelpers";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 interface SeededManifestFixture {
     readonly template: FixtureTemplate;

--- a/tests/unit/fixtures/runFixtureSetup.test.ts
+++ b/tests/unit/fixtures/runFixtureSetup.test.ts
@@ -28,8 +28,9 @@ import {
     runFixtureSetup,
 } from "../../fixtures/repo/runFixtureSetup";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 async function exists(candidate: string): Promise<boolean> {
     try {

--- a/tests/unit/fixtures/runFixtureTeardown.test.ts
+++ b/tests/unit/fixtures/runFixtureTeardown.test.ts
@@ -22,8 +22,9 @@ import {
 import { runFixtureSetup } from "../../fixtures/repo/runFixtureSetup";
 import { runFixtureTeardown } from "../../fixtures/repo/runFixtureTeardown";
 import { seedFixtureTemplate } from "../../fixtures/repo/seed";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 
 async function exists(candidate: string): Promise<boolean> {
     try {

--- a/tests/unit/fixtures/scenarios.independence.test.ts
+++ b/tests/unit/fixtures/scenarios.independence.test.ts
@@ -20,8 +20,9 @@ import {
     trackScratchHome,
 } from "./scenariosTestHelpers";
 import { REPOSITORY_SCENARIO_IDS } from "../../fixtures/repo/scenarios";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 afterAll(removeTrackedScratchDirectories);
 

--- a/tests/unit/fixtures/seed.test.ts
+++ b/tests/unit/fixtures/seed.test.ts
@@ -29,6 +29,7 @@ import {
 import { OVERLONG_NAMES_FAIL_REMOVAL } from "../../helpers/platformCapabilities";
 import { createScratchWorkspaces } from "./scratchWorkspaces";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
 
@@ -76,7 +77,7 @@ describe("seedFixtureTemplate", () => {
         scratch.register(templateA.home);
         templateB = await seedFixtureTemplate(destinationB);
         scratch.register(templateB.home);
-    }, 60_000);
+    }, withWindowsHeadroom(60_000));
 
     afterAll(async () => {
         await scratch.removeAll();
@@ -443,7 +444,7 @@ describe("seedFixtureTemplate failure cleanup", () => {
         }
 
         expect(await readdir(homeParent)).toEqual([]);
-    }, 30_000);
+    });
 });
 
 /**

--- a/tests/unit/fixtures/seedDeterminism.test.ts
+++ b/tests/unit/fixtures/seedDeterminism.test.ts
@@ -21,9 +21,10 @@ import {
     type FixtureSnapshot,
 } from "../../fixtures/repo/phase6Snapshot";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 const execFileAsync = promisify(execFile);
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 async function run(
     command: string,

--- a/tests/unit/fixtures/snapshot.test.ts
+++ b/tests/unit/fixtures/snapshot.test.ts
@@ -46,8 +46,9 @@ import {
 // `EBUSY: resource busy or locked, rmdir ...\not-a-repo` on the row whose own assertions had all
 // passed (#223). Retrying past writes the test does not control is what the helper exists for.
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 30_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(30_000);
 const UNUSED_PROFILE_DIR = "/nonexistent/profile";
 
 function buildDurableStateSnapshot(

--- a/tests/unit/fixtures/snapshotNormalize.test.ts
+++ b/tests/unit/fixtures/snapshotNormalize.test.ts
@@ -34,6 +34,7 @@ import type { FsEntry } from "../../fixtures/repo/snapshotTypes";
 import { captured, notCaptured } from "../../fixtures/repo/snapshotTypes";
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
 /**
  * The two tests below each seed a git template and then copy the whole tree -- `.git` included --
@@ -49,7 +50,7 @@ import { removeScratchDirectories } from "../../helpers/scratchDirectories";
  * Sized at roughly 12x the measured Windows cost rather than at that bad day, because one
  * observed swing is a floor on the variance, not a ceiling.
  */
-const COPY_HEAVY_TIMEOUT_MS = 90_000;
+const COPY_HEAVY_TIMEOUT_MS = withWindowsHeadroom(90_000);
 
 describe("normalizeSnapshot -- two raw copies of one seed compare equal (step 8's real scenario)", () => {
     let scratchDirs: string[] = [];

--- a/tests/unit/fixtures/workspaceIsolation.test.ts
+++ b/tests/unit/fixtures/workspaceIsolation.test.ts
@@ -19,8 +19,9 @@ import {
 import { seedFixtureTemplate, type FixtureTemplate } from "../../fixtures/repo/seed";
 import { git } from "./gitTestHelpers";
 import { removeScratchDirectories } from "../../helpers/scratchDirectories";
+import { withWindowsHeadroom } from "../../setup/platformTimeouts";
 
-const FIXTURE_TIMEOUT_MS = 60_000;
+const FIXTURE_TIMEOUT_MS = withWindowsHeadroom(60_000);
 
 describe("Phase 6 step 35 -- workspace isolation", () => {
     let workspaces: FixtureWorkspace[] = [];

--- a/tests/webview/unit/commitGraphMessages.test.tsx
+++ b/tests/webview/unit/commitGraphMessages.test.tsx
@@ -3,7 +3,7 @@
 import React, { act, useMemo, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import type { Commit } from "../../../src/types";
+import type { Commit, CommitDetail } from "../../../src/types";
 import type { InteractiveRebaseRangeCommit } from "../../../src/webviews/protocol/commitGraphTypes";
 import { useCommitGraphMessages } from "../../../src/webviews/react/commit-graph/useCommitGraphMessages";
 import type { CommitGraphPanelAction } from "../../../src/webviews/react/commit-graph/types";
@@ -383,6 +383,125 @@ describe("useCommitGraphMessages", () => {
                 root.unmount();
             });
             host.remove();
+        }
+    });
+});
+
+function makeDetail(hash: string): CommitDetail {
+    return { ...makeCommit(hash, `detail ${hash}`), body: "", files: [] };
+}
+
+function send(data: unknown): void {
+    act(() => {
+        window.dispatchEvent(new MessageEvent("message", { data }));
+    });
+}
+
+function page(...hashes: string[]) {
+    return {
+        type: "loadCommits",
+        append: false,
+        hasMore: false,
+        commits: hashes.map((hash) => makeCommit(hash, `commit ${hash}`)),
+    };
+}
+
+// #246: the host fans one commit's detail out to every commit list. A list still ringing its own
+// older pick showed a second selection ring beside the row whose changed files were on screen.
+describe("useCommitGraphMessages selection shared with other commit lists (#246)", () => {
+    async function mount(selectedHash: string | null) {
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const root = createRoot(host);
+        const dispatch = vi.fn();
+        const postMessage = vi.fn();
+        await act(async () => {
+            root.render(
+                <Harness
+                    dispatch={dispatch}
+                    postMessage={postMessage}
+                    selectedHash={selectedHash}
+                />,
+            );
+        });
+        const unmount = async () => {
+            await act(async () => {
+                root.unmount();
+            });
+            host.remove();
+        };
+        return { dispatch, postMessage, unmount };
+    }
+
+    it("moves its ring to a commit picked in another list, instead of keeping its own older pick", async () => {
+        const { dispatch, unmount } = await mount("bb22");
+        try {
+            send(page("aa11", "bb22"));
+            send({ type: "setCommitDetail", detail: makeDetail("cc33") });
+            expect(
+                dispatch,
+                "the bottom graph kept ringing bb22 while the detail pane showed cc33, so two " +
+                    "commit lists showed a selection ring at once",
+            ).toHaveBeenCalledWith({ type: "selectCommit", hash: "cc33" });
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("does not take the detail pane back on refresh when the picked commit is not in its own list", async () => {
+        const { dispatch, postMessage, unmount } = await mount("bb22");
+        try {
+            send(page("aa11", "bb22"));
+            send({ type: "setCommitDetail", detail: makeDetail("cc33") });
+            postMessage.mockClear();
+            send(page("aa11", "bb22"));
+            expect(
+                postMessage,
+                "a refresh replaced another list's pick with this list's first row and re-selected " +
+                    "it, pulling the detail pane away from the commit the user clicked",
+            ).not.toHaveBeenCalledWith(expect.objectContaining({ type: "selectCommit" }));
+            expect(
+                dispatch,
+                "a refresh arriving before the next render judged the list's old pick, not the " +
+                    "commit another list had just selected",
+            ).toHaveBeenLastCalledWith(
+                expect.objectContaining({ type: "loadCommits", selectedHash: "cc33" }),
+            );
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("still falls back to its first row when its own pick disappears from a refresh", async () => {
+        const { postMessage, unmount } = await mount("bb22");
+        try {
+            send(page("aa11", "bb22"));
+            send(page("aa11"));
+            expect(
+                postMessage,
+                "the keep-another-list's-pick rule swallowed this list's own vanished pick, leaving " +
+                    "the detail pane on a commit the list no longer has",
+            ).toHaveBeenCalledWith({ type: "selectCommit", hash: "aa11" });
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("keeps another list's pick of a commit it showed only before an earlier refresh", async () => {
+        const { postMessage, unmount } = await mount("bb22");
+        try {
+            send(page("aa11", "bb22"));
+            send(page("aa11"));
+            send({ type: "setCommitDetail", detail: makeDetail("bb22") });
+            postMessage.mockClear();
+            send(page("aa11"));
+            expect(
+                postMessage,
+                "the list judged bb22 by a page it no longer shows, so another list's pick of bb22 " +
+                    "was taken back on the next refresh",
+            ).not.toHaveBeenCalledWith(expect.objectContaining({ type: "selectCommit" }));
+        } finally {
+            await unmount();
         }
     });
 });

--- a/tests/webview/unit/nativeCommitGraphSelection.test.tsx
+++ b/tests/webview/unit/nativeCommitGraphSelection.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { Commit, CommitDetail } from "../../../src/types";
+
+// The sidebar graph (`NativeCommitGraph`) rings whichever row matches the `selectedHash` it hands
+// `CommitList`. Capturing that prop reads the ring without laying out a virtualized list in jsdom.
+const list = vi.hoisted(() => ({
+    selectedHash: undefined as string | null | undefined,
+    onSelectCommit: (_hash: string): void => undefined,
+}));
+
+vi.mock("../../../src/webviews/react/CommitList", () => ({
+    CommitList: (props: {
+        selectedHash: string | null;
+        onSelectCommit: (hash: string) => void;
+    }) => {
+        list.selectedHash = props.selectedHash;
+        list.onSelectCommit = props.onSelectCommit;
+        return null;
+    },
+}));
+
+import { NativeCommitGraph } from "../../../src/webviews/react/NativeCommitGraph";
+
+function makeCommit(hash: string): Commit {
+    return {
+        hash,
+        shortHash: hash,
+        message: `commit ${hash}`,
+        author: "Mahesh",
+        email: "m@example.com",
+        date: "2026-02-19T00:00:00Z",
+        parentHashes: ["parent"],
+        refs: [],
+    };
+}
+
+function makeDetail(hash: string): CommitDetail {
+    return { ...makeCommit(hash), body: "", files: [] };
+}
+
+function send(data: unknown): void {
+    act(() => {
+        window.dispatchEvent(new MessageEvent("message", { data }));
+    });
+}
+
+function page(...hashes: string[]) {
+    return { type: "loadCommits", append: false, hasMore: false, commits: hashes.map(makeCommit) };
+}
+
+async function mount() {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const postMessage = vi.fn();
+    const vscode = { postMessage } as unknown as React.ComponentProps<
+        typeof NativeCommitGraph
+    >["vscode"];
+    await act(async () => {
+        root.render(<NativeCommitGraph vscode={vscode} sendReady={false} />);
+    });
+    const unmount = async () => {
+        await act(async () => {
+            root.unmount();
+        });
+        host.remove();
+    };
+    return { postMessage, unmount };
+}
+
+beforeAll(() => {
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", {
+        value: true,
+        configurable: true,
+    });
+});
+
+// #246: the host fans one commit's detail out to every commit list. A list still ringing its own
+// older pick showed a second selection ring beside the row whose changed files were on screen.
+describe("NativeCommitGraph selection shared with other commit lists (#246)", () => {
+    it("moves its ring to a commit picked in another list, instead of keeping its own older pick", async () => {
+        const { unmount } = await mount();
+        try {
+            send(page("aa11", "bb22"));
+            act(() => list.onSelectCommit("bb22"));
+            send({ type: "setCommitDetail", detail: makeDetail("cc33") });
+            expect(
+                list.selectedHash,
+                "the sidebar graph kept ringing bb22 while the detail pane showed cc33, so two " +
+                    "commit lists showed a selection ring at once",
+            ).toBe("cc33");
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("does not take the detail pane back on refresh when the picked commit is not in its own list", async () => {
+        const { postMessage, unmount } = await mount();
+        try {
+            send(page("aa11", "bb22"));
+            act(() => list.onSelectCommit("bb22"));
+            postMessage.mockClear();
+            // One act: the refresh lands before React renders the adopted pick, as two back-to-back
+            // host messages can in the real webview.
+            act(() => {
+                for (const data of [
+                    { type: "setCommitDetail", detail: makeDetail("cc33") },
+                    page("aa11", "bb22"),
+                ]) {
+                    window.dispatchEvent(new MessageEvent("message", { data }));
+                }
+            });
+            expect(
+                postMessage,
+                "a refresh replaced another list's pick with this list's first row and re-selected " +
+                    "it, pulling the detail pane away from the commit the user clicked",
+            ).not.toHaveBeenCalledWith(expect.objectContaining({ type: "selectCommit" }));
+            expect(
+                list.selectedHash,
+                "a refresh arriving before the next render judged the list's old pick, not the " +
+                    "commit another list had just selected",
+            ).toBe("cc33");
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("still falls back to its first row when its own pick disappears from a refresh", async () => {
+        const { postMessage, unmount } = await mount();
+        try {
+            send(page("aa11", "bb22"));
+            act(() => list.onSelectCommit("bb22"));
+            postMessage.mockClear();
+            send(page("aa11"));
+            expect(
+                postMessage,
+                "the keep-another-list's-pick rule swallowed this list's own vanished pick, leaving " +
+                    "the detail pane on a commit the list no longer has",
+            ).toHaveBeenCalledWith({ type: "selectCommit", hash: "aa11" });
+        } finally {
+            await unmount();
+        }
+    });
+
+    it("keeps another list's pick of a commit it showed only before an earlier refresh", async () => {
+        const { postMessage, unmount } = await mount();
+        try {
+            send(page("aa11", "bb22"));
+            send(page("aa11"));
+            send({ type: "setCommitDetail", detail: makeDetail("bb22") });
+            postMessage.mockClear();
+            send(page("aa11"));
+            expect(
+                postMessage,
+                "the list judged bb22 by a page it no longer shows, so another list's pick of bb22 " +
+                    "was taken back on the next refresh",
+            ).not.toHaveBeenCalledWith(expect.objectContaining({ type: "selectCommit" }));
+        } finally {
+            await unmount();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #246

## What was wrong

When you select a commit, the host sends that commit's detail to every view that shows commits: the bottom graph, the sidebar **Graph**, the commit panel and the commit-info pane (`loadCommitDetail` in `repositoryViewEvents.ts`). Neither graph moved its own selection to that commit:

- The bottom graph's message hook (`useCommitGraphMessages`) forwarded the detail but left `selectedHash` alone.
- The sidebar graph (`NativeCommitGraph`) had no `setCommitDetail` case at all.

So the list you clicked earlier kept ringing its old pick. Two rings were on screen, and only one of them matched the files shown.

## What changed

- **The ring follows the shown commit.** On `setCommitDetail`, both lists select that commit, in the ref and in state.
- **A refresh keeps another list's pick.** Before this fix, a refresh fell back to the list's first row whenever the selected commit wasn't in the new page. It also posted `selectCommit`, which pulled the detail pane away from the commit the user had just clicked in the other list. Now a refresh keeps a selection this list never showed on its current page, because another list picked it. `loadedHashesRef` tracks the current page and resets on every non-append load.
- **The first-row fallback is unchanged** for the list's own pick vanishing, for example after a branch switch or a reset.

Out of scope: the undocked view is not in the detail fan-out, and the commit panel draws no commit rows.

## Tests

The tests are committed first, red, then the fix.

- `tests/webview/unit/commitGraphMessages.test.tsx`: 4 new tests for the bottom graph's hook.
- `tests/webview/unit/nativeCommitGraphSelection.test.tsx` (new): the same 4 cases against the rendered sidebar graph.

Each list gets the same 4 cases:

1. It adopts another list's pick. Red before the fix.
2. It keeps that pick through a refresh that lands before the next render. Red before the fix.
3. It still falls back to its first row when its own pick vanishes. A control; stays green.
4. It keeps another list's pick of a commit it showed only before an earlier refresh. A control; stays green.

Mutation pass: 10 mutations, 5 per file. Each one went red, and each failure names its own assertion.

| Mutation (both files) | Red test |
|---|---|
| drop the `selectCommit` dispatch on `setCommitDetail` | moves its ring to a commit picked in another list |
| drop the ref update on `setCommitDetail` | does not take the detail pane back on refresh (ref-before-render assertion) |
| drop the keep-another-list's-pick rule | does not take the detail pane back on refresh + keeps another list's pick … before an earlier refresh |
| always keep the previous pick | still falls back to its first row when its own pick disappears |
| never reset the loaded-page set | keeps another list's pick … before an earlier refresh |

## Test plan

- [x] Nine pre-commit gates
- [x] Full `bun run test` suite: 352 files, 4824 tests passed, and no fixture or baseline changed
- [x] Visual suite not re-run locally: no visual fixture sends `setCommitDetail` to a commit-graph context, so the changed code cannot run there. CI's `visual` job covers it on this PR.
- [ ] Manual Extension Development Host check: open the bottom graph and the sidebar graph, click a commit in one and then a different commit in the other, and confirm only one ring shows. Then refresh (fetch or commit) and confirm the detail pane stays on the clicked commit.
