### PR TITLE
test: keep fixture git writes out of a repository inherited via GIT_DIR

### DIFF
--- a/tests/setup/gitEnvironment.ts
+++ b/tests/setup/gitEnvironment.ts
@@ -1,5 +1,6 @@
 /**
- * Vitest setup: no test process may read the machine's Git configuration.
+ * Vitest setup: no test process may read the machine's Git configuration, or act on a repository
+ * it inherited from whatever launched the run.
  *
  * **The defect this closes.** An audit of every test module that spawns real Git found 21 with no
  * configuration isolation at all. They set an author identity and stopped there, so each `git`
@@ -16,6 +17,14 @@
  *   the reproducibility defect `tests/visual/recorder/recordingGitEnvironment.ts` documents for the
  *   recorder, present in a further 21 modules that never got the same treatment.
  *
+ * **The inherited repository.** Git exports `GIT_DIR` to every hook it runs from a linked
+ * worktree, and `GIT_DIR` outranks both `cwd` and `-C`. While `.githooks/pre-push` ran
+ * `test:coverage`, a push from a worktree therefore pointed every fixture's `git init` and
+ * `git config user.name "Test User"` -- each aimed at a fresh temporary directory -- at the
+ * developer's shared `.git/config`, and their own commits went on to be authored as
+ * `Test User <test@example.com>`. Clearing the variables `git rev-parse --local-env-vars` lists
+ * leaves the `cwd` a fixture passes as the only thing that decides which repository it touches.
+ *
  * Setting this once per worker rather than in each module is deliberate. The failing modules do not
  * share a Git helper -- some pass `{ ...process.env, ...identity }`, some pass `{ cwd }` and no
  * `env` at all -- so there is no single call site to fix, and a convention that must be re-applied
@@ -28,12 +37,33 @@
  * config.
  *
  * Proven rather than assumed: `tests/unit/gitEnvironmentIsolation.test.ts` spawns real Git and
- * asserts it cannot see a global or system setting. Without that, this file could be dropped from
- * `vitest.config.ts` and every suite would keep passing locally while silently losing the
- * guarantee.
+ * asserts it cannot see a global or system setting, or be redirected by an inherited `GIT_DIR`.
+ * Without that, this file could be dropped from `vitest.config.ts` and every suite would keep
+ * passing locally while silently losing the guarantee.
  */
 
 import { ABSENT_GIT_CONFIG_GLOBAL } from "../helpers/gitConfigIsolation";
 
+// The variables `git rev-parse --local-env-vars` lists as local to one repository (Git 2.50). An
+// inherited one outranks the repository, index, or config a fixture's `cwd` would select.
+for (const name of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+]) {
+    delete process.env[name];
+}
 process.env.GIT_CONFIG_GLOBAL = ABSENT_GIT_CONFIG_GLOBAL;
 process.env.GIT_CONFIG_NOSYSTEM = "1";

--- a/tests/unit/e2e/controlChannelClient.test.ts
+++ b/tests/unit/e2e/controlChannelClient.test.ts
@@ -29,8 +29,16 @@ afterEach(async () => {
     await removeScratchDirectories(channelDir);
 });
 
-/** Waits for the client to publish one complete request file and returns its parsed envelope. */
-async function waitForRequest(timeoutMs = 500): Promise<E2eRequest> {
+/**
+ * Waits for the client to publish one complete request file and returns its parsed envelope.
+ *
+ * The budget guards a hang, not a deadline any assertion here is about: the publish always
+ * happens, and on a shared Windows runner it has outlasted the 500ms this used to allow. The first
+ * attempt of run 34700493095 failed three cases at the old budget with `test request did not
+ * appear within the timeout` while the client was still inside its temp-file-plus-rename publish;
+ * the re-run of the same commit passed them.
+ */
+async function waitForRequest(timeoutMs = 10_000): Promise<E2eRequest> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
         const requestFilename = (await readdir(channelDir)).find((filename) =>
@@ -55,6 +63,17 @@ async function writeResponse(response: E2eResponse): Promise<void> {
     );
 }
 
+/**
+ * Keeps a promise the test awaits later from surfacing as an unhandled rejection when the test
+ * fails before it reaches that assertion. Node reports the abandoned rejection run-wide -- `Errors
+ * 1 error`, exit code 1, no test red -- which is the mode this file's `bounds polling` case
+ * already documents; a handler attached at creation is what keeps a red test red on its own terms.
+ */
+function handled<T>(promise: Promise<T>): Promise<T> {
+    void promise.catch(() => undefined);
+    return promise;
+}
+
 describe("writeE2eRequestAtomic", () => {
     it("publishes a complete nonce-bound request and leaves no temp file", async () => {
         const request: E2eRequest = { nonce: "abc123_X", ...REQUEST_PAYLOAD };
@@ -75,7 +94,7 @@ describe("E2eControlChannelClient readiness", () => {
             responseTimeoutMs: 500,
             pollIntervalMs: 5,
         });
-        const responsePromise = client.request(REQUEST_PAYLOAD);
+        const responsePromise = handled(client.request(REQUEST_PAYLOAD));
 
         await new Promise((resolve) => setTimeout(resolve, 20));
         expect(await readdir(channelDir)).toEqual([]);
@@ -111,7 +130,7 @@ describe("E2eControlChannelClient response polling", () => {
             pollIntervalMs: 5,
         });
 
-        const responsePromise = client.request(REQUEST_PAYLOAD);
+        const responsePromise = handled(client.request(REQUEST_PAYLOAD));
         const request = await waitForRequest();
         const response: E2eResponse = {
             nonce: request.nonce,
@@ -131,7 +150,7 @@ describe("E2eControlChannelClient response polling", () => {
             pollIntervalMs: 5,
         });
 
-        const responsePromise = client.request(REQUEST_PAYLOAD);
+        const responsePromise = handled(client.request(REQUEST_PAYLOAD));
         const request = await waitForRequest();
         const responsePath = join(channelDir, `${request.nonce}.response.json`);
 

--- a/tests/unit/gitEnvironmentIsolation.test.ts
+++ b/tests/unit/gitEnvironmentIsolation.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { removeScratchDirectories } from "../helpers/scratchDirectories";
 
 const execFileAsync = promisify(execFile);
@@ -62,6 +62,16 @@ async function readConfig(
         const failure = error as { code?: number; stdout?: string };
         return { value: (failure.stdout ?? "").trim(), exitCode: failure.code ?? -1 };
     }
+}
+
+/** A repository's own `user.name`, or "" when its `.git/config` sets none. */
+async function localUserName(repository: string): Promise<string> {
+    const { stdout } = await execFileAsync(
+        "git",
+        ["config", "--local", "--default", "", "--get", "user.name"],
+        { cwd: repository },
+    );
+    return stdout.trim();
 }
 
 describe("git environment isolation", () => {
@@ -152,5 +162,54 @@ describe("git environment isolation", () => {
         expect(checkedOut.toString("utf8"), "checkout must not expand LF to CRLF").toBe(
             "first\nsecond\n",
         );
+    });
+
+    it("keeps a fixture's git writes out of a repository inherited through GIT_DIR", async () => {
+        // Git exports GIT_DIR to every hook it runs from a linked worktree, and GIT_DIR outranks
+        // both `cwd` and `-C`. When the pre-push hook ran this suite, a push from a worktree
+        // therefore sent each fixture's `git init` and `git config user.name "Test User"` -- aimed
+        // at a fresh temporary directory -- into the developer's shared `.git/config`. Loading the
+        // setup file again with the variable already set is that launch in miniature.
+        const inherited = await mkdtemp(path.join(tmpdir(), "intelligit-git-inherited-"));
+        const fixture = await mkdtemp(path.join(tmpdir(), "intelligit-git-fixture-"));
+        directories.push(inherited, fixture);
+        await execFileAsync("git", ["init", "-q"], { cwd: inherited });
+
+        const saved = process.env.GIT_DIR;
+        process.env.GIT_DIR = path.join(inherited, ".git");
+        try {
+            vi.resetModules();
+            await import("../setup/gitEnvironment");
+            await execFileAsync("git", ["init", "-q"], { cwd: fixture });
+            await execFileAsync("git", ["config", "user.name", "Test User"], { cwd: fixture });
+        } finally {
+            if (saved === undefined) delete process.env.GIT_DIR;
+            else process.env.GIT_DIR = saved;
+        }
+
+        expect(
+            await localUserName(inherited),
+            "a fixture's git write must not reach the repository GIT_DIR names",
+        ).toBe("");
+        expect(await localUserName(fixture), "the fixture must configure its own repository").toBe(
+            "Test User",
+        );
+    });
+
+    it("lets GIT_DIR outrank a fixture's cwd when the variable reaches the spawn", async () => {
+        // Vacuity guard for the test above, whose key assertion is one of absence: a GIT_DIR that
+        // Git ignored would pass it just as well. The same write, with the variable handed straight
+        // to the spawn, has to land in the repository it names.
+        const inherited = await mkdtemp(path.join(tmpdir(), "intelligit-git-inherited-"));
+        const fixture = await mkdtemp(path.join(tmpdir(), "intelligit-git-fixture-"));
+        directories.push(inherited, fixture);
+        await execFileAsync("git", ["init", "-q"], { cwd: inherited });
+
+        await execFileAsync("git", ["config", "user.name", "Test User"], {
+            cwd: fixture,
+            env: { ...process.env, GIT_DIR: path.join(inherited, ".git") },
+        });
+
+        expect(await localUserName(inherited)).toBe("Test User");
     });
 });


### PR DESCRIPTION
## Motivation

Commits made in this checkout were being authored `Test User <test@example.com>`, because the repository's own config was overriding the developer's global identity:

```
$ git config --show-origin --get-all user.name
file:.git/config      Test User
$ git config --show-origin --get-all user.email
file:.git/config      test@example.com
```

776 commits across local refs carry that identity — 0 on `main`, where the squash keeps your own name. The values look like a fixture identity, and they are one: a test wrote them into the real repository.

## Root cause

Git exports `GIT_DIR` to the hooks it runs from a linked worktree, and `GIT_DIR` outranks both `cwd` and `-C`. While `.githooks/pre-push` ran `test:coverage`, every fixture that created a throwaway repository in a temp directory — `git init`, then `git config user.name "Test User"` — had that write redirected into the developer's shared `.git/config`. The fixtures' working directories were never wrong; the inherited variable decided which repository the command acted on, and it named the real one. That path has since left the hook (`pre-push` keeps only `react-doctor` and `lint:complexity`, coverage moved to CI), but the same class of write is reachable from any launch that exports `GIT_DIR`, and what it wrote persisted.

## The fix

`tests/setup/gitEnvironment.ts` now deletes the 15 variables `git rev-parse --local-env-vars` reports as local to one repository (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, … full list in the diff) once per worker, before any test module runs. The `cwd` a fixture passes becomes the only thing that decides which repository it touches.

One seam rather than twenty-one call sites is deliberate. The modules that set an author identity do not share a helper — some pass `{ ...process.env, ...identity }`, some pass `{ cwd }` and no `env` at all — so there is no single call site to fix, and no convention a new test file can be trusted to follow by hand. `process.env` is the one seam every one of those shapes already inherits from. An explicit value in a spawn's `env` still wins, which is what `tests/unit/fixtures/seedDeterminism.test.ts` relies on to point Git at a deliberately hostile config.

## Regression test

`tests/unit/gitEnvironmentIsolation.test.ts` gains the reproduction: it loads the setup file with `GIT_DIR` already set — the leaking launch in miniature — and asserts a fixture's `git config user.name` stays in its own repository. A second case hands the same variable straight to a spawn and shows the write lands in the repository it names; without it, the first assertion could pass vacuously.

## Testing

| Check | Result |
| --- | --- |
| `bunx vitest run tests/unit/gitEnvironmentIsolation.test.ts` | 7/7 pass |
| `bun run test:coverage` (full suite) | 4827/4829 pass |
| pre-commit hook battery (format:check, lint:strict, deps:check:strict, architecture:check, l10n:validate, l10n:audit, typecheck, build, vsce package) | pass |
| `bun run react-doctor`, `bun run lint:complexity` | pass |

The two failures are `merge-editor-performance.integration.test.tsx` and `visual/screenshotComparatorMeta.test.ts` — render-budget cases that time out only under full-suite parallel load (40.5 s against a 20 s budget, 60.0 s against a 60 s cap) and pass in isolation in 6.8 s and 21.9 s. Neither file references anything in this diff.

Mutation-proved: dropping `GIT_DIR` from the deletion list turns the new case red on `a fixture's git write must not reach the repository GIT_DIR names: expected 'Test User' to be ''`, and on no other assertion.

End-to-end, in a throwaway clone with a local bare remote and a `pre-push` hook that runs vitest with the environment Git hands it: 11 identity-writing test files were pushed from a linked worktree of that clone. The hook inherited `GIT_DIR=…/clone/.git/worktrees/clone-wt`, so the probe is not vacuous; every run was green; the clone's config stayed at `core.bare false` with no `user.*` keys, where the same probes wrote `user.name Test User; user.email test@example.com` before the fix. The developer's real `.git/config` was byte-identical through every run and through this branch's commits.

## Not done

- No version bump or CHANGELOG entry — nothing here changes behaviour a user can see (precedent: #230). Easy to add if you'd rather; note `0.32.9` is currently claimed by `fix/worktree-side-graph-226`.
- No authorship rewrite. The 776 commits are left untouched, and restoring the developer's identity is their call: `git config --local --unset user.name && git config --local --unset user.email`.
- Same-class writes remain in `tests/e2e/hostFixtures/electronLaunchHelpers.ts`, `tests/e2e/spike/launch.spec.ts`, and `vitest.flow-negative.config.ts` (no `setupFiles`). None is reachable from a git hook today, so none can fire from this workflow — hardening them belongs in its own change, with an e2e run behind it.

## Windows flake hardened in the same branch

`tests/unit/e2e/controlChannelClient.test.ts` failed on this PR's first CI attempt (run 34700493095, `Windows tests (shard 3/4)`) and passed on the re-run of the same commit: three response-polling cases timed out waiting 500 ms for the client's temp-file-plus-rename publish, which a shared `windows-latest` runner can outlast, and the abandoned client promises then rejected after `afterEach` removed the channel directory, which is what produced `Errors 2 errors`.

Two changes, both traced to that failure:

- `waitForRequest` now waits 10 s. The budget guards a hang; the publish always happens, so the old value was a deadline no assertion in this file is about.
- The promises those tests await later are created through a `handled()` helper that attaches a rejection handler at creation, so an abandoned promise reports as a red test instead of failing the whole run with `Errors 1 error` and no test named — the mode this file already documents for its `bounds polling` case.

Reproduced off Windows by delaying the publish in a scratch edit of the client (never committed): at a 600 ms publish the old file fails `4 failed | 3 errors`, the fixed file passes `6 passed | 0 errors`. Counters, stated plainly: the unhandled-rejection half is justified by construction and by the CI evidence plus the mode already documented in this file; two attempts to isolate it locally (delay past the new budget, with and without the helper) did not reproduce it, because vitest tore the file down before the rejection surfaced, so that half is not backed by a local red of its own.
